### PR TITLE
Add a convenience steam sign in method that integrates the subsystem

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/LootLockerSDK.Build.cs
+++ b/LootLockerSDK/Source/LootLockerSDK/LootLockerSDK.Build.cs
@@ -41,8 +41,9 @@ public class LootLockerSDK : ModuleRules
                 "HTTP",
                 "Json",
                 "JsonUtilities",
-                "Projects"
-			}
+                "Projects", 
+                "OnlineSubsystem"
+            }
             );
         DynamicallyLoadedModuleNames.AddRange(
             new string[]

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -16,6 +16,11 @@ void ULootLockerManager::StartAndroidSession(const FString& DeviceId, const FAut
     ULootLockerAuthenticationRequestHandler::StartAndroidSession(DeviceId, OnStartedSessionRequestCompleted);
 }
 
+void ULootLockerManager::StartSteamSessionUsingSubsystem(int LocalUserNumber, const FAuthResponseBP& OnStartedSessionRequestCompleted)
+{
+    ULootLockerAuthenticationRequestHandler::StartSteamSessionUsingSubsystem(LocalUserNumber, OnStartedSessionRequestCompleted);
+}
+
 void ULootLockerManager::StartAmazonLunaSession(const FString& AmazonLunaGuid, const FAuthResponseBP& OnStartedSessionRequestCompleted)
 {
     ULootLockerAuthenticationRequestHandler::StartAmazonLunaSession(AmazonLunaGuid, OnStartedSessionRequestCompleted);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -49,6 +49,11 @@ void ULootLockerSDKManager::VerifyPlayerAndStartSteamSession(const FString& Stea
         }));
 }
 
