### PR TITLE
docs: add Copilot instructions for Unreal SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,13 @@
 
 - Read [.github/instructions/architecture.md](instructions/architecture.md) first to understand **where code lives** and the repo’s architectural boundaries.
 - Follow guardrails in [.github/instructions/guardrails.md](instructions/guardrails.md).
+- Follow conventions in [.github/instructions/style-guide.md](instructions/style-guide.md).
+- Reference patterns in [.github/instructions/patterns.md](instructions/patterns.md).
+- Path-specific instructions (higher precedence than this file):
+  - Public C++ facade: [.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h.instructions.md](instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h.instructions.md)
+  - Public Blueprint facade: [.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h.instructions.md](instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h.instructions.md)
+  - Request handler headers: [.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI.instructions.md](instructions/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI.instructions.md)
+  - Request handler impls: [.github/instructions/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI.instructions.md](instructions/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI.instructions.md)
 - Branching rules:
   - Work only on a work branch (no direct commits to `dev`/`main`).
   - PRs must target **base = `dev`** (never `main`).

--- a/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI.instructions.md
+++ b/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI.instructions.md
@@ -1,0 +1,24 @@
+# Path-specific instructions — Private/GameAPI implementations
+
+Applies to files under: `LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/`
+
+- Implement request handlers declared under `Public/GameAPI/`.
+- Prefer using existing shared plumbing:
+  - `LLAPI<ResponseType>::CallAPI(...)` / `CallAPIUsingRawJSON(...)`
+  - `ULootLockerGameEndpoints` for endpoints
+  - `ULootLockerHttpClient` for transport
+- Params and auth headers:
+  - Path params: pass ordered arguments as `TArray<FStringFormatArg>{ ... }` (do not pre-encode).
+  - Query params: use `TMultiMap<FString, FString>` and only add values when meaningful.
+  - Do not manually add `x-session-token`; `ULootLockerHttpClient` sets it from `PlayerData.Token` when present.
+- Keep responses consistent:
+  - Ensure `success`, `StatusCode`, `ErrorData`, and `Context` are propagated as in the existing `LLAPI` pattern.
+  - Use `FResponseInspectorCallback` (where already used) for side effects before invoking the user delegate (for example caching player state on successful auth).
+- Deprecation-aware changes:
+  - Avoid silent breaking behavior changes in existing requests unless explicitly requested.
+  - If an API needs to change behavior or migrate routes, prefer keeping the old request method working (or forwarding internally) and adding a new method/type for the new behavior.
+- Logging & secrets:
+  - Do not log tokens/credentials/API keys.
+  - If logging JSON for diagnostics, obfuscate using `LootLockerUtilities::ObfuscateJsonStringForLogging(...)`.
+- Comments:
+  - Keep comments minimal and focused; avoid restating obvious code.

--- a/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI.instructions.md
+++ b/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI.instructions.md
@@ -1,0 +1,25 @@
+# Path-specific instructions — Public/GameAPI request handlers
+
+Applies to files under: `LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/`
+
+- These headers define the SDK’s request/response DTOs and request handler entrypoints.
+- Keep module boundaries intact:
+  - Do not include runtime `Private/` headers here.
+- DTO conventions (verifiable in existing handlers):
+  - Prefer `USTRUCT(BlueprintType)` for request/response structs.
+  - Use `UPROPERTY(EditAnywhere, BlueprintReadWrite, ...)` on fields.
+  - JSON-facing fields commonly use **snake_case** to match backend payload keys; keep names aligned with expected JSON keys.
+  - Response structs typically inherit from `FLootLockerResponse` (preserve `success`, `StatusCode`, `ErrorData`, `Context`).
+- JSON / Blueprint compatibility (critical):
+  - These structs are serialized/deserialized via `FJsonObjectConverter` in the shared request plumbing.
+  - Prefer additive changes to request/response DTOs.
+  - Avoid removing or renaming existing `UPROPERTY` fields: it can break user code, backend JSON expectations, and Blueprint pins.
+  - If you must discourage a field, prefer keeping it and using Unreal's deprecation metadata for properties (`DeprecatedProperty` / `DeprecationMessage`) when appropriate.
+- Handler method conventions:
+  - Typically `static FString <Method>(..., const <DelegateType>& OnCompletedRequest)` returning a request id.
+  - Prefer standard C++ delegates (`DECLARE_DELEGATE_OneParam`) here (Blueprint dynamic delegates belong in the Blueprint facade).
+- Request plumbing:
+  - Prefer using existing endpoint catalog entries (`ULootLockerGameEndpoints`) and the `LLAPI<ResponseType>` wrapper rather than duplicating HTTP/JSON code.
+- Logging & secrets:
+  - Treat tokens/credentials/API keys as sensitive; avoid logging them.
+  - If logging JSON request bodies, use `LootLockerUtilities::ObfuscateJsonStringForLogging(...)` (or repo-consistent equivalent).

