### PR TITLE
Add User-Instance-Identifier Header

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -11,6 +11,7 @@
 #include "Misc/FileHelper.h"
 #include "Misc/Guid.h"
 
+const FString ULootLockerHttpClient::UserAgent = FString::Format(TEXT("X-UnrealEngine-Agent/{0}"), { ENGINE_VERSION_STRING });
 const FString ULootLockerHttpClient::UserInstanceIdentifier = FGuid::NewGuid().ToString();
 
 ULootLockerHttpClient::ULootLockerHttpClient()
@@ -29,7 +30,7 @@ void ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requ
 #endif
 	Request->SetURL(endPoint);
 
-	Request->SetHeader(TEXT("User-Agent"), TEXT("X-UnrealEngine-Agent"));
+	Request->SetHeader(TEXT("User-Agent"), UserAgent);
 	Request->SetHeader(TEXT("User-Instance-Identifier"), UserInstanceIdentifier);
     Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
     Request->SetHeader(TEXT("Accepts"), TEXT("application/json"));
@@ -92,7 +93,8 @@ void ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& r
 
     FString Boundary = "lootlockerboundary";
 
-    Request->SetHeader(TEXT("User-Agent"), TEXT("X-UnrealEngine-Agent"));
+	Request->SetHeader(TEXT("User-Agent"), UserAgent);
+	Request->SetHeader(TEXT("User-Instance-Identifier"), UserInstanceIdentifier);
     Request->SetHeader(TEXT("Content-Type"), TEXT("multipart/form-data; boundary=" + Boundary));
 
     for (TTuple<FString, FString> CustomHeader : customHeaders)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
@@ -35,6 +35,7 @@ public:
     void UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString> AdditionalFields, const FResponseCallback& onCompleteRequest, TMap<FString, FString> customHeaders = TMap<FString, FString>()) const;
 private:
     static bool ResponseIsValid(const FHttpResponsePtr& InResponse, bool bWasSuccessful, FString RequestMethod, FString Endpoint, FString Data);
+    static const FString UserAgent;
     static const FString UserInstanceIdentifier;
 };
 


### PR DESCRIPTION
The purpose of this is to be able to keep track of a game instance across network switches and session changes for logging purposes.

Also adds the engine version to the User-Agent header