### PR TITLE
Cleanup of LootLockerConfig and static usages

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerAuthenticationRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerAuthenticationRequestHandler.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2021 LootLocker
 
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
+
+#include "LootLockerConfig.h"
 #include "LootLockerGameEndpoints.h"
 #include "LootLockerPlatformManager.h"
 #include "LootLockerStateData.h"
@@ -16,7 +18,6 @@ ULootLockerAuthenticationRequestHandler::ULootLockerAuthenticationRequestHandler
 
 void ULootLockerAuthenticationRequestHandler::WhiteLabelCreateAccount(const FString& Email, const FString& Password, const FLootLockerLoginResponseDelegateBP& OnCompletedRequestBP, const FLootLockerLoginResponseDelegate& OnCompletedRequest)
 {
-	const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
 	FLootLockerLoginRequest SignupRequest;
 	SignupRequest.email = Email;
 	SignupRequest.password = Password;

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBalanceRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBalanceRequestHandler.cpp
@@ -63,6 +63,6 @@ void ULootLockerBalanceRequestHandler::DebitBalanceToWallet(const FString& Walle
 void ULootLockerBalanceRequestHandler::CreateWallet(const FString& HolderULID, const ELootLockerWalletHolderTypes& HolderType, const FLootLockerCreateWalletResponseBP& OnCompleteBP, const FLootLockerCreateWalletResponseDelegate& OnComplete)
 {
 	LLAPI<FLootLockerCreateWalletResponse>::CallAPI(HttpClient, 
-		FLootLockerCreateWalletRequest{ HolderULID, ULootLockerConfig::GetEnum(TEXT("ELootLockerWalletHolderTypes"), static_cast<int32>(HolderType)).ToLower() }, 
+		FLootLockerCreateWalletRequest{ HolderULID, ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerWalletHolderTypes"), static_cast<int32>(HolderType)).ToLower() }, 
 		ULootLockerGameEndpoints::CreateWallet, {}, EmptyQueryParams, OnCompleteBP, OnComplete);
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerUserGeneratedContentRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerUserGeneratedContentRequestHandler.cpp
@@ -41,7 +41,7 @@ void ULootLockerUserGeneratedContentRequestHandler::GetAssetCandidate(int AssetC
 
 void ULootLockerUserGeneratedContentRequestHandler::AddFileToAssetCandidate(int AssetCandidateId, const FString& FilePath, ELootLockerAssetFilePurpose FilePurpose, const FResponseCallbackBP& OnCompletedRequestBP, const FResponseCallback& OnCompletedRequest)
 {
-    FString purpose = ULootLockerConfig::GetEnum(TEXT("ELootLockerAssetFilePurpose"), static_cast<int32>(FilePurpose));
+    FString purpose = ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerAssetFilePurpose"), static_cast<int32>(FilePurpose));
     TMap<FString, FString> AdditionalData;
     AdditionalData.Add("purpose", purpose);
 	

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -1,19 +1,3 @@
 // Copyright (c) 2021 LootLocker
 
 #include "LootLockerConfig.h"
-
-DEFINE_LOG_CATEGORY(LogLootLockerGameSDK);
-
-FString ULootLockerConfig::GetEnum(const TCHAR* Enum, int32 EnumValue)
-{
-#if ENGINE_MAJOR_VERSION <= 4 && ENGINE_MINOR_VERSION <= 27
-    const UEnum* EnumPtr = FindObject<UEnum>(StaticClass()->GetOuter(), Enum, true);
-#else
-    const UEnum* EnumPtr = FindObject<UEnum>(StaticClass()->GetOuterUPackage(), Enum, true);
-#endif
-    if (!EnumPtr)
-        return NSLOCTEXT("Invalid", "Invalid", "Invalid").ToString();
-
-    return EnumPtr->GetDisplayNameTextByValue(EnumValue).ToString();
-
-}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -5,7 +5,7 @@
 
 #include "HttpModule.h"
 #include "JsonObjectConverter.h"
-#include "LootLockerConfig.h"
+#include "LootLockerSDK.h"
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
 #include "Interfaces/IHttpResponse.h"
 #include "Misc/FileHelper.h"

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPlatformManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPlatformManager.cpp
@@ -28,18 +28,3 @@ FString FLootLockerPlatformRepresentation::GetFriendlyPlatformString()
 {
     return ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerPlatform"), static_cast<int>(Platform));
 }
-
-void ULootLockerCurrentPlatform::Set(const ELootLockerPlatformType& LegacyPlatform)
-{
-    switch (LegacyPlatform) {
-    case ELootLockerPlatformType::Android: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::Android); break;
-    case ELootLockerPlatformType::Ios: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::AppleSignIn); break;
-    case ELootLockerPlatformType::Steam: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::Steam); break;
-    case ELootLockerPlatformType::NintendoSwitch: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::NintendoSwitch); break;
-    case ELootLockerPlatformType::PlayStationNetwork: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::PlayStationNetwork); break;
-    case ELootLockerPlatformType::Xbox: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::Xbox); break;
-
-    case ELootLockerPlatformType::UNUSED:
-    default: CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::None); break;
-    }
-}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPlatformManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPlatformManager.cpp
@@ -24,7 +24,7 @@ TMap<ELootLockerPlatform, FLootLockerPlatformRepresentation> ULootLockerCurrentP
 
 FLootLockerPlatformRepresentation& ULootLockerCurrentPlatform::CurrentPlatform = *PlatformRepresentations.Find(ELootLockerPlatform::None);
 