--- a/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h.instructions.md
+++ b/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h.instructions.md
@@ -1,0 +1,16 @@
+# Path-specific instructions — LootLockerManager.h
+
+Applies to: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h`
+
+- Treat this file as the **Blueprint-facing facade**. Avoid breaking changes unless explicitly requested.
+- Keep diffs minimal and localized; this header is large and used as a user-facing API surface.
+- Docs are required for any API you add or change. Match the existing `/** ... */` documentation style in this file.
+- When adding Blueprint API:
+  - Use `UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | <Area>")` matching existing category naming.
+  - If returning a request id, return `FString` and use `UPARAM(DisplayName = "RequestId")`.
+  - Use metadata patterns already present when appropriate: `AdvancedDisplay`, `AutoCreateRefTerm`.
+  - For deprecations, use `meta = (DeprecatedFunction, DeprecationMessage="...")`, point to the replacement method, and keep the existing “Deprecation date …” comment style.
+- Delegate conventions in this file:
+  - Blueprint delegates are dynamic (`DECLARE_DYNAMIC_DELEGATE_*`) and commonly use a `...BP` suffix.
+  - Prefer existing response struct types (`FLootLockerResponse`-derived) for callbacks.
+- Do not introduce logging that could expose sensitive data (tokens, passwords, API keys). If you must log JSON for diagnostics, use the existing obfuscation helpers in `LootLockerUtilities`.