+void ULootLockerSDKManager::StartSteamSessionUsingSubsystem(int LocalUserNumber, const FLootLockerSessionResponse& OnCompletedRequest)
+{
+    ULootLockerAuthenticationRequestHandler::StartSteamSessionUsingSubsystem(LocalUserNumber, FAuthResponseBP(), OnCompletedRequest);
+}
+
 void ULootLockerSDKManager::StartSteamSession(const FString& SteamId64, const FLootLockerSessionResponse& OnCompletedRequest)
 {
     ULootLockerAuthenticationRequestHandler::StartSteamSession(SteamId64, FAuthResponseBP(), OnCompletedRequest);

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerAuthenticationRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerAuthenticationRequestHandler.h
@@ -467,6 +467,8 @@ public:
 	static void RefreshEpicSession(const FString& RefreshToken, const FEpicSessionResponseBP& OnCompletedRequestBP = FEpicSessionResponseBP(), const FLootLockerEpicSessionResponseDelegate& OnCompletedRequest = FLootLockerEpicSessionResponseDelegate());
     static void StartAmazonLunaSession(const FString& AmazonLunaGuid, const FAuthResponseBP& AuthResponseBP = FAuthResponseBP(), const FLootLockerSessionResponse& Delegate = FLootLockerSessionResponse());
     static void StartSteamSession(const FString& SteamId64, const FAuthResponseBP& AuthResponseBP = FAuthResponseBP(), const FLootLockerSessionResponse& Delegate = FLootLockerSessionResponse());
+	static void StartSteamSessionUsingSubsystem(int LocalUserNumber, const FAuthResponseBP& AuthResponseBP = FAuthResponseBP(), const FLootLockerSessionResponse&
+		                              Delegate = FLootLockerSessionResponse());
     static void StartNintendoSwitchSession(const FString& NSAIdToken, const FAuthResponseBP& OnCompletedRequestBP = FAuthResponseBP(), const FLootLockerSessionResponse& OnCompletedRequest = FLootLockerSessionResponse());
 	static void StartXboxSession(const FString& XboxUserToken, const FAuthResponseBP& OnCompletedRequestBP = FAuthResponseBP(), const FLootLockerSessionResponse& OnCompletedRequest = FLootLockerSessionResponse());
 	static void StartAppleSession(const FString& AuthorizationCode, const FAppleSessionResponseBP& OnCompletedRequestBP = FAppleSessionResponseBP(), const FLootLockerAppleSessionResponseDelegate& OnCompletedRequest = FLootLockerAppleSessionResponseDelegate());
@@ -478,7 +480,12 @@ public:
 	static void RefreshAppleGameCenterSession(const FString& RefreshToken, const FLootLockerAppleGameCenterSessionResponseBP& OnCompletedRequestBP = FLootLockerAppleGameCenterSessionResponseBP(), const FLootLockerAppleGameCenterSessionResponseDelegate& OnCompletedRequest = FLootLockerAppleGameCenterSessionResponseDelegate());
 	static void StartMetaSession(const FString& UserId, const FString& Nonce, const FLootLockerMetaSessionResponseBP& OnCompletedRequestBP = FLootLockerMetaSessionResponseBP(), const FLootLockerMetaSessionResponseDelegate& OnCompletedRequest = FLootLockerMetaSessionResponseDelegate());
 	static void RefreshMetaSession(const FString& RefreshToken, const FLootLockerMetaSessionResponseBP& OnCompletedRequestBP = FLootLockerMetaSessionResponseBP(), const FLootLockerMetaSessionResponseDelegate& OnCompletedRequest = FLootLockerMetaSessionResponseDelegate());
+
 	static ULootLockerHttpClient* HttpClient;
 private:
 	static TMap<FString, FString> DomainKeyHeaders();
+	static FDelegateHandle SteamLoginDelegateHandle;
+	static void StartSteamSessionSignedIn(int LocalUserNumber, const FAuthResponseBP& BPDelegate, const FLootLockerSessionResponse& CPPDelegate);
+	static void InvokeCallbacksWithErrorResponse(const FString& Message, const FAuthResponseBP& BPDelegate,
+	                                             const FLootLockerSessionResponse& CPPDelegate);
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -85,6 +85,19 @@ public:
     static void VerifyPlayerAndStartSteamSession(const FString& SteamId64, const FString& PlatformToken, const FAuthResponseBP& OnCompletedRequest);
 
     /**
+     * [BETA, this method is beta functionality ] Start a session for a Steam user
+     * A game can support multiple platforms, but it is recommended that a build only supports one platform.
+     * https://ref.lootlocker.io/game-api/#authentication-request
+     *
+     * NOTE: This requires that you have set up your project for Steam game development: https://dev.epicgames.com/documentation/en-us/unreal-engine/online-subsystem-steam-interface-in-unreal-engine
+     *
+     * @param LocalUserNumber The User Number for whom to start the steam session
+     * @param OnStartedSessionRequestCompleted Delegate for handling the server response.
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication")
+    static void StartSteamSessionUsingSubsystem(int LocalUserNumber, const FAuthResponseBP& OnStartedSessionRequestCompleted);
+
+    /**
      * Start a session for a Steam user
      * Note: Steam requires that you verify the player before starting a steam session. See the method VerifyPlayer
      * A game can support multiple platforms, but it is recommended that a build only supports one platform.

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -82,6 +82,18 @@ public:
     static void VerifyPlayerAndStartSteamSession(const FString& SteamId64, const FString& PlatformToken, const FLootLockerSessionResponse& OnCompletedRequest);
 
     /**
+     * [BETA, this method is beta functionality ] Start a session for a Steam user
+     * A game can support multiple platforms, but it is recommended that a build only supports one platform.
+     * https://ref.lootlocker.io/game-api/#authentication-request
+     *
+     * NOTE: This requires that you have set up your project for Steam game development: https://dev.epicgames.com/documentation/en-us/unreal-engine/online-subsystem-steam-interface-in-unreal-engine
+     *
+     * @param LocalUserNumber The User Number for whom to start the steam session
+     * @param OnCompletedRequest Delegate for handling the server response.
+     */
+    static void StartSteamSessionUsingSubsystem(int LocalUserNumber, const FLootLockerSessionResponse& OnCompletedRequest);
+
+    /**
      * Start a session for a Steam user
      * Note: Steam requires that you verify the player before starting a steam session. See the method VerifyPlayer
      * A game can support multiple platforms, but it is recommended that a build only supports one platform.


### PR DESCRIPTION
This is a speculative change. Now that I understand the Online Subsystems better after spending considerable time with them (I blame Google), I felt when updating the Steam sign in docs like we could simplify this greatly for our users to actually less cost to us than one'd think. 

I have yet to test whether this actually works. Especially in different editor versions.

Additionally, Epic has said that the Online Subsystems are out of support (willl be replaced).

All of this maintenance would fall on us with this change. That said, Steam is a good POC for such a change since it's so simple.

Let's have a chat about it.