### PR TITLE
reduce http client log output

### DIFF
--- a/5.00/DemoProject/Plugins/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/5.00/DemoProject/Plugins/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -58,7 +58,7 @@ void ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requ
 				return;
 			}
 
-			UE_LOG(LogTemp, Warning, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
+			UE_LOG(LogTemp, Log, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
 			response.success = true;
 			response.FullTextFromServer = Response->GetContentAsString();
 			response.ServerCallHasError = false;
@@ -167,7 +167,7 @@ void ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& r
             response.ServerCallStatusCode = Response->GetResponseCode();
             response.ServerError = Response->GetContentAsString();
         
-            UE_LOG(LogTemp, Warning, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
+            UE_LOG(LogTemp, Log, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
             bool success = ResponseIsValid(Response, bWasSuccessful);
         
             response.success = success;

--- a/5.00/Plugins/LootLockerSDK/LootLockerSDK.uplugin
+++ b/5.00/Plugins/LootLockerSDK/LootLockerSDK.uplugin
@@ -19,7 +19,7 @@
         "Name": "LootLockerSDK",
         "Type": "Runtime",
         "LoadingPhase": "Default",
-        "WhitelistPlatforms": [ "Win64", "Win32", "Mac", "Android","PS4","IOS" ,"XboxOne", "Switch" ]
+        "WhitelistPlatforms": [ "Win64", "Mac", "Android", "PS4", "IOS", "Switch" ]
       }
     ]
 }

--- a/5.00/Plugins/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/5.00/Plugins/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -58,7 +58,7 @@ void ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requ
 				return;
 			}
 
-			UE_LOG(LogTemp, Warning, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
+			UE_LOG(LogTemp, Log, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
 			response.success = true;
 			response.FullTextFromServer = Response->GetContentAsString();
 			response.ServerCallHasError = false;
@@ -167,7 +167,7 @@ void ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& r
             response.ServerCallStatusCode = Response->GetResponseCode();
             response.ServerError = Response->GetContentAsString();
         
-            UE_LOG(LogTemp, Warning, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
+            UE_LOG(LogTemp, Log, TEXT("Response code: %d; Response content:\n%s"), Response->GetResponseCode(), *ResponseString);
             bool success = ResponseIsValid(Response, bWasSuccessful);
         
             response.success = success;


### PR DESCRIPTION
The HTTP client was logging every response as a warning, which added a lot of color to the log file that's just irritating. Reduced that output to a lower level.