### PR TITLE
Change 'RemoveAssetFromHeroLoadout' to correctly use only path params

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerHeroRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerHeroRequestHandler.cpp
@@ -87,6 +87,6 @@ void ULootLockerHeroRequestHandler::AddGlobalAssetVariationToHeroLoadout(const i
 
 void ULootLockerHeroRequestHandler::RemoveAssetToHeroLoadout(const int32 HeroID, const int32 AssetInstanceID, const FHeroLoadoutReseponseBP &OnCompleteBP, const FHeroLoadoutReseponseDelegate &OnComplete)
 {
-	LLAPI<FLootLockerHeroLoadoutResponse>::CallAPI(HttpClient, FLootLockerHeroAssetInstance{ AssetInstanceID }, ULootLockerGameEndpoints::RemoveAssetToHeroLoadout,  { HeroID }, EmptyQueryParams, OnCompleteBP, OnComplete);
+	LLAPI<FLootLockerHeroLoadoutResponse>::CallAPI(HttpClient, LootLockerEmptyRequest, ULootLockerGameEndpoints::RemoveAssetToHeroLoadout,  { HeroID, AssetInstanceID }, EmptyQueryParams, OnCompleteBP, OnComplete);
 }
 


### PR DESCRIPTION
GOALS correctly pointed out that according to reference documentation (https://ref.lootlocker.com/game-api/#remove-asset-from-hero-loadout) the asset instance id is supposed to be supplied as a path parameter, not in request data.