### PR TITLE
fix: Add support for asset variations and rental options to catalogs

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
@@ -51,6 +51,78 @@ public:
 
 };
 
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerAssetItemDetailsKey
+{
+    GENERATED_BODY()
+    /*
+    * The id of the catalog listing
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Catalog_listing_id = "";
+    /*
+    * The id of the item
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Item_id = "";
+    /*
+    * The Asset Variation ID
+    * Asset Variations is a deprecated feature, this is added for backward compatibility only
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Asset_variation_id = "";
+    /*
+    * The Asset Rental option ID
+    * Asset Rental Options is a deprecated feature, this is added for backward compatibility only
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Rental_option_id = "";
+
+public:
+
+    friend uint32 GetTypeHash(const FLootLockerAssetItemDetailsKey& p) {
+        return HashCombine(HashCombine(GetTypeHash(p.Catalog_listing_id), GetTypeHash(p.Item_id)), HashCombine(GetTypeHash(p.Asset_variation_id), GetTypeHash(p.Rental_option_id)));
+    }
+
+    bool operator==(const FLootLockerAssetItemDetailsKey& Other) const
+    {
+        return Catalog_listing_id.Equals(Other.Catalog_listing_id) && Item_id.Equals(Other.Item_id) && Asset_variation_id.Equals(Other.Asset_variation_id) && Rental_option_id.Equals(Other.Rental_option_id);
+    }
+
+    FLootLockerAssetItemDetailsKey() = default;
+
+    FLootLockerAssetItemDetailsKey(const FString& InCatalogListingId, const FString& InItemId, const FString& InAssetVariationId, const FString& InRentalOptionId)
+        : Catalog_listing_id(InCatalogListingId)
+        , Item_id(InItemId)
+        , Asset_variation_id(InAssetVariationId)
+        , Rental_option_id(InRentalOptionId)
+    {
+    }
+
+    FLootLockerAssetItemDetailsKey(const FLootLockerAssetItemDetailsKey& Other) = default;
+
+    FLootLockerAssetItemDetailsKey& operator=(const FLootLockerAssetItemDetailsKey& Other) = default;
+
+    ~FLootLockerAssetItemDetailsKey() = default;
+
+    FLootLockerAssetItemDetailsKey(const FString& InCatalogListingId, const FString& InItemId)
+        : Catalog_listing_id(InCatalogListingId)
+        , Item_id(InItemId)
+        , Asset_variation_id("")
+        , Rental_option_id("")
+    {
+    }
+
+    FLootLockerAssetItemDetailsKey(const FLootLockerItemDetailsKey& Other)
+        : Catalog_listing_id(Other.Catalog_listing_id)
+        , Item_id(Other.Item_id)
+        , Asset_variation_id("")
+        , Rental_option_id("")
+    {
+    }
+
+};
+
 /**
  * 
  */
@@ -596,6 +668,12 @@ struct FLootLockerInlinedCatalogEntry : public FLootLockerCatalogEntry
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FLootLockerAssetDetails AssetDetails;
     /**
+     * This is a list of potentially matching asset details for this catalog entry, in case there are multiple variations / rental options
+     * Asset Variations and Rental Options are deprecated features, this is added for backward compatibility only
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerAssetDetails> OptionalAssetDetailVariants;
+    /**
      * Progression point details inlined for this catalog entry, will be Empty if the entity_kind is not progression_points
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -616,7 +694,7 @@ struct FLootLockerInlinedCatalogEntry : public FLootLockerCatalogEntry
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FLootLockerInlinedGroupDetails GroupDetails;
 
-    FLootLockerInlinedCatalogEntry(): AssetDetails(), ProgressionPointDetails(), ProgressionResetDetails(), CurrencyDetails(), GroupDetails() {}
+    FLootLockerInlinedCatalogEntry(): AssetDetails(), OptionalAssetDetailVariants(), ProgressionPointDetails(), ProgressionResetDetails(), CurrencyDetails(), GroupDetails() {}
 
     FLootLockerInlinedCatalogEntry(const FLootLockerCatalogEntry& Entry, const FLootLockerListCatalogPricesResponse& CatalogListing);
 
@@ -647,6 +725,14 @@ struct FLootLockerListCatalogPricesResponse : public FLootLockerResponse
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TMap<FLootLockerItemDetailsKey, FLootLockerAssetDetails> Asset_Details;
+
+    /**
+     * This is a list of potentially matching asset details for this catalog entry, in case there are multiple variations / rental options
+     * Asset Variations and Rental Options are deprecated features, this is added for backward compatibility only
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TMap<FLootLockerAssetItemDetailsKey, FLootLockerAssetDetails> Optional_Asset_Detail_Variants;
+
 
     /**
      * Lookup map for details about entities of entity type progression_points
@@ -714,6 +800,13 @@ struct FLootLockerListCatalogPricesV2Response : public FLootLockerResponse
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TMap<FLootLockerItemDetailsKey, FLootLockerAssetDetails> Asset_Details;
+
+    /**
+     * This is a list of potentially matching asset details for this catalog entry, in case there are multiple variations / rental options
+     * Asset Variations and Rental Options are deprecated features, this is added for backward compatibility only
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TMap<FLootLockerAssetItemDetailsKey, FLootLockerAssetDetails> Optional_Asset_Detail_Variants;
 
     /**
      * Lookup map for details about entities of entity type progression_points


### PR DESCRIPTION
Note that the changes are done for both v1 and v2 catalog listing.

- Catalog Response has a dict of assets so needs a dict of asset variations as well
  - Solution: Parse assets but place optionals in separate dict
- Catalog Entries of type Group has a list of Associations with just the basic key
  - Failed to solve: Figure out a clean way to get the variations here. Since the associations hold just the basic key (listing id and item id) there's no way to figure out cleanly which association goes with which variation without backend changes.
- Inlined Catalog Entries has a single asset_details var
  - Solution: Add optionals array and populate with all asset variants that match the basic key if there's not a single asset detail that matches. Populate optionals list only if entry asset details has no single match.
- Inlined Group has a list of assetDetails
  - Solution: Add single match if found for the association, otherwise add all optionals matching basic key BUT keep track of previously added basic keys so we don't add the same optionals multiple times for multiple associations with the same basic key.