-const FString FLootLockerPlatformRepresentation::GetFriendlyStringFromEnum(const ELootLockerPlatform& Platform)
+FString FLootLockerPlatformRepresentation::GetFriendlyPlatformString()
 {
     return ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerPlatform"), static_cast<int>(Platform));
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPlatformManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPlatformManager.cpp
@@ -3,6 +3,8 @@
 
 #include "LootLockerPlatformManager.h"
 
+#include "Utils/LootLockerUtilities.h"
+
 TMap<ELootLockerPlatform, FLootLockerPlatformRepresentation> ULootLockerCurrentPlatform::PlatformRepresentations = TMap<ELootLockerPlatform, FLootLockerPlatformRepresentation>{
         {ELootLockerPlatform::None, FLootLockerPlatformRepresentation(ELootLockerPlatform::None, "", "")}
 		, {ELootLockerPlatform::Guest, FLootLockerPlatformRepresentation(ELootLockerPlatform::Guest, "guest", "guest")}
@@ -24,7 +26,7 @@ FLootLockerPlatformRepresentation& ULootLockerCurrentPlatform::CurrentPlatform =
 
 const FString FLootLockerPlatformRepresentation::GetFriendlyStringFromEnum(const ELootLockerPlatform& Platform)
 {
-    return ULootLockerConfig::GetEnum(TEXT("ELootLockerPlatform"), static_cast<int>(Platform));
+    return ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerPlatform"), static_cast<int>(Platform));
 }
 
 void ULootLockerCurrentPlatform::Set(const ELootLockerPlatformType& LegacyPlatform)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDK.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDK.cpp
@@ -4,10 +4,11 @@
 #if WITH_EDITOR
 #include "ISettingsModule.h"
 #include "ISettingsSection.h"
-#include "LootLockerConfig.h"
 #endif
+#include "LootLockerConfig.h"
 
 #define LOCTEXT_NAMESPACE "FLootLockerSDKModule"
+DEFINE_LOG_CATEGORY(LogLootLockerGameSDK);
 void FLootLockerSDKModule::StartupModule()
 {
 	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -2,8 +2,9 @@
 
 
 #include "LootLockerStateData.h"
-#include "LootLockerConfig.h"
+
 #include "LootLockerPersistedState.h"
+#include "LootLockerSDK.h"
 #include "Kismet/GameplayStatics.h"
 
 FString ULootLockerStateData::Token = "";

--- a/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.cpp
@@ -14,6 +14,19 @@ const TArray<FObfuscationDetails> UObfuscationSettings::FieldsToObfuscate =
     FObfuscationDetails(FString("token"), "*", 3, 3, true)
 };
 
+FString ULootLockerEnumUtils::GetEnum(const TCHAR* Enum, int32 EnumValue)
+{
+#if ENGINE_MAJOR_VERSION <= 4 && ENGINE_MINOR_VERSION <= 27
+    const UEnum* EnumPtr = FindObject<UEnum>(StaticClass()->GetOuter(), Enum, true);
+#else
+    const UEnum* EnumPtr = FindObject<UEnum>(StaticClass()->GetOuterUPackage(), Enum, true);
+#endif
+    if (!EnumPtr)
+        return NSLOCTEXT("Invalid", "Invalid", "Invalid").ToString();
+
+    return EnumPtr->GetDisplayNameTextByValue(EnumValue).ToString();
+}
+
 namespace LootLockerUtilities
 {
     FString AppendParameterToUrl(const FString& Url, const FString& Parameter)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.h
@@ -4,8 +4,11 @@
 
 #include "LootLockerConfig.h"
 #include "LootLockerStateData.h"
+#include "LootLockerGameEndpoints.h"
+#include "LootLockerSDK.h"
 #include "GameAPI/LootLockerCharacterRequestHandler.h"
 #include "GameAPI/LootLockerMissionsRequestHandler.h"
+#include "LootLockerUtilities.generated.h"
 
 constexpr FLootLockerEmptyRequest LootLockerEmptyRequest;
 
@@ -33,6 +36,14 @@ struct FObfuscationDetails
 struct UObfuscationSettings
 {
     static const TArray<FObfuscationDetails> FieldsToObfuscate;
+};
+
+UCLASS()
+class LOOTLOCKERSDK_API ULootLockerEnumUtils : public UObject
+{
+    GENERATED_BODY()
+public:
+    static FString GetEnum(const TCHAR* Enum, int32 EnumValue);
 };
 
 namespace LootLockerUtilities
@@ -136,7 +147,7 @@ struct LLAPI
                 Delimiter = "&";
             }
         }
-        const FString RequestMethod = ULootLockerConfig::GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(Endpoint.requestMethod));
+        const FString RequestMethod = ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(Endpoint.requestMethod));
 #if WITH_EDITOR
         UE_LOG(LogLootLockerGameSDK, Log, TEXT("Request:"));
         if (!ContentString.IsEmpty() && !IsEmptyJsonString(ContentString)) {
@@ -161,7 +172,7 @@ struct LLAPI
         FString EndpointWithArguments = FString::Format(*Endpoint.endpoint, FStringFormatNamedArguments{ {"domainKey", Config && !Config->DomainKey.IsEmpty() ? Config->DomainKey + "." : ""} });
         EndpointWithArguments = FString::Format(*EndpointWithArguments, InOrderedArguments);
         
-        const FString RequestMethod = ULootLockerConfig::GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(Endpoint.requestMethod));
+        const FString RequestMethod = ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(Endpoint.requestMethod));
         CustomHeaders.Add(TEXT("x-session-token"), ULootLockerStateData::GetToken());
 
 #if WITH_EDITOR
