### PR TITLE
feat: Add async purchase support

### DIFF
--- a/.github/scripts/verify-compilation.ps1
+++ b/.github/scripts/verify-compilation.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+#Requires -Version 5.0
 <#
 .SYNOPSIS
     Verifies that the LootLocker Unreal SDK plugin compiles without errors.

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
@@ -9,7 +9,6 @@
 #include "LootLockerGameEndpoints.h"
 #include "LootLockerStateData.h"
 #include "Utils/LootLockerUtilities.h"
-#include "LootLockerLogger.h"
 
 FString ULootLockerPurchasesRequestHandler::ActivateRentalAsset(const FLootLockerPlayerData& PlayerData, int AssetInstanceId, const FActivateRentalAssetResponseDelegate& OnCompletedRequest)
 {
@@ -251,6 +250,7 @@ FString ULootLockerPurchasesRequestHandler::ContinualAsyncPurchasePollAction(con
     {
         FLootLockerAsyncPurchaseStatusResponse TimedOutResponse;
         TimedOutResponse.success = false;
+        TimedOutResponse.Status = ELootLockerAsyncPurchaseStatus::TimedOut;
         OnComplete.ExecuteIfBound(TimedOutResponse);
         KillAsyncPurchaseProcess(ProcessID);
         return TEXT("");
@@ -260,6 +260,7 @@ FString ULootLockerPurchasesRequestHandler::ContinualAsyncPurchasePollAction(con
     {
         FLootLockerAsyncPurchaseStatusResponse CancelledResponse;
         CancelledResponse.success = false;
+        CancelledResponse.Status = ELootLockerAsyncPurchaseStatus::Cancelled;
         OnComplete.ExecuteIfBound(CancelledResponse);
         KillAsyncPurchaseProcess(ProcessID);
         return TEXT("");
@@ -286,7 +287,7 @@ FString ULootLockerPurchasesRequestHandler::ContinualAsyncPurchasePollAction(con
 
         if (!StatusResponse.success)
         {
-            if (StatusResponse.StatusCode >= 500 && StatusResponse.StatusCode <= 599 && _innerProcess.Retries <= _innerProcess.RetryLimit)
+            if (StatusResponse.StatusCode >= 500 && StatusResponse.StatusCode <= 599 && _innerProcess.Retries < _innerProcess.RetryLimit)
             {
                 _innerProcess.Retries++;
                 _scheduleNextPoll(_innerProcess.AsyncPurchaseProcessTimerHandle, _innerProcess.PollingIntervalSeconds, ProcessID);
@@ -351,11 +352,13 @@ ULootLockerAsyncPollAsyncPurchase* ULootLockerAsyncPollAsyncPurchase::AsyncPollA
     Instance->Items = InItems;
     Instance->PollingIntervalInSeconds = InPollingIntervalSeconds;
     Instance->TimeoutAfterMinutes = InTimeoutAfterMinutes;
+    Instance->RegisterWithGameInstance(WorldContextObject);
     return Instance;
 }
 
 void ULootLockerAsyncPollAsyncPurchase::Activate()
 {
+    Super::Activate();
     const TSharedPtr<FLootLockerPlayerData> PlayerDataPtr = ULootLockerStateData::GetStateForPlayerOrDefaultFromCache(ForPlayerWithUlid);
     FLootLockerPlayerData PlayerData = PlayerDataPtr.IsValid() ? *PlayerDataPtr : FLootLockerPlayerData();
 
@@ -376,6 +379,14 @@ void ULootLockerAsyncPollAsyncPurchase::Activate()
             else if (Response.success && Response.Status == ELootLockerAsyncPurchaseStatus::Failed)
             {
                 OnFailed.Broadcast(ProcessID, Response);
+            }
+            else if (Response.Status == ELootLockerAsyncPurchaseStatus::TimedOut)
+            {
+                OnTimedOut.Broadcast(ProcessID, Response);
+            }
+            else if (Response.Status == ELootLockerAsyncPurchaseStatus::Cancelled)
+            {
+                OnCancelled.Broadcast(ProcessID, Response);
             }
             else
             {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
@@ -2,10 +2,14 @@
 
 #include "GameAPI/LootLockerPurchasesRequestHandler.h"
 
+#include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 #include "LootLockerGameEndpoints.h"
+#include "LootLockerStateData.h"
 #include "Utils/LootLockerUtilities.h"
+#include "LootLockerLogger.h"
 
 FString ULootLockerPurchasesRequestHandler::ActivateRentalAsset(const FLootLockerPlayerData& PlayerData, int AssetInstanceId, const FActivateRentalAssetResponseDelegate& OnCompletedRequest)
 {
@@ -151,33 +155,235 @@ FString ULootLockerPurchasesRequestHandler::RedeemPlayStationStorePurchaseForPla
     return LLAPI<FLootLockerResponse>::CallAPIUsingRawJSON(JsonString, ULootLockerGameEndpoints::RedeemPlayStationStorePurchase, {}, {}, PlayerData, OnCompleted);
 }
 
-FString ULootLockerPurchasesRequestHandler::RedeemPlayStationStorePurchaseForCharacter(const FLootLockerPlayerData& PlayerData, const FString& CharacterId, const FString& TransactionId, const FString& AuthCode, const FString& EntitlementLabel, const FString& ServiceLabel, const FString& ServiceName, const int Environment, const int UseCount, const FLootLockerDefaultDelegate& OnCompleted)
-{
-    TSharedRef<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
-    JsonObject->SetStringField(TEXT("transaction_id"), TransactionId);
-    JsonObject->SetStringField(TEXT("auth_code"), AuthCode);
-    JsonObject->SetStringField(TEXT("entitlement_label"), EntitlementLabel);
-    JsonObject->SetStringField(TEXT("character_id"), CharacterId);
-    
-    // Add optional parameters if they are set
-    if (!ServiceLabel.IsEmpty())
-    {
-        JsonObject->SetStringField(TEXT("service_label"), ServiceLabel);
-    }
-    if (!ServiceName.IsEmpty())
-    {
-        JsonObject->SetStringField(TEXT("service_name"), ServiceName);
-    }
-    if (Environment != -1)
-    {
-        JsonObject->SetNumberField(TEXT("environment"), Environment);
-    }
-    if (UseCount != -1)
-    {
-        JsonObject->SetNumberField(TEXT("use_count"), UseCount);
-    }
-    
     FString JsonString = LootLockerUtilities::FStringFromJsonObject(JsonObject);
 
     return LLAPI<FLootLockerResponse>::CallAPIUsingRawJSON(JsonString, ULootLockerGameEndpoints::RedeemPlayStationStorePurchase, {}, {}, PlayerData, OnCompleted);
+}
+
+//==================================================
+// Async Purchase Static Data
+//==================================================
+
+TMap<FString, FLootLockerAsyncPurchaseProcess> ULootLockerPurchasesRequestHandler::AsyncPurchaseProcesses = TMap<FString, FLootLockerAsyncPurchaseProcess>();
+
+FLootLockerAsyncPurchaseProcess::FLootLockerAsyncPurchaseProcess(float _PollingIntervalSeconds, float TimeoutAfterMinutes)
+    : TimeoutTime(FDateTime::UtcNow() + FTimespan::FromMinutes(TimeoutAfterMinutes))
+    , PollingIntervalSeconds(FMath::Max(1.0f, _PollingIntervalSeconds))
+{
+}
+
+//==================================================
+// Async Purchase Primitive Methods
+//==================================================
+
+FString ULootLockerPurchasesRequestHandler::InitiateAsyncPurchase(const FLootLockerPlayerData& PlayerData, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompleted)
+{
+    return LLAPI<FLootLockerAsyncPurchaseInitiatedResponse>::CallAPI(FLootLockerPurchaseCatalogItemRequest{ WalletId, Items }, ULootLockerGameEndpoints::InitiateAsyncPurchase, {}, {}, PlayerData, OnCompleted);
+}
+
+FString ULootLockerPurchasesRequestHandler::GetAsyncPurchaseStatus(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegate& OnCompleted)
+{
+    return LLAPI<FLootLockerAsyncPurchaseStatusResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::PollAsyncPurchaseStatus, { EntitlementId }, {}, PlayerData, OnCompleted);
+}
+
+FString ULootLockerPurchasesRequestHandler::RetryAsyncPurchase(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompleted)
+{
+    return LLAPI<FLootLockerAsyncPurchaseInitiatedResponse>::CallAPI(FLootLockerPurchaseCatalogItemRequest{ WalletId, Items }, ULootLockerGameEndpoints::RetryAsyncPurchase, { EntitlementId }, {}, PlayerData, OnCompleted);
+}
+
+//==================================================
+// Async Purchase Polling
+//==================================================
+
+FString ULootLockerPurchasesRequestHandler::StartAsyncPurchasePolling(const FLootLockerPlayerData& PlayerData, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseStatusDelegate& OnStatusUpdate, const FLootLockerAsyncPurchaseStatusDelegate& OnComplete, float PollingIntervalSeconds, float TimeoutAfterMinutes)
+{
+    const FString ProcessID = FGuid::NewGuid().ToString();
+    FLootLockerAsyncPurchaseProcess NewProcess(PollingIntervalSeconds, TimeoutAfterMinutes);
+    NewProcess.WalletId = WalletId;
+    NewProcess.Items = Items;
+    NewProcess.PlayerData = PlayerData;
+    AsyncPurchaseProcesses.Add(ProcessID, NewProcess);
+
+    InitiateAsyncPurchase(PlayerData, WalletId, Items, FLootLockerAsyncPurchaseInitiatedDelegate::CreateLambda([ProcessID, OnStatusUpdate, OnComplete](FLootLockerAsyncPurchaseInitiatedResponse InitiateResponse)
+    {
+        FLootLockerAsyncPurchaseProcess* _processPtr = AsyncPurchaseProcesses.Find(ProcessID);
+        if (nullptr == _processPtr)
+        {
+            return;
+        }
+        if (!InitiateResponse.success)
+        {
+            FLootLockerAsyncPurchaseStatusResponse ErrorResponse;
+            ErrorResponse.success = false;
+            ErrorResponse.StatusCode = InitiateResponse.StatusCode;
+            ErrorResponse.FullTextFromServer = InitiateResponse.FullTextFromServer;
+            ErrorResponse.ErrorData = InitiateResponse.ErrorData;
+            OnComplete.ExecuteIfBound(ErrorResponse);
+            KillAsyncPurchaseProcess(ProcessID);
+            return;
+        }
+        _processPtr->EntitlementId = InitiateResponse.Entitlement_id;
+        ContinualAsyncPurchasePollAction(ProcessID, OnStatusUpdate, OnComplete);
+    }));
+
+    return ProcessID;
+}
+
+void ULootLockerPurchasesRequestHandler::CancelAsyncPurchasePolling(const FString& ProcessID)
+{
+    FLootLockerAsyncPurchaseProcess* _processPtr = AsyncPurchaseProcesses.Find(ProcessID);
+    if (nullptr != _processPtr)
+    {
+        _processPtr->ShouldCancel = true;
+    }
+}
+
+FString ULootLockerPurchasesRequestHandler::ContinualAsyncPurchasePollAction(const FString& ProcessID, const FLootLockerAsyncPurchaseStatusDelegate& OnStatusUpdate, const FLootLockerAsyncPurchaseStatusDelegate& OnComplete)
+{
+    const FLootLockerAsyncPurchaseProcess* _processPtr = AsyncPurchaseProcesses.Find(ProcessID);
+    if (nullptr == _processPtr)
+    {
+        return TEXT("");
+    }
+    const FLootLockerAsyncPurchaseProcess& _process = *_processPtr;
+
+    if (_process.TimeoutTime <= FDateTime::UtcNow())
+    {
+        FLootLockerAsyncPurchaseStatusResponse TimedOutResponse;
+        TimedOutResponse.success = false;
+        OnComplete.ExecuteIfBound(TimedOutResponse);
+        KillAsyncPurchaseProcess(ProcessID);
+        return TEXT("");
+    }
+
+    if (_process.ShouldCancel)
+    {
+        FLootLockerAsyncPurchaseStatusResponse CancelledResponse;
+        CancelledResponse.success = false;
+        OnComplete.ExecuteIfBound(CancelledResponse);
+        KillAsyncPurchaseProcess(ProcessID);
+        return TEXT("");
+    }
+
+    return GetAsyncPurchaseStatus(_process.PlayerData, _process.EntitlementId, LLAPI<FLootLockerAsyncPurchaseStatusResponse>::FResponseInspectorCallback::CreateLambda([ProcessID, OnStatusUpdate, OnComplete](FLootLockerAsyncPurchaseStatusResponse& StatusResponse)
+    {
+        FLootLockerAsyncPurchaseProcess* _innerProcessPtr = AsyncPurchaseProcesses.Find(ProcessID);
+        if (nullptr == _innerProcessPtr)
+        {
+            return;
+        }
+        FLootLockerAsyncPurchaseProcess& _innerProcess = *_innerProcessPtr;
+
+        auto _scheduleNextPoll = [OnStatusUpdate, OnComplete](FTimerHandle& TimerHandle, const float TimeToNextPoll, const FString& PID)
+        {
+            FTimerDelegate TimerDelegate;
+            TimerDelegate.BindLambda([OnStatusUpdate, OnComplete, PID]()
+            {
+                ContinualAsyncPurchasePollAction(PID, OnStatusUpdate, OnComplete);
+            });
+            SetAsyncPurchaseTimer(TimerHandle, TimerDelegate, TimeToNextPoll);
+        };
+
+        if (!StatusResponse.success)
+        {
+            if (StatusResponse.StatusCode >= 500 && StatusResponse.StatusCode <= 599 && _innerProcess.Retries <= _innerProcess.RetryLimit)
+            {
+                _innerProcess.Retries++;
+                _scheduleNextPoll(_innerProcess.AsyncPurchaseProcessTimerHandle, _innerProcess.PollingIntervalSeconds, ProcessID);
+                return;
+            }
+            OnComplete.ExecuteIfBound(StatusResponse);
+            KillAsyncPurchaseProcess(ProcessID);
+            return;
+        }
+
+        _innerProcess.Retries = 0;
+
+        if (ELootLockerAsyncPurchaseStatus::Active == StatusResponse.Status || ELootLockerAsyncPurchaseStatus::Failed == StatusResponse.Status)
+        {
+            OnComplete.ExecuteIfBound(StatusResponse);
+            KillAsyncPurchaseProcess(ProcessID);
+            return;
+        }
+
+        // Still pending — notify and reschedule
+        OnStatusUpdate.ExecuteIfBound(StatusResponse);
+        _scheduleNextPoll(_innerProcess.AsyncPurchaseProcessTimerHandle, _innerProcess.PollingIntervalSeconds, ProcessID);
+    }));
+}
+
+void ULootLockerPurchasesRequestHandler::KillAsyncPurchaseProcess(const FString& ProcessID)
+{
+    FLootLockerAsyncPurchaseProcess* _processPtr = AsyncPurchaseProcesses.Find(ProcessID);
+    if (nullptr == _processPtr)
+    {
+        return;
+    }
+    ClearAsyncPurchaseTimer(_processPtr->AsyncPurchaseProcessTimerHandle);
+    AsyncPurchaseProcesses.Remove(ProcessID);
+}
+
+void ULootLockerPurchasesRequestHandler::SetAsyncPurchaseTimer(FTimerHandle& TimerHandle, const FTimerDelegate& Delegate, float Time)
+{
+    if (GEngine && GEngine->GameViewport && GEngine->GameViewport->GetWorld())
+    {
+        GEngine->GameViewport->GetWorld()->GetTimerManager().SetTimer(TimerHandle, Delegate, Time, false);
+    }
+}
+
+void ULootLockerPurchasesRequestHandler::ClearAsyncPurchaseTimer(FTimerHandle& TimerHandle)
+{
+    if (GEngine && GEngine->GameViewport && GEngine->GameViewport->GetWorld())
+    {
+        GEngine->GameViewport->GetWorld()->GetTimerManager().SetTimer(TimerHandle, -1.0f, false);
+    }
+}
+
+//==================================================
+// Async Blueprint Node
+//==================================================
+
+ULootLockerAsyncPollAsyncPurchase* ULootLockerAsyncPollAsyncPurchase::AsyncPollAsyncPurchase(UObject* WorldContextObject, FString PlayerWithUlid, FString InWalletId, TArray<FLootLockerCatalogItemAndQuantityPair> InItems, float InPollingIntervalSeconds, float InTimeoutAfterMinutes)
+{
+    ULootLockerAsyncPollAsyncPurchase* Instance = NewObject<ULootLockerAsyncPollAsyncPurchase>();
+    Instance->ForPlayerWithUlid = PlayerWithUlid;
+    Instance->WalletId = InWalletId;
+    Instance->Items = InItems;
+    Instance->PollingIntervalInSeconds = InPollingIntervalSeconds;
+    Instance->TimeoutAfterMinutes = InTimeoutAfterMinutes;
+    return Instance;
+}
+
+void ULootLockerAsyncPollAsyncPurchase::Activate()
+{
+    const TSharedPtr<FLootLockerPlayerData> PlayerDataPtr = ULootLockerStateData::GetStateForPlayerOrDefaultFromCache(ForPlayerWithUlid);
+    FLootLockerPlayerData PlayerData = PlayerDataPtr.IsValid() ? *PlayerDataPtr : FLootLockerPlayerData();
+
+    ProcessID = ULootLockerPurchasesRequestHandler::StartAsyncPurchasePolling(
+        PlayerData,
+        WalletId,
+        Items,
+        FLootLockerAsyncPurchaseStatusDelegate::CreateLambda([this](FLootLockerAsyncPurchaseStatusResponse Response)
+        {
+            OnPending.Broadcast(ProcessID, Response);
+        }),
+        FLootLockerAsyncPurchaseStatusDelegate::CreateLambda([this](FLootLockerAsyncPurchaseStatusResponse Response)
+        {
+            if (Response.success && Response.Status == ELootLockerAsyncPurchaseStatus::Active)
+            {
+                OnActive.Broadcast(ProcessID, Response);
+            }
+            else if (Response.success && Response.Status == ELootLockerAsyncPurchaseStatus::Failed)
+            {
+                OnFailed.Broadcast(ProcessID, Response);
+            }
+            else
+            {
+                OnFailed.Broadcast(ProcessID, Response);
+            }
+            SetReadyToDestroy();
+        }),
+        PollingIntervalInSeconds,
+        TimeoutAfterMinutes
+    );
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
@@ -155,11 +155,6 @@ FString ULootLockerPurchasesRequestHandler::RedeemPlayStationStorePurchaseForPla
     return LLAPI<FLootLockerResponse>::CallAPIUsingRawJSON(JsonString, ULootLockerGameEndpoints::RedeemPlayStationStorePurchase, {}, {}, PlayerData, OnCompleted);
 }
 
-    FString JsonString = LootLockerUtilities::FStringFromJsonObject(JsonObject);
-
-    return LLAPI<FLootLockerResponse>::CallAPIUsingRawJSON(JsonString, ULootLockerGameEndpoints::RedeemPlayStationStorePurchase, {}, {}, PlayerData, OnCompleted);
-}
-
 //==================================================
 // Async Purchase Static Data
 //==================================================
@@ -182,6 +177,11 @@ FString ULootLockerPurchasesRequestHandler::InitiateAsyncPurchase(const FLootLoc
 }
 
 FString ULootLockerPurchasesRequestHandler::GetAsyncPurchaseStatus(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegate& OnCompleted)
+{
+    return LLAPI<FLootLockerAsyncPurchaseStatusResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::PollAsyncPurchaseStatus, { EntitlementId }, {}, PlayerData, OnCompleted);
+}
+
+FString ULootLockerPurchasesRequestHandler::GetAsyncPurchaseStatus(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const LLAPI<FLootLockerAsyncPurchaseStatusResponse>::FResponseInspectorCallback& OnCompleted)
 {
     return LLAPI<FLootLockerAsyncPurchaseStatusResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::PollAsyncPurchaseStatus, { EntitlementId }, {}, PlayerData, OnCompleted);
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -216,6 +216,10 @@ FLootLockerEndPoints ULootLockerGameEndpoints::QuerySteamPurchaseRedemptionStatu
 FLootLockerEndPoints ULootLockerGameEndpoints::FinalizeSteamPurchaseRedemption = InitEndpoint("store/steam/redeem/finalise", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::RefundByEntitlementIds = InitEndpoint("refund/v1", ELootLockerHTTPMethod::POST);
 
+FLootLockerEndPoints ULootLockerGameEndpoints::InitiateAsyncPurchase = InitEndpoint("purchase/inspired-ibex/v1", ELootLockerHTTPMethod::POST);
+FLootLockerEndPoints ULootLockerGameEndpoints::PollAsyncPurchaseStatus = InitEndpoint("purchase/inspired-ibex/v1/{0}", ELootLockerHTTPMethod::GET);
+FLootLockerEndPoints ULootLockerGameEndpoints::RetryAsyncPurchase = InitEndpoint("purchase/inspired-ibex/v1/{0}/retry", ELootLockerHTTPMethod::POST);
+
 //Trigger Events
 FLootLockerEndPoints ULootLockerGameEndpoints::TriggerEventEndpoint = InitEndpoint("v1/player/trigger", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::GetTriggeredEventsEndpoint = InitEndpoint("v1/player/triggers", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1519,6 +1519,48 @@ FString ULootLockerManager::RefundByEntitlementIds(const FString& ForPlayerWithU
         }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::InitiateAsyncPurchaseSingleCatalogItem(const FString& ForPlayerWithUlid, const FString& WalletId, const FString& ItemId, const int Quantity, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest)
+{
+    TArray<FLootLockerCatalogItemAndQuantityPair> Items;
+    FLootLockerCatalogItemAndQuantityPair Item;
+    Item.Catalog_listing_id = ItemId;
+    Item.Quantity = Quantity;
+    Items.Add(Item);
+    return ULootLockerSDKManager::InitiateAsyncPurchaseCatalogItems(WalletId, Items, FLootLockerAsyncPurchaseInitiatedDelegate::CreateLambda([OnCompletedRequest](FLootLockerAsyncPurchaseInitiatedResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
+FString ULootLockerManager::InitiateAsyncPurchaseCatalogItems(const FString& ForPlayerWithUlid, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::InitiateAsyncPurchaseCatalogItems(WalletId, Items, FLootLockerAsyncPurchaseInitiatedDelegate::CreateLambda([OnCompletedRequest](FLootLockerAsyncPurchaseInitiatedResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
+FString ULootLockerManager::GetAsyncPurchaseStatus(const FString& ForPlayerWithUlid, const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegateBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::GetAsyncPurchaseStatus(EntitlementId, FLootLockerAsyncPurchaseStatusDelegate::CreateLambda([OnCompletedRequest](FLootLockerAsyncPurchaseStatusResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
+FString ULootLockerManager::RetryAsyncPurchase(const FString& ForPlayerWithUlid, const FString& EntitlementId, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::RetryAsyncPurchase(EntitlementId, WalletId, Items, FLootLockerAsyncPurchaseInitiatedDelegate::CreateLambda([OnCompletedRequest](FLootLockerAsyncPurchaseInitiatedResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
+void ULootLockerManager::CancelAsyncPurchasePolling(const FString& ProcessID)
+{
+    ULootLockerPurchasesRequestHandler::CancelAsyncPurchasePolling(ProcessID);
+}
+
 //Triggers
 FString ULootLockerManager::InvokeTriggersByKey(const FString& ForPlayerWithUlid, const TArray<FString>& KeysToInvoke, const FLootLockerInvokeTriggersByKeyResponseBP& OnComplete)
 {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1124,6 +1124,31 @@ FString ULootLockerSDKManager::RefundByEntitlementIds(const TArray<FString>& Ent
     return ULootLockerPurchasesRequestHandler::RefundByEntitlementIds(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), EntitlementIds, OnCompletedRequest);
 }
 
+FString ULootLockerSDKManager::InitiateAsyncPurchaseCatalogItems(const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    return ULootLockerPurchasesRequestHandler::InitiateAsyncPurchase(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), WalletId, Items, OnCompletedRequest);
+}
+
+FString ULootLockerSDKManager::GetAsyncPurchaseStatus(const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    return ULootLockerPurchasesRequestHandler::GetAsyncPurchaseStatus(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), EntitlementId, OnCompletedRequest);
+}
+
+FString ULootLockerSDKManager::RetryAsyncPurchase(const FString& EntitlementId, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    return ULootLockerPurchasesRequestHandler::RetryAsyncPurchase(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), EntitlementId, WalletId, Items, OnCompletedRequest);
+}
+
+FString ULootLockerSDKManager::StartAsyncPurchasePolling(const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseStatusDelegate& OnStatusUpdate, const FLootLockerAsyncPurchaseStatusDelegate& OnComplete, float PollingIntervalSeconds, float TimeoutAfterMinutes, const FString& ForPlayerWithUlid /* = "" */)
+{
+    return ULootLockerPurchasesRequestHandler::StartAsyncPurchasePolling(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), WalletId, Items, OnStatusUpdate, OnComplete, PollingIntervalSeconds, TimeoutAfterMinutes);
+}
+
+void ULootLockerSDKManager::CancelAsyncPurchasePolling(const FString& ProcessID)
+{
+    ULootLockerPurchasesRequestHandler::CancelAsyncPurchasePolling(ProcessID);
+}
+
 //Triggers
 FString ULootLockerSDKManager::InvokeTriggersByKey(const TArray<FString>& KeysToInvoke, const FLootLockerInvokeTriggersByKeyResponseDelegate& OnComplete, const FString& ForPlayerWithUlid /* = "" */)
 {

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "LootLockerResponse.h"
 #include "LootLockerPlayerData.h"
+#include "TimerManager.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
 #include "LootLockerPurchasesRequestHandler.generated.h"
 
 USTRUCT(BlueprintType)
@@ -426,6 +428,79 @@ struct FLootLockerRefundByEntitlementIdsResponse : public FLootLockerResponse
     TArray<FLootLockerRefundWarning> warnings;
 };
 
+//==================================================
+// Async Purchase Types
+//==================================================
+
+/**
+ * Possible statuses for an async purchase
+ */
+UENUM(BlueprintType, Category = "LootLocker")
+enum class ELootLockerAsyncPurchaseStatus : uint8
+{
+    Pending = 0,
+    Active = 1,
+    Failed = 2,
+};
+
+/**
+ * Response from initiating an async purchase
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerAsyncPurchaseInitiatedResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+     * The id of the entitlement created for this purchase
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Entitlement_id = "";
+};
+
+/**
+ * Response from polling the status of an async purchase
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerAsyncPurchaseStatusResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+     * The id of the entitlement this status refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Entitlement_id = "";
+    /**
+     * The current status of the purchase
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    ELootLockerAsyncPurchaseStatus Status = ELootLockerAsyncPurchaseStatus::Pending;
+    /**
+     * The failure reason. Only populated when status is failed.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Error = "";
+};
+
+DECLARE_DELEGATE_OneParam(FLootLockerAsyncPurchaseInitiatedDelegate, FLootLockerAsyncPurchaseInitiatedResponse);
+DECLARE_DELEGATE_OneParam(FLootLockerAsyncPurchaseStatusDelegate, FLootLockerAsyncPurchaseStatusResponse);
+
+struct FLootLockerAsyncPurchaseProcess
+{
+    static constexpr int RetryLimit = 5;
+    FString EntitlementId = "";
+    FString WalletId = "";
+    TArray<FLootLockerCatalogItemAndQuantityPair> Items;
+    FLootLockerPlayerData PlayerData;
+    FDateTime TimeoutTime;
+    float PollingIntervalSeconds = 1.0f;
+    int Retries = 0;
+    bool ShouldCancel = false;
+    FTimerHandle AsyncPurchaseProcessTimerHandle;
+
+    FLootLockerAsyncPurchaseProcess() = default;
+    FLootLockerAsyncPurchaseProcess(float _PollingIntervalSeconds, float TimeoutAfterMinutes);
+};
+
 DECLARE_DELEGATE_OneParam(FActivateRentalAssetResponseDelegate, FLootLockerActivateRentalAssetResponse);
 DECLARE_DELEGATE_OneParam(FLootLockerBeginSteamPurchaseRedemptionDelegate, FLootLockerBeginSteamPurchaseRedemptionResponse);
 DECLARE_DELEGATE_OneParam(FLootLockerQuerySteamPurchaseRedemptionStatusDelegate, FLootLockerQuerySteamPurchaseRedemptionStatusResponse);
@@ -468,4 +543,84 @@ public:
     static FString FinalizeSteamPurchaseRedemption(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FLootLockerDefaultDelegate& OnCompleted);
 
     static FString RefundByEntitlementIds(const FLootLockerPlayerData& PlayerData, const TArray<FString>& EntitlementIds, const FLootLockerRefundByEntitlementIdsDelegate& OnCompleted);
+
+    static FString InitiateAsyncPurchase(const FLootLockerPlayerData& PlayerData, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompleted);
+
+    static FString GetAsyncPurchaseStatus(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegate& OnCompleted);
+
+    static FString RetryAsyncPurchase(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompleted);
+
+    static FString StartAsyncPurchasePolling(const FLootLockerPlayerData& PlayerData, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseStatusDelegate& OnStatusUpdate, const FLootLockerAsyncPurchaseStatusDelegate& OnComplete, float PollingIntervalSeconds = 1.0f, float TimeoutAfterMinutes = 5.0f);
+
+    static void CancelAsyncPurchasePolling(const FString& ProcessID);
+
+    static FString ContinualAsyncPurchasePollAction(const FString& ProcessID, const FLootLockerAsyncPurchaseStatusDelegate& OnStatusUpdate, const FLootLockerAsyncPurchaseStatusDelegate& OnComplete);
+
+    static void KillAsyncPurchaseProcess(const FString& ProcessID);
+
+protected:
+    static void SetAsyncPurchaseTimer(FTimerHandle& TimerHandle, const FTimerDelegate& Delegate, float Time);
+    static void ClearAsyncPurchaseTimer(FTimerHandle& TimerHandle);
+
+private:
+    static TMap<FString, FLootLockerAsyncPurchaseProcess> AsyncPurchaseProcesses;
+};
+
+//==================================================
+// Async Blueprint Delegate Definitions
+//==================================================
+
+/**
+ * Multicast delegate for events triggered from the async purchase polling node
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FLootLockerAsyncPurchasePollingMulticastDelegate, FString, ProcessID, FLootLockerAsyncPurchaseStatusResponse, Response);
+
+//==================================================
+// Async Blueprint Node Definitions
+//==================================================
+
+UCLASS()
+class ULootLockerAsyncPollAsyncPurchase : public UBlueprintAsyncActionBase
+{
+    GENERATED_BODY()
+public:
+    /**
+     * Initiate an async purchase and automatically poll until it reaches a terminal state.
+     * While pending, OnPending is triggered each poll. On completion, OnActive or OnFailed is triggered.
+     *
+     * @param WorldContextObject Non input: Automatic context for async node
+     * @param ForPlayerWithUlid Optional: Execute for the player with this ulid. Leave empty for the default player.
+     * @param WalletId The id of the wallet to use for the purchase
+     * @param Items The catalog items with quantities to purchase
+     * @param PollingIntervalSeconds Optional: How often to poll in seconds (minimum 1)
+     * @param TimeoutAfterMinutes Optional: How many minutes before the process times out
+     */
+    UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", Category = "LootLocker Methods | Purchases", WorldContext = "WorldContextObject", AdvancedDisplay = "PollingIntervalSeconds,TimeoutAfterMinutes,ForPlayerWithUlid", PollingIntervalSeconds = 1.0f, TimeoutAfterMinutes = 5.0f, ForPlayerWithUlid = ""))
+    static LOOTLOCKERSDK_API ULootLockerAsyncPollAsyncPurchase* AsyncPollAsyncPurchase(UObject* WorldContextObject, FString ForPlayerWithUlid, FString WalletId, TArray<FLootLockerCatalogItemAndQuantityPair> Items, float PollingIntervalSeconds, float TimeoutAfterMinutes);
+
+    /** Triggered on each poll while the purchase is still pending */
+    UPROPERTY(BlueprintAssignable)
+    FLootLockerAsyncPurchasePollingMulticastDelegate OnPending;
+    /** Triggered when the purchase has completed successfully (status = Active) */
+    UPROPERTY(BlueprintAssignable)
+    FLootLockerAsyncPurchasePollingMulticastDelegate OnActive;
+    /** Triggered when the purchase has failed (status = Failed) */
+    UPROPERTY(BlueprintAssignable)
+    FLootLockerAsyncPurchasePollingMulticastDelegate OnFailed;
+    /** Triggered if the process times out */
+    UPROPERTY(BlueprintAssignable)
+    FLootLockerAsyncPurchasePollingMulticastDelegate OnTimedOut;
+    /** Triggered if the process was cancelled using CancelAsyncPurchasePolling */
+    UPROPERTY(BlueprintAssignable)
+    FLootLockerAsyncPurchasePollingMulticastDelegate OnCancelled;
+
+    LOOTLOCKERSDK_API virtual void Activate() override;
+
+protected:
+    FString ForPlayerWithUlid = "";
+    FString ProcessID = "";
+    FString WalletId = "";
+    TArray<FLootLockerCatalogItemAndQuantityPair> Items;
+    float PollingIntervalInSeconds = 1.0f;
+    float TimeoutAfterMinutes = 5.0f;
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -7,6 +7,7 @@
 #include "LootLockerPlayerData.h"
 #include "TimerManager.h"
 #include "Kismet/BlueprintAsyncActionBase.h"
+#include "LootLockerSDK/Private/Utils/LootLockerUtilities.h"
 #include "LootLockerPurchasesRequestHandler.generated.h"
 
 USTRUCT(BlueprintType)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -442,6 +442,8 @@ enum class ELootLockerAsyncPurchaseStatus : uint8
     Pending = 0,
     Active = 1,
     Failed = 2,
+    TimedOut = 3,
+    Cancelled = 4,
 };
 
 /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -559,6 +559,7 @@ public:
     static void KillAsyncPurchaseProcess(const FString& ProcessID);
 
 protected:
+    static FString GetAsyncPurchaseStatus(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const LLAPI<FLootLockerAsyncPurchaseStatusResponse>::FResponseInspectorCallback& OnCompleted);
     static void SetAsyncPurchaseTimer(FTimerHandle& TimerHandle, const FTimerDelegate& Delegate, float Time);
     static void ClearAsyncPurchaseTimer(FTimerHandle& TimerHandle);
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -254,6 +254,10 @@ public:
     static FLootLockerEndPoints FinalizeSteamPurchaseRedemption;
     static FLootLockerEndPoints RefundByEntitlementIds;
 
+    static FLootLockerEndPoints InitiateAsyncPurchase;
+    static FLootLockerEndPoints PollAsyncPurchaseStatus;
+    static FLootLockerEndPoints RetryAsyncPurchase;
+
     //Trigger Events
     static FLootLockerEndPoints TriggerEventEndpoint;
     static FLootLockerEndPoints GetTriggeredEventsEndpoint;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -2865,7 +2865,7 @@ public:
     /**
       Initiate an async purchase of a single catalog item using a specified wallet.
       The async purchase flow uses a dedicated endpoint and returns an entitlement_id to poll for status.
-      Use InitiateAndPollAsyncPurchase for an automatic polling experience.
+      Use the AsyncPollAsyncPurchase Blueprint node (or StartAsyncPurchasePolling in C++) for an automatic polling experience.
 
       @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
       @param WalletId The id of the wallet to use for the purchase
@@ -2880,7 +2880,7 @@ public:
     /**
       Initiate an async purchase of one or more catalog items using a specified wallet.
       The async purchase flow uses a dedicated endpoint and returns an entitlement_id to poll for status.
-      Use InitiateAndPollAsyncPurchase for an automatic polling experience.
+      Use the AsyncPollAsyncPurchase Blueprint node (or StartAsyncPurchasePolling in C++) for an automatic polling experience.
 
       @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
       @param WalletId The id of the wallet to use for the purchase

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -290,6 +290,10 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerBeginSteamPurchaseRedemptionDelegat
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerQuerySteamPurchaseRedemptionStatusDelegateBP, FLootLockerQuerySteamPurchaseRedemptionStatusResponse, Response);
 /** Blueprint response delegate for refund by entitlement IDs responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerRefundByEntitlementIdsResponseDelegate, FLootLockerRefundByEntitlementIdsResponse, Response);
+/** Blueprint response delegate for initiating an async purchase */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerAsyncPurchaseInitiatedDelegateBP, FLootLockerAsyncPurchaseInitiatedResponse, Response);
+/** Blueprint response delegate for polling the status of an async purchase */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerAsyncPurchaseStatusDelegateBP, FLootLockerAsyncPurchaseStatusResponse, Response);
 
 //==================================================
 // Trigger Delegates
@@ -2857,6 +2861,67 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString RefundByEntitlementIds(const FString& ForPlayerWithUlid, const TArray<FString>& EntitlementIds, const FLootLockerRefundByEntitlementIdsResponseDelegate& OnCompletedRequest);
+
+    /**
+      Initiate an async purchase of a single catalog item using a specified wallet.
+      The async purchase flow uses a dedicated endpoint and returns an entitlement_id to poll for status.
+      Use InitiateAndPollAsyncPurchase for an automatic polling experience.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
+      @param WalletId The id of the wallet to use for the purchase
+      @param ItemId The catalog listing id of the item to purchase
+      @param Quantity The quantity to purchase
+      @param OnCompletedRequest Delegate for handling the server response
+      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString InitiateAsyncPurchaseSingleCatalogItem(const FString& ForPlayerWithUlid, const FString& WalletId, const FString& ItemId, const int Quantity, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest);
+
+    /**
+      Initiate an async purchase of one or more catalog items using a specified wallet.
+      The async purchase flow uses a dedicated endpoint and returns an entitlement_id to poll for status.
+      Use InitiateAndPollAsyncPurchase for an automatic polling experience.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
+      @param WalletId The id of the wallet to use for the purchase
+      @param Items The catalog items with quantities to purchase
+      @param OnCompletedRequest Delegate for handling the server response
+      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString InitiateAsyncPurchaseCatalogItems(const FString& ForPlayerWithUlid, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest);
+
+    /**
+      Get the current status of an async purchase.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
+      @param EntitlementId The entitlement id returned when initiating the async purchase
+      @param OnCompletedRequest Delegate for handling the server response
+      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString GetAsyncPurchaseStatus(const FString& ForPlayerWithUlid, const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegateBP& OnCompletedRequest);
+
+    /**
+      Retry a failed async purchase.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
+      @param EntitlementId The entitlement id of the failed purchase
+      @param WalletId The id of the wallet to use for the retry
+      @param Items The catalog items with quantities from the original purchase
+      @param OnCompletedRequest Delegate for handling the server response
+      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString RetryAsyncPurchase(const FString& ForPlayerWithUlid, const FString& EntitlementId, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest);
+
+    /**
+      Cancel an ongoing async purchase polling process started via the AsyncPollAsyncPurchase Blueprint node.
+
+      @param ProcessID The process id returned by StartAsyncPurchasePolling
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases")
+    static void CancelAsyncPurchasePolling(const FString& ProcessID);
 
     //==================================================
     // Triggers

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -2490,6 +2490,61 @@ public:
     static FString FinalizeSteamPurchaseRedemption(const FString & EntitlementId, const FLootLockerDefaultDelegate & OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
     /**
+     Initiate an async purchase of one or more catalog items using a specified wallet.
+
+     @param WalletId The id of the wallet to use for the purchase
+     @param Items The catalog items with quantities to purchase
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString InitiateAsyncPurchaseCatalogItems(const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Get the current status of an async purchase.
+
+     @param EntitlementId The entitlement id returned when initiating the async purchase
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString GetAsyncPurchaseStatus(const FString& EntitlementId, const FLootLockerAsyncPurchaseStatusDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Retry a failed async purchase.
+
+     @param EntitlementId The entitlement id of the failed purchase
+     @param WalletId The id of the wallet to use for the retry
+     @param Items The catalog items with quantities from the original purchase
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString RetryAsyncPurchase(const FString& EntitlementId, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Initiate an async purchase and automatically poll for its result.
+     While pending, OnStatusUpdate is called on each poll. When the purchase reaches a terminal state (active or failed, or timeout), OnComplete is called.
+
+     @param WalletId The id of the wallet to use for the purchase
+     @param Items The catalog items with quantities to purchase
+     @param OnStatusUpdate Delegate called on each poll while the purchase is pending
+     @param OnComplete Delegate called when the purchase reaches a terminal state
+     @param PollingIntervalSeconds How often to poll in seconds (minimum 1)
+     @param TimeoutAfterMinutes How many minutes before the process times out
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A process id string that can be passed to CancelAsyncPurchasePolling
+     */
+    static FString StartAsyncPurchasePolling(const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseStatusDelegate& OnStatusUpdate, const FLootLockerAsyncPurchaseStatusDelegate& OnComplete, float PollingIntervalSeconds = 1.0f, float TimeoutAfterMinutes = 5.0f, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Cancel an ongoing async purchase polling process.
+
+     @param ProcessID The process id returned by StartAsyncPurchasePolling
+     */
+    static void CancelAsyncPurchasePolling(const FString& ProcessID);
+
+    /**
      Refund one or more entitlements by their IDs.
 
      Submits a refund request for the specified entitlement IDs. Assets associated with the entitlements


### PR DESCRIPTION
## Summary

Implements async purchase support for [lootlocker/index#1369](https://github.com/lootlocker/index/issues/1369).

The server-side work is already complete. This PR adds SDK support for the async purchase flow: initiate a purchase, poll its status, and handle the final active/failed outcome — with full auto-polling using the same architecture as the Remote Session feature.

## Changes

### `LootLockerGameEndpoints.h` / `.cpp`
- Added 3 new endpoints:
  - `InitiateAsyncPurchase` — `POST purchase/inspired-ibex/v1`
  - `PollAsyncPurchaseStatus` — `GET purchase/inspired-ibex/v1/{0}`
  - `RetryAsyncPurchase` — `POST purchase/inspired-ibex/v1/{0}/retry`

### `LootLockerPurchasesRequestHandler.h` / `.cpp`
- Added `ELootLockerAsyncPurchaseStatus` enum (`Pending`, `Active`, `Failed`)
- Added `FLootLockerAsyncPurchaseInitiatedResponse` and `FLootLockerAsyncPurchaseStatusResponse` structs
- Added `FLootLockerAsyncPurchaseProcess` process struct with `FTimerHandle`-based polling state
- Added primitive methods: `InitiateAsyncPurchase`, `GetAsyncPurchaseStatus`, `RetryAsyncPurchase`
- Added polling methods: `StartAsyncPurchasePolling`, `CancelAsyncPurchasePolling`, `ContinualAsyncPurchasePollAction`, `KillAsyncPurchaseProcess`
- Added `ULootLockerAsyncPollAsyncPurchase : UBlueprintAsyncActionBase` Blueprint async action node with `OnPending` / `OnActive` / `OnFailed` / `OnTimedOut` / `OnCancelled` output pins
- Polling interval clamped to ≥ 1 s (enforcing the server-side rate limit of 1 req/s per player per entitlement)
- Automatic retry on 5xx responses (up to retry limit), timeout via `FDateTime::UtcNow()`

### `LootLockerManager.h` / `.cpp`
- Added `FLootLockerAsyncPurchaseInitiatedDelegateBP` and `FLootLockerAsyncPurchaseStatusDelegateBP` Blueprint delegates
- Added 5 `BlueprintCallable` facade methods: `InitiateAsyncPurchaseSingleCatalogItem`, `InitiateAsyncPurchaseCatalogItems`, `GetAsyncPurchaseStatus`, `RetryAsyncPurchase`, `CancelAsyncPurchasePolling`

### `LootLockerSDKManager.h` / `.cpp`
- Added 5 C++ static facade methods mirroring the Blueprint facade

## Testing

Verified locally with `verify-compilation.ps1` against UE 5.7 — all 3 targets (UnrealEditor, UnrealGame Development, UnrealGame Shipping) passed ✅

@johannesloot