### PR TITLE
CreateHeroWithVariation sets optional asset_variation_id

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerHeroRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerHeroRequestHandler.cpp
@@ -29,6 +29,11 @@ void ULootLockerHeroRequestHandler::CreateHero(const FLootLockerCreateHeroReques
 	LLAPI<FLootLockerPlayerHeroResponse>::CallAPI(HttpClient, Request, ULootLockerGameEndpoints::CreateHero, { },EmptyQueryParams, OnCompleteBP, OnComplete, LLAPI<FLootLockerPlayerHeroResponse>::FResponseInspectorCallback());
 }
 
+void ULootLockerHeroRequestHandler::CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest &Request, const FLootLockerPlayerHeroBP &OnCompleteBP, const FLootLockerPlayerHeroDelegate &OnComplete)
+{
+	LLAPI<FLootLockerPlayerHeroResponse>::CallAPI(HttpClient, Request, ULootLockerGameEndpoints::CreateHero, { },EmptyQueryParams, OnCompleteBP, OnComplete, LLAPI<FLootLockerPlayerHeroResponse>::FResponseInspectorCallback());
+}
+
 void ULootLockerHeroRequestHandler::GetHero(const int32 HeroID, const FLootLockerPlayerHeroBP &OnCompleteBP, const FLootLockerPlayerHeroDelegate &OnComplete)
 {
 	LLAPI<FLootLockerPlayerHeroResponse>::CallAPI(HttpClient, LootLockerEmptyRequest, ULootLockerGameEndpoints::GetHero,  { HeroID },EmptyQueryParams, OnCompleteBP, OnComplete, LLAPI<FLootLockerPlayerHeroResponse>::FResponseInspectorCallback());

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -201,6 +201,11 @@ void ULootLockerManager::CreateHero(const FLootLockerCreateHeroRequest &Request,
 	ULootLockerHeroRequestHandler::CreateHero(Request, OnCompleteBP, FLootLockerPlayerHeroDelegate());
 }
 
+void ULootLockerManager::CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest &Request, const FLootLockerPlayerHeroBP &OnCompleteBP)
+{
+	ULootLockerHeroRequestHandler::CreateHeroWithVariation(Request, OnCompleteBP, FLootLockerPlayerHeroDelegate());
+}
+
 void ULootLockerManager::GetHero(const int32 HeroID, const FLootLockerPlayerHeroBP &OnCompleteBP)
 {
 	ULootLockerHeroRequestHandler::GetHero(HeroID, OnCompleteBP, FLootLockerPlayerHeroDelegate());

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -201,6 +201,11 @@ void ULootLockerSDKManager::CreateHero(const FLootLockerCreateHeroRequest &Reque
 	ULootLockerHeroRequestHandler::CreateHero(Request, FLootLockerPlayerHeroBP(), OnCompletedRequest);
 }
 
+void ULootLockerSDKManager::CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest &Request, const FLootLockerPlayerHeroDelegate &OnCompletedRequest)
+{
+	ULootLockerHeroRequestHandler::CreateHeroWithVariation(Request, FLootLockerPlayerHeroBP(), OnCompletedRequest);
+}
+
 void ULootLockerSDKManager::GetHero(const int32 HeroID, const FLootLockerPlayerHeroDelegate &OnCompletedRequest)
 {
 	ULootLockerHeroRequestHandler::GetHero(HeroID, FLootLockerPlayerHeroBP(), OnCompletedRequest);

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerHeroRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerHeroRequestHandler.h
@@ -84,6 +84,22 @@ struct FLootLockerCreateHeroRequest
 	int32 hero_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker | Heroes")
 	FString name;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker | Heroes")
+	bool is_default = false;
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerCreateHeroWithVariationRequest
+{
+	GENERATED_BODY()
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker | Heroes")
+	int32 hero_id = 0;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker | Heroes")
+	FString name;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker | Heroes")
+	int32 asset_variation_id = 0;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker | Heroes")
+	bool is_default = false;
 };
 
 USTRUCT(BlueprintType)
@@ -173,6 +189,7 @@ public:
 	static void ListPlayerHeroes(const FLootLockerHeroListBP& OnCompleteBP, const FLootLockerHeroListDelegate& OnComplete);
 	static void ListOtherPlayersHeroesBySteamID64(const int64 SteamID64, const FLootLockerHeroListBP& OnCompleteBP, const FLootLockerHeroListDelegate& OnComplete);
 	static void CreateHero(const FLootLockerCreateHeroRequest& Request, const FLootLockerPlayerHeroBP& OnCompleteBP, const FLootLockerPlayerHeroDelegate& OnComplete);
+	static void CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest& Request, const FLootLockerPlayerHeroBP& OnCompleteBP, const FLootLockerPlayerHeroDelegate& OnComplete);
 	static void GetHero(const int32 HeroID, const FLootLockerPlayerHeroBP& OnCompleteBP, const FLootLockerPlayerHeroDelegate& OnComplete);
 	static void GetOtherPlayersDefaultHeroBySteamID64(const int64 SteamID64, const FLootLockerPlayerHeroBP& OnCompleteBP, const FLootLockerPlayerHeroDelegate& OnComplete);
 	static void UpdateHero(const int32 HeroID, const FLootLockerUpdateHeroRequest& Request, const FLootLockerPlayerHeroBP& OnCompleteBP, const FLootLockerPlayerHeroDelegate& OnComplete);

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -450,6 +450,15 @@ public:
 	static void CreateHero(const FLootLockerCreateHeroRequest& Request, const FLootLockerPlayerHeroBP& OnCompleteBP);
 
     /**
+     * Create a hero for the current player with the supplied name from the game hero specified with the supplied hero id, asset variation id, and whether to set as default.
+     * https://ref.lootlocker.com/game-api/#creating-a-hero
+     *
+     * @param Request Request specifying the hero id for the game hero to use for creation and the name of the hero to create, an asset variation id for this hero, and whether this hero should be the default
+     * @param OnCompleteBP Delegate for handling the response
+     */
+	static void CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest& Request, const FLootLockerPlayerHeroBP& OnCompleteBP);
+
+    /**
      * Return information about the requested hero on the current player
      * https://ref.lootlocker.com/game-api/#getting-a-hero
      *

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -414,6 +414,15 @@ public:
 	static void CreateHero(const FLootLockerCreateHeroRequest& Request, const FLootLockerPlayerHeroDelegate& OnCompleteRequest);
 
     /**
+     * Create a hero for the current player with the supplied name from the game hero specified with the supplied hero id
+     * https://ref.lootlocker.com/game-api/#creating-a-hero
+     *
+     * @param Request Request specifying the hero id for the game hero to use for creation and the name of the hero to create
+     * @param OnCompleteRequest Delegate for handling the response
+     */
+	static void CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest& Request, const FLootLockerPlayerHeroDelegate& OnCompleteRequest);
+
+    /**
      * Return information about the requested hero on the current player
      * https://ref.lootlocker.com/game-api/#getting-a-hero
      *

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -414,10 +414,10 @@ public:
 	static void CreateHero(const FLootLockerCreateHeroRequest& Request, const FLootLockerPlayerHeroDelegate& OnCompleteRequest);
 
     /**
-     * Create a hero for the current player with the supplied name from the game hero specified with the supplied hero id
+     * Create a hero for the current player with the supplied name from the game hero specified with the supplied hero id, asset variation id, and whether to set as default.
      * https://ref.lootlocker.com/game-api/#creating-a-hero
      *
-     * @param Request Request specifying the hero id for the game hero to use for creation and the name of the hero to create
+     * @param Request Request specifying the hero id for the game hero to use for creation and the name of the hero to create, an asset variation id for this hero, and whether this hero should be the default
      * @param OnCompleteRequest Delegate for handling the response
      */
 	static void CreateHeroWithVariation(const FLootLockerCreateHeroWithVariationRequest& Request, const FLootLockerPlayerHeroDelegate& OnCompleteRequest);


### PR DESCRIPTION
This adds a new function to the SDK, because the existing CreateHero implementation had no way of sending the (optional) asset_variation_id parameter. You probably don't want to integrate this PR, but create a general facility in CallAPI to deal with optional arguments for any other requests that also have them (i.e. the name field in UpdateHero).