@@ -195,7 +206,7 @@ struct LLAPI
             }
         }
         
-        const FString RequestMethod = ULootLockerConfig::GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(Endpoint.requestMethod));
+        const FString RequestMethod = ULootLockerEnumUtils::GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(Endpoint.requestMethod));
         CustomHeaders.Add(TEXT("x-session-token"), ULootLockerStateData::GetToken());
 
         // create callback lambda

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
@@ -3,10 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
 #include "LootLockerResponse.h"
-#include "LootLockerConfig.h"
-#include "JsonObjectConverter.h"
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
 #include "GameAPI/LootLockerAssetsRequestHandler.h"
 #include "LootLockerPlayerRequestHandler.generated.h"

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerUserGeneratedContentRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerUserGeneratedContentRequestHandler.h
@@ -3,10 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
-#include "LootLockerConfig.h"
 #include "LootLockerResponse.h"
-#include "JsonObjectConverter.h"
 #include "LootLockerHttpClient.h"
 #include "LootLockerUserGeneratedContentRequestHandler.generated.h"
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -3,69 +3,12 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "LootLockerResponse.h"
 #include "LootLockerConfig.generated.h"
-
-DECLARE_LOG_CATEGORY_EXTERN(LogLootLockerGameSDK, Log, All);
-
-UENUM(BlueprintType)
-enum class ELootLockerHTTPMethod : uint8
-{
-	GET = 0         UMETA(DisplayName = "GET"),
-	POST = 1        UMETA(DisplayName = "POST"),
-	DELETE = 2      UMETA(DisplayName = "DELETE"),
-	PUT = 3         UMETA(DisplayName = "PUT"),
-	HEAD = 4        UMETA(DisplayName = "HEAD"),
-	CREATE = 5      UMETA(DisplayName = "CREATE"),
-	OPTIONS = 6     UMETA(DisplayName = "OPTIONS"),
-	PATCH = 7       UMETA(DisplayName = "PATCH"),
-	UPLOAD = 8      UMETA(DisplayName = "UPLOAD")
-};
-
-UENUM(BlueprintType)
-enum class ELootLockerPlatformType : uint8
-{
-	Android = 0				UMETA(DisplayName = "Android"),
-	Ios = 1					UMETA(DisplayName = "Ios"),
-	Steam = 2				UMETA(DisplayName = "Steam"),
-	NintendoSwitch = 3		UMETA(DisplayName = "NintendoSwitch"),
-	PlayStationNetwork = 4  UMETA(DisplayName = "PlayStationNetwork"),
-	Xbox = 5				UMETA(DisplayName = "Xbox"),
-	UNUSED = 6				UMETA(DisplayName = "Unused")
-};
-
-USTRUCT(BlueprintType)
-struct FLootLockerEndPoints
-{
-	GENERATED_BODY()
-public:
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	FString endpoint;
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
-	ELootLockerHTTPMethod requestMethod = ELootLockerHTTPMethod::GET;
-};
-
-USTRUCT(BlueprintType)
-struct FLootLockerGetRequests
-{
-	GENERATED_BODY()
-	TArray<FStringFormatArg> args;
-};
-
-DECLARE_DYNAMIC_DELEGATE_OneParam(FResponseCallbackBP, FLootLockerResponse, Response);
-DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerResponseCallback, FLootLockerResponse, Response);
-DECLARE_DELEGATE_OneParam(FResponseCallback, FLootLockerResponse);
 
 UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "LootLocker SDK Settings"))
 class LOOTLOCKERSDK_API ULootLockerConfig : public UObject
 {
 	GENERATED_BODY()
-public:
-	static FString GetEnum(const TCHAR* Enum, int32 EnumValue);
-    static FString GetRequestMethodString(ELootLockerHTTPMethod RequestMethod)
-    {
-        return GetEnum(TEXT("ELootLockerHTTPMethod"), static_cast<int32>(RequestMethod));
-    }
 public:
 	// API Key used to talk to LootLocker. The API key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (DisplayName = "LootLocker API Key"))

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -2,8 +2,32 @@
 
 #pragma once
 
-#include "LootLockerConfig.h"
 #include "LootLockerGameEndpoints.generated.h"
+
+UENUM(BlueprintType)
+enum class ELootLockerHTTPMethod : uint8
+{
+    GET = 0         UMETA(DisplayName = "GET"),
+    POST = 1        UMETA(DisplayName = "POST"),
+    DELETE = 2      UMETA(DisplayName = "DELETE"),
+    PUT = 3         UMETA(DisplayName = "PUT"),
+    HEAD = 4        UMETA(DisplayName = "HEAD"),
+    CREATE = 5      UMETA(DisplayName = "CREATE"),
+    OPTIONS = 6     UMETA(DisplayName = "OPTIONS"),
+    PATCH = 7       UMETA(DisplayName = "PATCH"),
+    UPLOAD = 8      UMETA(DisplayName = "UPLOAD")
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerEndPoints
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+    FString endpoint;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+    ELootLockerHTTPMethod requestMethod = ELootLockerHTTPMethod::GET;
+};
 
 UCLASS()
 class LOOTLOCKERSDK_API ULootLockerGameEndpoints : public UObject

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "LootLockerResponse.h"
 #include "Interfaces/IHttpRequest.h"
-#include "LootLockerConfig.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "LootLockerHttpClient.generated.h"
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerPlatformManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerPlatformManager.h
@@ -2,12 +2,21 @@
 
 #pragma once
 
-#include <stdexcept>
-
 #include "CoreMinimal.h"
-#include "LootLockerConfig.h"
 #include "LootLockerStateData.h"
 #include "LootLockerPlatformManager.generated.h"
+
+UENUM(BlueprintType)
+enum class ELootLockerPlatformType : uint8
+{
+	Android = 0				UMETA(DisplayName = "Android"),
+	Ios = 1					UMETA(DisplayName = "Ios"),
+	Steam = 2				UMETA(DisplayName = "Steam"),
+	NintendoSwitch = 3		UMETA(DisplayName = "NintendoSwitch"),
+	PlayStationNetwork = 4  UMETA(DisplayName = "PlayStationNetwork"),
+	Xbox = 5				UMETA(DisplayName = "Xbox"),
+	UNUSED = 6				UMETA(DisplayName = "Unused")
+};
 
 UENUM(BlueprintType)
 enum class ELootLockerPlatform : uint8

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerPlatformManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerPlatformManager.h
@@ -48,19 +48,15 @@ struct FLootLockerPlatformRepresentation
 	UPROPERTY(BlueprintReadOnly, Category = "LootLocker")
     FString PlatformString;
 	UPROPERTY(BlueprintReadOnly, Category = "LootLocker")
-    FString FriendlyPlatformString;
-	UPROPERTY(BlueprintReadOnly, Category = "LootLocker")
     FString AuthenticationProviderString;
 
     FLootLockerPlatformRepresentation(const ELootLockerPlatform& Platform = ELootLockerPlatform::None, const FString& PlatformString = TEXT(""), const FString& AuthenticationProviderString = TEXT(""))
 	    : Platform(Platform),
 	    PlatformString(PlatformString),
-	    FriendlyPlatformString(GetFriendlyStringFromEnum(Platform)),
 		AuthenticationProviderString(AuthenticationProviderString)
 	{
 	}
-private:
-	static const FString GetFriendlyStringFromEnum(const ELootLockerPlatform& Platform);
+	FString GetFriendlyPlatformString();
 };
 
 UCLASS(BlueprintType)
