### PR TITLE
Change Config category to Game

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -66,7 +66,7 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
 	FString endpoint;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	ELootLockerHTTPMethod requestMethod;
+	ELootLockerHTTPMethod requestMethod = ELootLockerHTTPMethod::GET;
 };
 
 USTRUCT(BlueprintType)
@@ -80,7 +80,7 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FResponseCallbackBP, FLootLockerResponse, Resp
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerResponseCallback, FLootLockerResponse, Response);
 DECLARE_DELEGATE_OneParam(FResponseCallback, FLootLockerResponse);
 
-UCLASS(Config = LootLockerSDK)
+UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "LootLocker SDK Settings"))
 class LOOTLOCKERSDK_API ULootLockerConfig : public UObject
 {
 	GENERATED_BODY()

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -92,17 +92,17 @@ public:
     }
 public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	FString LootLockerGameKey = TEXT("d925392bfba5bf79827b8ee8207e21e511f1483a");
+	FString LootLockerGameKey;
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	ELootLockerPlatformType Platform = ELootLockerPlatformType::Android;
+    ELootLockerPlatformType Platform;
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	FString GameVersion = TEXT("0.0.0.1");
+    FString GameVersion;
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	bool OnDevelopmentMode = true;
+	bool OnDevelopmentMode;
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
 	bool AllowTokenRefresh = true;
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	FString DomainKey = "2e85q3wx";
+	FString DomainKey;
 };
 
 


### PR DESCRIPTION
This fixes the problem that the config isn't packaged with the game. It does not have any effects that I can tell in editor (it still has it's own category in plugins etc). But it does mean that the storage of the settings has changed from a dedicated "LootLockerSDK.ini" file to the DefaultGame.ini file where it now has it's own section. This works so if you think it's ok, we can go ahead and merge it. If not, then we will need to look into how to explicitly package and point to the dedicated ini. I've looked most of the day today and haven't succeeded yet. But it should in theory be as simple as finding the right property to set.