### PR TITLE
Saving session_token when it exists

### DIFF
--- a/v2/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.h
+++ b/v2/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.h
@@ -30,6 +30,10 @@ struct LLAPI
             if (response.success)
             {
                 ResponseStruct.success = FJsonObjectConverter::JsonObjectStringToUStruct<W>(response.FullTextFromServer, &ResponseStruct, 0, 0);
+                if (ResponseStruct.session_token != "")
+                {
+                    ULootLockerPersistentDataHolder::Token = ResponseStruct.session_token;
+                }
             }
             else
             {

--- a/v2/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/v2/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -26,6 +26,7 @@ public:
 	FString message;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
 	FString error;
+	FString session_token;
 };
 
 UENUM(BlueprintType)


### PR DESCRIPTION
Saving session_token if it exists
The previous SDK had specific authentication responses, and used those when authenticating to store the session_response, in this new version all responses use the same struct, so it needs to be included for all responses, hence the "if(session_token != "").