@@ -74,8 +70,8 @@ public:
     };
 	static const ELootLockerPlatform& Get() { return CurrentPlatform.Platform; }
 	static const FString& GetString() { return CurrentPlatform.PlatformString; }
-	static const FString& GetFriendlyString() { return CurrentPlatform.FriendlyPlatformString; }
-	static const FString& GetAuthenticationProviderString() { return CurrentPlatform.FriendlyPlatformString; }
+	static FString GetFriendlyString() { return CurrentPlatform.GetFriendlyPlatformString(); }
+	static FString GetAuthenticationProviderString() { return GetFriendlyString(); }
 	UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Miscellaneous")
 	static const FLootLockerPlatformRepresentation& GetPlatformRepresentation() { return CurrentPlatform; }
 	UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Miscellaneous")

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerPlatformManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerPlatformManager.h
@@ -7,18 +7,6 @@
 #include "LootLockerPlatformManager.generated.h"
 
 UENUM(BlueprintType)
-enum class ELootLockerPlatformType : uint8
-{
-	Android = 0				UMETA(DisplayName = "Android"),
-	Ios = 1					UMETA(DisplayName = "Ios"),
-	Steam = 2				UMETA(DisplayName = "Steam"),
-	NintendoSwitch = 3		UMETA(DisplayName = "NintendoSwitch"),
-	PlayStationNetwork = 4  UMETA(DisplayName = "PlayStationNetwork"),
-	Xbox = 5				UMETA(DisplayName = "Xbox"),
-	UNUSED = 6				UMETA(DisplayName = "Unused")
-};
-
-UENUM(BlueprintType)
 enum class ELootLockerPlatform : uint8
 {
 	None = 0				UMETA(DisplayName = "None"),
@@ -83,7 +71,6 @@ public:
 		CurrentPlatform = *PlatformRepresentations.Find(Platform);
 		ULootLockerStateData::SetLastActivePlatform(CurrentPlatform.PlatformString);
 	}