--- a/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h.instructions.md
+++ b/.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h.instructions.md
@@ -1,0 +1,14 @@
+# Path-specific instructions — LootLockerSDKManager.h
+
+Applies to: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h`
+
+- Treat this file as a **public C++ facade**. Avoid breaking changes (signature changes, renames, removals) unless explicitly requested.
+- Keep diffs minimal: do not reformat unrelated sections of this large header.
+- Maintain the existing documentation style:
+  - Use `/** ... */` doc blocks.
+  - Document all parameters with `@param` and include a meaningful `@return` when a value is returned.
+  - If a function returns a request id, document that it is a **unique id used to match callbacks**.
+- Preserve the existing semantics around player selection:
+  - When a function accepts `ForPlayerWithUlid` (or `PlayerUlid`), it is treated as optional in many APIs (empty often implies “default player”). Keep that consistent with surrounding code.
+- Prefer routing work through existing request handlers (`Public/GameAPI/…`) and existing plumbing (`LLAPI`, `ULootLockerHttpClient`) instead of adding bespoke HTTP/JSON logic here.
+- Be explicit about error behavior in docs when it is already called out in nearby functions (for example, “HTTP 401 indicates refresh token expired” patterns).

--- a/.github/instructions/patterns.md
+++ b/.github/instructions/patterns.md
@@ -1,0 +1,94 @@
+# LootLocker Unreal SDK — implementation patterns (reference)
+
+Docs-only. This document complements the style guide by describing the *existing* patterns used when adding/changing SDK functionality.
+
+This doc intentionally avoids re-stating rules that already live in:
+
+- `.github/instructions/style-guide.md` (repo-wide conventions)
+- applicable `.github/instructions/**/*.instructions.md` files (higher-precedence, path-specific rules)
+
+If this doc and the surrounding code disagree, prefer the surrounding code and keep diffs minimal.
+
+## Pattern: add a new API call (end-to-end)
+
+This repo generally uses a layered structure:
+
+1) Endpoint catalog (`ULootLockerGameEndpoints`)
+2) Request handler (GameAPI handler class)
+3) Public facade(s) (`ULootLockerSDKManager` for C++, `ULootLockerManager` for Blueprint)
+
+### 1) Add/declare the endpoint
+
+- Declare a new `static FLootLockerEndPoints` in:
+  - `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h`
+- Initialize it in:
+  - `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp`
+
+Conventions:
+
+- Use `FLootLockerEndPoints` with `.endpoint` and `.requestMethod`.
+- Prefer using path templates and formatting args rather than concatenating strings in handlers.
+
+### 2) Add request/response DTOs and handler method
+
+- Prefer placing request/response structs in the relevant request handler header:
+  - `LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/<Something>RequestHandler.h`
+- Implement the handler in:
+  - `LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/<Something>RequestHandler.cpp`
+
+Conventions observed across request handlers:
+
+- Request/response types are `USTRUCT(BlueprintType)` with `UPROPERTY(EditAnywhere, BlueprintReadWrite, ...)`.
+- JSON-facing fields commonly use snake_case matching backend keys.
+- Handler methods are typically `static FString <Method>(..., const <DelegateType>& OnCompletedRequest)`.
+
+Prefer using the existing `LLAPI<ResponseType>` wrapper:
+
+- Serialization helpers and `LLAPI` live in:
+  - `LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.h`
+
+Typical call shapes:
+
+- `LLAPI<ResponseType>::CallAPI(RequestStruct, Endpoint, OrderedArgs, QueryParams, PlayerData, OnCompletedRequest, /*optional inspector*/)`
+- `LLAPI<ResponseType>::CallAPIUsingRawJSON(JsonString, Endpoint, ...)`
+
+Parameter conventions (as used by `LLAPI` and existing handlers):
+
+- Path params: pass ordered arguments as `TArray<FStringFormatArg>{ ... }`.
+  - Do not pre-encode; `LLAPI` URL-encodes path params before formatting the endpoint URL.
+- Query params: use `TMultiMap<FString, FString>` and only add params when meaningful (avoid adding empty/default values).
+- Auth header: do not manually add `x-session-token` in request handlers; `ULootLockerHttpClient` sets it from `PlayerData.Token` when present.
+
+When appropriate, use `FResponseInspectorCallback` for side effects (e.g., caching auth/session state) before invoking the consumer delegate.
+
+### 3) Expose via public facade(s)
+
+C++ facade:
+
+- Add a forwarding static method to:
+  - `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h`
+- Implement (if needed) in:
+  - `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp`
+
+Blueprint facade:
+
+- Add a `UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | <Area>")` to:
+  - `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h`
+- Implement (if needed) in:
+  - `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp`
+
+Conventions observed in Blueprint facade:
+
+- Follow the existing Blueprint exposure and documentation conventions in the facade file.
+
+## Pattern: response/error handling
+
+- Prefer using `FLootLockerResponse`-derived response structs.
+- Ensure `success`, `StatusCode`, `ErrorData`, and `Context` are set consistently.
+- For standardized synthetic errors, use the existing factories:
+  - `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerResponse.h` (`LootLockerResponseFactory`)
+
+## Pattern: logging, secrets, and boundaries
+
+- Follow the repo-wide guidance in `.github/instructions/style-guide.md` and any applicable path-specific instruction files.
+