-	static void Set(const ELootLockerPlatformType& LegacyPlatform);
 
 	virtual void PostInitProperties() override
 	{

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerResponse.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerResponse.h
@@ -47,6 +47,10 @@ struct FLootLockerResponse
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerDefaultResponseBP, FLootLockerResponse, Var);
 DECLARE_DELEGATE_OneParam(FLootLockerDefaultDelegate, FLootLockerResponse);
 
+DECLARE_DYNAMIC_DELEGATE_OneParam(FResponseCallbackBP, FLootLockerResponse, Response);
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerResponseCallback, FLootLockerResponse, Response);
+DECLARE_DELEGATE_OneParam(FResponseCallback, FLootLockerResponse);
+
 USTRUCT(BlueprintType)
 struct FLootLockerKeyBasedPagination
 {

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDK.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDK.h
@@ -4,8 +4,8 @@
 
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
-#include "LootLockerConfig.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogLootLockerGameSDK, Log, All);
 class FLootLockerSDKModule : public IModuleInterface
 {
 public:

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "LootLockerConfig.h"
 #include "GameAPI/LootLockerAccountLinkRequestHandler.h"
 #include "GameAPI/LootLockerAssetInstancesRequestHandler.h"
 #include "GameAPI/LootLockerAssetsRequestHandler.h"


### PR DESCRIPTION
We've had a bug for a long time where it was sometime impossible to package with LL. Error messages have been unhelpful and I haven't had time to investigate it. I ran into it today however and decided to address our mess of a config file (as that was the one packaging was complaining about) and breaking out a bunch of functionality that didn't feel at home there. After having done that, I was finally able to sort through the linking and find that the problem was a static constructor using a static method that used a non static member method on an object that didn't exist yet. I seem to have fixed it now.