--- a/.github/instructions/style-guide.md
+++ b/.github/instructions/style-guide.md
@@ -1,0 +1,207 @@
+# LootLocker Unreal SDK — conventions & style guide
+
+Docs-only. This is a repo-specific guide for contributors and coding agents.
+
+This guide is intentionally **descriptive**: it only documents conventions that are verifiably present in the current codebase.
+
+## Scope & “source of truth”
+
+- Repo structure / boundaries: see [.github/instructions/architecture.md](architecture.md)
+- Guardrails for changes: see [.github/instructions/guardrails.md](guardrails.md)
+- File/folder-specific rules: prefer applicable `.github/instructions/**/*.instructions.md` (linked from `.github/copilot-instructions.md`)
+
+## 1) Module boundary discipline (non-negotiable)
+
+This repo is an Unreal Engine **plugin** with modules under `LootLockerSDK/Source/`.
+
+- **Runtime module**: `LootLockerSDK/Source/LootLockerSDK/`
+  - Public headers (external include surface): `.../Public/`
+  - Internal implementation: `.../Private/`
+- **Editor module**: `LootLockerSDK/Source/LootLockerSDKEditor/` (Editor-only tooling; not shipped)
+
+Rules (match existing architecture docs + common usage):
+
+- Do not include `Private/` headers from outside the owning module.
+- Prefer keeping helpers/internal types in `Private/`.
+- Be cautious when adding new headers to `Public/` (it expands the SDK’s public API surface).
+
+## 2) Public facades & Blueprint exposure
+
+### Where user-facing API lives
+
+- Blueprint-facing facade: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h` (`ULootLockerManager`)
+- C++-style facade: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h` (`ULootLockerSDKManager`)
+
+Both facades follow a “static methods on a UObject” pattern.
+
+### Blueprint callable functions
+
+Conventions observed in `ULootLockerManager`:
+
+- Blueprint-facing functions are organized under the `"LootLocker Methods | <Area>"` category hierarchy.
+- Many async-style Blueprint functions return a request id (`FString`) so callers can match callbacks when multiple requests are in flight.
+
+More detailed, file-specific rules (documentation rigor, metadata usage, deprecation conventions) are captured in the path-specific instruction files for the public facades.
+
+### Deprecation practices (observed in the Blueprint facade)
+
+Deprecations are present in `ULootLockerManager` and `ULootLockerSDKManager` and should be treated as a compatibility mechanism (prefer deprecating over removing/renaming).
+
+- Mark deprecated Blueprint-callable methods with `meta=(DeprecatedFunction, DeprecationMessage="...")`.
+- Mark deprecated Cpp-callable methods with `[[deprecated("This method is deprecated in favor of method <alternative>")]] // Deprecation date <deprecation date>`
+- Keep the existing inline comment convention for dating deprecations (for example `// Deprecation date 2025-09-24`).
+- Prefer an additive migration path:
+  - add a replacement method (new name/signature/behavior)
+  - keep the old method working (or forward internally when feasible)
+  - update `DeprecationMessage` to point at the replacement
+
+### Delegate patterns (Blueprint vs C++)
+
+The runtime codebase uses both:
+
+- **Blueprint delegates** (dynamic) in `LootLockerManager.h`:
+  - `DECLARE_DYNAMIC_DELEGATE_OneParam(<Name>BP, <ResponseStruct>, <ParamName>);`
+  - Suffix convention: `...BP` (e.g., `FAuthResponseBP`, `FAppleSessionResponseBP`).
+
+- **C++ delegates** (non-dynamic) in request handlers (example: `LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerAuthenticationRequestHandler.h`):
+  - `DECLARE_DELEGATE_OneParam(FLootLockerSessionResponse, FLootLockerAuthenticationResponse);`
+
+Guideline:
+
+- Use **dynamic delegates** only for Blueprint-exposed surface APIs.
+- Use **standard delegates** for internal plumbing and C++ request handlers.
+
+## 3) Request / response conventions
+
+### Where request handlers live
+
+- Public declarations & DTOs: `LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/`
+- Implementations: `LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/`
+
+Request handler classes are typically `UObject` classes with **static methods** that:
+
+- Return an `FString` request id.
+- Accept a response delegate.
+
+More detailed, folder-specific rules (DTO conventions, delegate expectations, and plumbing preferences) are captured in the path-specific instruction files for `Public/GameAPI/` and `Private/GameAPI/`.
+
+### Request/response DTOs (USTRUCT) and field naming
+
+Observed pattern (example: `LootLockerAuthenticationRequestHandler.h`):
+
+- Requests and responses are declared as `USTRUCT(BlueprintType)` (or occasionally plain `USTRUCT()`).
+- Fields are `UPROPERTY(EditAnywhere, BlueprintReadWrite, ...)`.
+- JSON-facing field names frequently use **snake_case** (e.g., `session_token`, `refresh_token`, `player_identifier`) which matches backend payload keys.
+
+Guideline:
+
+- When a field is serialized to/from backend JSON using `FJsonObjectConverter`, keep the name aligned with the expected JSON key (commonly snake_case in this repo).
+- Avoid renaming existing JSON-facing fields (it can break wire compatibility and Blueprint pins). Prefer additive changes.
+
+### Base response & error representation
+
+- Base response struct: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerResponse.h` (`FLootLockerResponse`)
+  - `success`, `StatusCode`, `FullTextFromServer`, `ErrorData`, `Context`
+- Error payload: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerErrorData.h` (`FLootLockerErrorData`)
+- Request context: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerRequestContext.h` (`FLootLockerRequestContext`)
+
+Guideline:
+
+- Response structs commonly **inherit** from `FLootLockerResponse` and add payload fields.
+- If you add a new response struct, preserve the base members and mapping (`success`, `StatusCode`, `ErrorData`, `Context`).
+
+### JSON conversion & the LLAPI wrapper
+
+The primary request/response plumbing is implemented in:
+
+- `LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.h` (`LLAPI<ResponseType>` and helpers)
+
+Key observed conventions:
+
+- Requests are typically serialized using `LootLockerUtilities::UStructToJsonString(RequestStruct)`.
+- Requests are sent via `ULootLockerHttpClient::SendApi(...)`.
+- Response parsing uses `FJsonObjectConverter::JsonObjectStringToUStruct<ResponseType>(...)`.
+- `LLAPI<ResponseType>` supports an optional `FResponseInspectorCallback` used for side effects before the user callback (e.g., caching player state on successful auth).
+
+Guideline:
+
+- Prefer using `LLAPI<ResponseType>::CallAPI(...)` / `CallAPIUsingRawJSON(...)` instead of duplicating HTTP/JSON code.
+- If you must do custom parsing, still return a standard response struct and keep `ErrorData`/`Context` populated.
+
+### Endpoints
+
+Endpoints are declared as static `FLootLockerEndPoints` members in:
+
+- `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h`
+
+They are initialized in the runtime module’s private implementation (`LootLockerGameEndpoints.cpp`).
+
+Guideline:
+
+- Add/declare new endpoints in the endpoints catalog rather than hard-coding URLs in handlers.
+
+## 4) Logging, secrets, and safe diagnostics
+
+### What logging utility is used
+
+- Central logger: `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerLogger.h` (`FLootLockerLogger`)
+- Implementation: `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerLogger.cpp`
+
+The SDK logs HTTP request/response information (see `ULootLockerHttpClient` and `FLootLockerLogger::LogHttpRequest`).
+
+### Logging defaults & safety intent
+
+Config expresses the intent to avoid accidental logging outside the editor:
+
+- `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h`
+  - `LogOutsideOfEditor` defaults to `false`
+  - Comment warns about “unintentional logging of data” because requests/responses are logged
+
+### Do not log secrets
+
+Treat the following as sensitive (non-exhaustive):
+
+- Session/auth tokens (`x-session-token`, `session_token`, `token`, `refresh_token`)
+- Credentials (`email`, `password`)
+- API keys / domain keys (`game_key`, `domain_key`, `game_api_key`)
+
+### Existing obfuscation helpers
+
+There is an existing JSON obfuscation utility and a concrete list of obfuscated keys:
+
+- `LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.cpp`
+  - `UObfuscationSettings::FieldsToObfuscate` includes: `game_key`, `email`, `password`, `domain_key`, `session_token`, `token`
+  - `LootLockerUtilities::ObfuscateJsonStringForLogging(...)`
+
+Guideline:
+
+- When adding any new logging that includes JSON request/response bodies, prefer passing the JSON string through `LootLockerUtilities::ObfuscateJsonStringForLogging(...)` (or a repo-consistent equivalent) before writing it.
+- Avoid adding new logs that print request headers verbatim when they may include `x-session-token`.
+
+## 5) Documentation expectations by file type
+
+You will encounter different documentation “bar heights” in this repo:
+
+- Public facade APIs in `LootLockerManager.h` and `LootLockerSDKManager.h`:
+  - Expect **rigorous, user-facing method documentation** (`/** ... @param ... @return ... */` style is widely used).
+- Request/response DTOs (USTRUCTs) in request handler headers:
+  - Prefer clear struct/field docs when the meaning is not obvious from backend naming.
+- Internal/private implementation (.cpp, `Private/` helpers):
+  - Keep comments minimal and focused; avoid restating obvious code.
+
+## 6) Formatting/tooling
+
+- No repository-wide `.clang-format` or `.editorconfig` was found at the repo root.
+- The codebase contains mixed formatting (tabs/spaces, brace placement) depending on file age.
+
+Guideline:
+
+- Match the surrounding file style.
+- Prefer minimal diffs; do not reformat unrelated lines.
+
+## 7) Diff hygiene & duplication avoidance
+
+- Keep changes focused (no drive-by refactors).
+- Search for existing handlers/utilities before creating new ones.
+  - Request handlers are already organized under `Public/GameAPI/` + `Private/GameAPI/`.
+


### PR DESCRIPTION
## Summary
Adds repo-specific Copilot / coding-agent instructions for the LootLocker Unreal SDK under `.github/instructions/`, and links them from `.github/copilot-instructions.md`. The goal is to keep AI-assisted changes consistent with the existing architecture, request/response plumbing, and public API conventions — while keeping diffs minimal and avoiding accidental public API expansion.

## What changed
- Updated `.github/copilot-instructions.md` to point to the repo’s instruction set and highlight that path-specific `.instructions.md` files take precedence.
- Added repo-wide guidance:
  - `.github/instructions/style-guide.md` — conventions, module boundaries, request/response patterns, logging/secrets hygiene, deprecation conventions (as observed), and diff discipline.
  - `.github/instructions/patterns.md` — reference workflow for adding/changing an API call (endpoints → request handler → facade), plus parameter/auth conventions consistent with `LLAPI` + `ULootLockerHttpClient`.
- Added path-specific instruction files (higher precedence, scoped rules) for high-impact public surfaces:
  - Public C++ facade: `.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h.instructions.md`
  - Public Blueprint facade: `.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h.instructions.md`
  - Request handler headers: `.github/instructions/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI.instructions.md`
  - Request handler impls: `.github/instructions/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI.instructions.md`

## Intent / guardrails encoded
- Search-first: reuse existing handlers, DTO patterns, and plumbing (`LLAPI`, endpoints catalog) before introducing new structures.
- Public API awareness: treat changes under `Public/` as compatibility decisions; prefer additive changes.
- JSON compatibility: avoid renaming/removing JSON-facing `UPROPERTY` fields; prefer additive DTO evolution.
- Secrets/logging: avoid logging tokens/credentials/keys; prefer existing obfuscation helpers for JSON diagnostics.
- Minimal diffs: no drive-by refactors or formatting churn.

This resolves https://github.com/lootlocker/index/issues/1163 for the Unreal SDK