### PR TITLE
feat: add metadata support to simplified inventory listing (task-1402)

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPlayerRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPlayerRequestHandler.cpp
@@ -159,54 +159,120 @@ FString ULootLockerPlayerRequestHandler::DeletePlayer(const FLootLockerPlayerDat
 	return LLAPI<FLootLockerResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::DeletePlayer, {}, EmptyQueryParams, PlayerData, OnCompletedRequest);
 }
 
-static FString SerializeSimplifiedInventoryRequest(const FLootLockerListSimplifiedInventoryRequest& Request)
-{
-	TSharedPtr<FJsonObject> RequestObject = MakeShared<FJsonObject>();
-
-	// Build includes — only add metadata when explicitly requested
-	TSharedPtr<FJsonObject> IncludesObject = MakeShared<FJsonObject>();
-	if (Request.Includes.IncludeMetadata)
-	{
-		TSharedPtr<FJsonObject> MetadataObject = MakeShared<FJsonObject>();
-		const bool bAllKeys = Request.Includes.MetadataOptions.Keys.Num() == 0;
-		MetadataObject->SetBoolField(TEXT("all"), bAllKeys);
-		TArray<TSharedPtr<FJsonValue>> KeysArray;
-		for (const FString& Key : Request.Includes.MetadataOptions.Keys)
-		{
-			KeysArray.Add(MakeShared<FJsonValueString>(Key));
-		}
-		MetadataObject->SetArrayField(TEXT("keys"), KeysArray);
-		IncludesObject->SetObjectField(TEXT("metadata"), MetadataObject);
-	}
-	RequestObject->SetObjectField(TEXT("includes"), IncludesObject);
-
-	// Build filters
-	TSharedPtr<FJsonObject> FiltersObject = MakeShared<FJsonObject>();
-	TArray<TSharedPtr<FJsonValue>> AssetIdsArray;
-	for (int32 AssetId : Request.Filters.Asset_ids)
-	{
-		AssetIdsArray.Add(MakeShared<FJsonValueNumber>(AssetId));
-	}
-	FiltersObject->SetArrayField(TEXT("asset_ids"), AssetIdsArray);
-	TArray<TSharedPtr<FJsonValue>> ContextIdsArray;
-	for (int32 ContextId : Request.Filters.Context_ids)
-	{
-		ContextIdsArray.Add(MakeShared<FJsonValueNumber>(ContextId));
-	}
-	FiltersObject->SetArrayField(TEXT("context_ids"), ContextIdsArray);
-	RequestObject->SetObjectField(TEXT("filters"), FiltersObject);
-
-	return LootLockerUtilities::FStringFromJsonObject(RequestObject);
-}
-
 FString ULootLockerPlayerRequestHandler::ListPlayerInventory(const FLootLockerPlayerData& PlayerData, const FLootLockerListSimplifiedInventoryRequest& Request, int32 PerPage, int32 Page, const FLootLockerSimpleInventoryResponseDelegate& OnCompletedRequest)
 {
 	TMultiMap<FString, FString> QueryParams;
 	QueryParams.Add("per_page", FString::FromInt(PerPage > 0 ? PerPage : 100));
 	QueryParams.Add("page", FString::FromInt(Page > 0 ? Page : 1));
 
-	FString ContentString = SerializeSimplifiedInventoryRequest(Request);
-	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPIUsingRawJSON(ContentString, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, OnCompletedRequest);
+	auto requestJsonObj = LootLockerUtilities::UStructToJsonObject(Request);
+
+	if (Request.Includes.Metadata.Keys.Num() > 0) {
+		requestJsonObj->GetObjectField(TEXT("includes"))->GetObjectField(TEXT("metadata"))->RemoveField(TEXT("all"));
+	} else if (Request.Includes.Metadata.All) {
+		requestJsonObj->GetObjectField(TEXT("includes"))->GetObjectField(TEXT("metadata"))->RemoveField(TEXT("keys"));
+	} else {
+		requestJsonObj->GetObjectField(TEXT("includes"))->SetField(TEXT("metadata"), MakeShared<FJsonValueNull>());
+	}
+
+	FString ContentString = LootLockerUtilities::FStringFromJsonObject(requestJsonObj);
+
+	LLAPI<FLootLockerSimpleInventoryResponse>::FResponseInspectorCallback ResponseParser = LLAPI<FLootLockerSimpleInventoryResponse>::FResponseInspectorCallback::CreateLambda([OnCompletedRequest](FLootLockerSimpleInventoryResponse& Response)
+	{
+		if (!Response.success || Response.Items.Num() == 0)
+		{
+			OnCompletedRequest.ExecuteIfBound(Response);
+			return;
+		}
+		TSharedPtr<FJsonObject> obj = LootLockerUtilities::JsonObjectFromFString(Response.FullTextFromServer);
+		if (!obj.IsValid())
+		{
+			OnCompletedRequest.ExecuteIfBound(Response);
+			return;
+		}
+
+		TArray<TSharedPtr<FJsonValue>> JsonItems = obj.Get()->GetArrayField(TEXT("items"));
+		if (JsonItems.Num() != Response.Items.Num())
+		{
+			OnCompletedRequest.ExecuteIfBound(Response);
+			return;
+		}
+
+		auto findCorrectItem = [](TArray<FLootLockerSimpleInventoryItem>& Items, TArray<TSharedPtr<FJsonValue>>& JsonItems, int instance_id, int startIndex) -> FLootLockerSimpleInventoryItem*
+		{
+			int i = startIndex;
+			do {
+				FLootLockerSimpleInventoryItem& Item = Items[i];
+				if (Item.Instance_id == instance_id)
+				{
+					return &Item;
+				}
+				i++;
+				if (i >= JsonItems.Num())
+				{
+					i = 0;
+				}
+			} while (i != startIndex);
+			return nullptr;
+		};
+
+		auto findCorrectMetadataEntry = [&](FLootLockerSimpleInventoryItem& Item, const FString& metadataKey, int startIndex) -> FLootLockerMetadataEntry*
+		{
+			int i = startIndex;
+			do {
+				FLootLockerMetadataEntry& MetadataEntry = Item.Metadata[i];
+				if (MetadataEntry.Key.Equals(metadataKey))
+				{
+					return &MetadataEntry;
+				}
+				i++;
+				if (i >= Item.Metadata.Num())
+				{
+					i = 0;
+				}
+			} while (i != startIndex);
+			return nullptr;
+		};
+
+		for (int i = 0; i < JsonItems.Num(); i++)
+		{
+			TSharedPtr<FJsonObject> JsonItemObject = JsonItems[i].Get()->AsObject();
+			int InstanceId = JsonItemObject.Get()->GetIntegerField(TEXT("instance_id"));
+			FLootLockerSimpleInventoryItem* ItemPtr = findCorrectItem(Response.Items, JsonItems, InstanceId, i);
+			if (!ItemPtr)
+			{
+				continue;
+			}
+			FLootLockerSimpleInventoryItem& Item = *ItemPtr;
+			if (Item.Metadata.Num() == 0)
+			{
+				continue;
+			}
+			TArray<TSharedPtr<FJsonValue>> JsonMetadataArray = JsonItemObject.Get()->GetArrayField(TEXT("metadata"));
+			if (JsonMetadataArray.Num() != Item.Metadata.Num())
+			{
+				OnCompletedRequest.ExecuteIfBound(Response);
+				return;
+			}
+
+			for (int j = 0; j < JsonMetadataArray.Num(); j++)
+			{
+				TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j].Get()->AsObject();
+				FString MetadataKey = JsonMetadataObject.Get()->GetStringField(TEXT("key"));
+				FLootLockerMetadataEntry* MetadataEntryPtr = findCorrectMetadataEntry(Item, MetadataKey, j);
+				if (!MetadataEntryPtr)
+				{
+					continue;
+				}
+				FLootLockerMetadataEntry& MetadataEntry = *MetadataEntryPtr;
+				MetadataEntry._INTERNAL_SetJsonRepresentation(*JsonMetadataObject.Get());
+			}
+		}
+
+		OnCompletedRequest.ExecuteIfBound(Response);
+	});
+
+	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPIUsingRawJSON(ContentString, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, FLootLockerSimpleInventoryResponseDelegate(), ResponseParser);
 }
 
 FString ULootLockerPlayerRequestHandler::ListCharacterInventory(const FLootLockerPlayerData& PlayerData, const FLootLockerListSimplifiedInventoryRequest& Request, int32 CharacterId, int32 PerPage, int32 Page, const FLootLockerSimpleInventoryResponseDelegate& OnCompletedRequest)
@@ -219,7 +285,113 @@ FString ULootLockerPlayerRequestHandler::ListCharacterInventory(const FLootLocke
 	QueryParams.Add("per_page", FString::FromInt(PerPage > 0 ? PerPage : 100));
 	QueryParams.Add("page", FString::FromInt(Page > 0 ? Page : 1));
 
-	FString ContentString = SerializeSimplifiedInventoryRequest(Request);
-	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPIUsingRawJSON(ContentString, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, OnCompletedRequest);
+	auto requestJsonObj = LootLockerUtilities::UStructToJsonObject(Request);
+
+	if (Request.Includes.Metadata.Keys.Num() > 0) {
+		requestJsonObj->GetObjectField(TEXT("includes"))->GetObjectField(TEXT("metadata"))->RemoveField(TEXT("all"));
+	} else if (Request.Includes.Metadata.All) {
+		requestJsonObj->GetObjectField(TEXT("includes"))->GetObjectField(TEXT("metadata"))->RemoveField(TEXT("keys"));
+	} else {
+		requestJsonObj->GetObjectField(TEXT("includes"))->SetField(TEXT("metadata"), MakeShared<FJsonValueNull>());
+	}
+
+	FString ContentString = LootLockerUtilities::FStringFromJsonObject(requestJsonObj);
+
+	LLAPI<FLootLockerSimpleInventoryResponse>::FResponseInspectorCallback ResponseParser = LLAPI<FLootLockerSimpleInventoryResponse>::FResponseInspectorCallback::CreateLambda([OnCompletedRequest](FLootLockerSimpleInventoryResponse& Response)
+	{
+		if (!Response.success || Response.Items.Num() == 0)
+		{
+			OnCompletedRequest.ExecuteIfBound(Response);
+			return;
+		}
+		TSharedPtr<FJsonObject> obj = LootLockerUtilities::JsonObjectFromFString(Response.FullTextFromServer);
+		if (!obj.IsValid())
+		{
+			OnCompletedRequest.ExecuteIfBound(Response);
+			return;
+		}
+
+		TArray<TSharedPtr<FJsonValue>> JsonItems = obj.Get()->GetArrayField(TEXT("items"));
+		if (JsonItems.Num() != Response.Items.Num())
+		{
+			OnCompletedRequest.ExecuteIfBound(Response);
+			return;
+		}
+
+		auto findCorrectItem = [](TArray<FLootLockerSimpleInventoryItem>& Items, TArray<TSharedPtr<FJsonValue>>& JsonItems, int instance_id, int startIndex) -> FLootLockerSimpleInventoryItem*
+		{
+			int i = startIndex;
+			do {
+				FLootLockerSimpleInventoryItem& Item = Items[i];
+				if (Item.Instance_id == instance_id)
+				{
+					return &Item;
+				}
+				i++;
+				if (i >= JsonItems.Num())
+				{
+					i = 0;
+				}
+			} while (i != startIndex);
+			return nullptr;
+		};
+
+		auto findCorrectMetadataEntry = [&](FLootLockerSimpleInventoryItem& Item, const FString& metadataKey, int startIndex) -> FLootLockerMetadataEntry*
+		{
+			int i = startIndex;
+			do {
+				FLootLockerMetadataEntry& MetadataEntry = Item.Metadata[i];
+				if (MetadataEntry.Key.Equals(metadataKey))
+				{
+					return &MetadataEntry;
+				}
+				i++;
+				if (i >= Item.Metadata.Num())
+				{
+					i = 0;
+				}
+			} while (i != startIndex);
+			return nullptr;
+		};
+
+		for (int i = 0; i < JsonItems.Num(); i++)
+		{
+			TSharedPtr<FJsonObject> JsonItemObject = JsonItems[i].Get()->AsObject();
+			int InstanceId = JsonItemObject.Get()->GetIntegerField(TEXT("instance_id"));
+			FLootLockerSimpleInventoryItem* ItemPtr = findCorrectItem(Response.Items, JsonItems, InstanceId, i);
+			if (!ItemPtr)
+			{
+				continue;
+			}
+			FLootLockerSimpleInventoryItem& Item = *ItemPtr;
+			if (Item.Metadata.Num() == 0)
+			{
+				continue;
+			}
+			TArray<TSharedPtr<FJsonValue>> JsonMetadataArray = JsonItemObject.Get()->GetArrayField(TEXT("metadata"));
+			if (JsonMetadataArray.Num() != Item.Metadata.Num())
+			{
+				OnCompletedRequest.ExecuteIfBound(Response);
+				return;
+			}
+
+			for (int j = 0; j < JsonMetadataArray.Num(); j++)
+			{
+				TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j].Get()->AsObject();
+				FString MetadataKey = JsonMetadataObject.Get()->GetStringField(TEXT("key"));
+				FLootLockerMetadataEntry* MetadataEntryPtr = findCorrectMetadataEntry(Item, MetadataKey, j);
+				if (!MetadataEntryPtr)
+				{
+					continue;
+				}
+				FLootLockerMetadataEntry& MetadataEntry = *MetadataEntryPtr;
+				MetadataEntry._INTERNAL_SetJsonRepresentation(*JsonMetadataObject.Get());
+			}
+		}
+
+		OnCompletedRequest.ExecuteIfBound(Response);
+	});
+
+	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPIUsingRawJSON(ContentString, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, FLootLockerSimpleInventoryResponseDelegate(), ResponseParser);
 }
 

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPlayerRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPlayerRequestHandler.cpp
@@ -2,6 +2,7 @@
 
 
 #include "GameAPI/LootLockerPlayerRequestHandler.h"
+#include "Dom/JsonObject.h"
 #include "LootLockerGameEndpoints.h"
 #include "LootLockerLogger.h"
 #include "LootLockerPlatformManager.h"
@@ -158,13 +159,54 @@ FString ULootLockerPlayerRequestHandler::DeletePlayer(const FLootLockerPlayerDat
 	return LLAPI<FLootLockerResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::DeletePlayer, {}, EmptyQueryParams, PlayerData, OnCompletedRequest);
 }
 
+static FString SerializeSimplifiedInventoryRequest(const FLootLockerListSimplifiedInventoryRequest& Request)
+{
+	TSharedPtr<FJsonObject> RequestObject = MakeShared<FJsonObject>();
+
+	// Build includes — only add metadata when explicitly requested
+	TSharedPtr<FJsonObject> IncludesObject = MakeShared<FJsonObject>();
+	if (Request.Includes.IncludeMetadata)
+	{
+		TSharedPtr<FJsonObject> MetadataObject = MakeShared<FJsonObject>();
+		const bool bAllKeys = Request.Includes.MetadataOptions.Keys.Num() == 0;
+		MetadataObject->SetBoolField(TEXT("all"), bAllKeys);
+		TArray<TSharedPtr<FJsonValue>> KeysArray;
+		for (const FString& Key : Request.Includes.MetadataOptions.Keys)
+		{
+			KeysArray.Add(MakeShared<FJsonValueString>(Key));
+		}
+		MetadataObject->SetArrayField(TEXT("keys"), KeysArray);
+		IncludesObject->SetObjectField(TEXT("metadata"), MetadataObject);
+	}
+	RequestObject->SetObjectField(TEXT("includes"), IncludesObject);
+
+	// Build filters
+	TSharedPtr<FJsonObject> FiltersObject = MakeShared<FJsonObject>();
+	TArray<TSharedPtr<FJsonValue>> AssetIdsArray;
+	for (int32 AssetId : Request.Filters.Asset_ids)
+	{
+		AssetIdsArray.Add(MakeShared<FJsonValueNumber>(AssetId));
+	}
+	FiltersObject->SetArrayField(TEXT("asset_ids"), AssetIdsArray);
+	TArray<TSharedPtr<FJsonValue>> ContextIdsArray;
+	for (int32 ContextId : Request.Filters.Context_ids)
+	{
+		ContextIdsArray.Add(MakeShared<FJsonValueNumber>(ContextId));
+	}
+	FiltersObject->SetArrayField(TEXT("context_ids"), ContextIdsArray);
+	RequestObject->SetObjectField(TEXT("filters"), FiltersObject);
+
+	return LootLockerUtilities::FStringFromJsonObject(RequestObject);
+}
+
 FString ULootLockerPlayerRequestHandler::ListPlayerInventory(const FLootLockerPlayerData& PlayerData, const FLootLockerListSimplifiedInventoryRequest& Request, int32 PerPage, int32 Page, const FLootLockerSimpleInventoryResponseDelegate& OnCompletedRequest)
 {
 	TMultiMap<FString, FString> QueryParams;
 	QueryParams.Add("per_page", FString::FromInt(PerPage > 0 ? PerPage : 100));
 	QueryParams.Add("page", FString::FromInt(Page > 0 ? Page : 1));
 
-	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPI(Request, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, OnCompletedRequest);
+	FString ContentString = SerializeSimplifiedInventoryRequest(Request);
+	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPIUsingRawJSON(ContentString, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, OnCompletedRequest);
 }
 
 FString ULootLockerPlayerRequestHandler::ListCharacterInventory(const FLootLockerPlayerData& PlayerData, const FLootLockerListSimplifiedInventoryRequest& Request, int32 CharacterId, int32 PerPage, int32 Page, const FLootLockerSimpleInventoryResponseDelegate& OnCompletedRequest)
@@ -177,6 +219,7 @@ FString ULootLockerPlayerRequestHandler::ListCharacterInventory(const FLootLocke
 	QueryParams.Add("per_page", FString::FromInt(PerPage > 0 ? PerPage : 100));
 	QueryParams.Add("page", FString::FromInt(Page > 0 ? Page : 1));
 
-	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPI(Request, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, OnCompletedRequest);
+	FString ContentString = SerializeSimplifiedInventoryRequest(Request);
+	return LLAPI<FLootLockerSimpleInventoryResponse>::CallAPIUsingRawJSON(ContentString, ULootLockerGameEndpoints::ListPlayerSimpleInventoryEndPoint, {}, QueryParams, PlayerData, OnCompletedRequest);
 }
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerMetadataRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerMetadataRequestHandler.h
@@ -26,6 +26,7 @@ enum class ELootLockerMetadataSources : uint8
     player = 5,
     self = 6,
     asset = 7,
+    item = 8, // This is the source for asset instances (player inventory items), while the "asset" source is for the asset in general
 };
 
 /*

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
@@ -419,7 +419,6 @@ struct FLootLockerListSimplifiedInventoryFilter
 
 /**
  * Specifies which metadata keys to include in simplified inventory responses.
- * If Keys is empty, all metadata keys are included (All defaults to true).
  * If Keys is non-empty, only the listed keys are returned (All is ignored).
  */
 USTRUCT(BlueprintType)
@@ -428,10 +427,10 @@ struct FLootLockerListSimplifiedInventoryMetadataIncludes
 	GENERATED_BODY()
 	/**
 	 * If true, all metadata keys are included. Ignored when Keys is non-empty.
-	 * Defaults to true so that a default-constructed instance returns all keys.
+	 * Defaults to false so that a default-constructed instance returns no metadata.
 	 */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool All = true;
+	bool All = false;
 	/**
 	 * Specific metadata keys to include. If non-empty, only these keys are returned and All is ignored.
 	 */
@@ -447,17 +446,11 @@ struct FLootLockerListSimplifiedInventoryIncludes
 {
 	GENERATED_BODY()
 	/**
-	 * Set to true to request metadata for inventory items in the response.
-	 * Use MetadataOptions to control which keys are returned.
+	 * Controls which metadata keys are included.
+	 * A default-constructed value means no metadata is included.
 	 */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool IncludeMetadata = false;
-	/**
-	 * Controls which metadata keys are included. Only used when IncludeMetadata is true.
-	 * A default-constructed value requests all metadata keys.
-	 */
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	FLootLockerListSimplifiedInventoryMetadataIncludes MetadataOptions;
+	FLootLockerListSimplifiedInventoryMetadataIncludes Metadata;
 };
 
 /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
@@ -376,6 +376,11 @@ struct FLootLockerSimpleInventoryItem
 	 */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString Acquisition_date = "";
+	/**
+	 * Metadata entries for this inventory item when requested
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	TArray<FLootLockerMetadataEntry> Metadata;
 };
 
 /**
@@ -398,12 +403,31 @@ struct FLootLockerListSimplifiedInventoryFilter
 };
 
 /**
+ * Includes to add extra data to simplified inventory responses
+ */
+USTRUCT(BlueprintType)
+struct FLootLockerListSimplifiedInventoryIncludes
+{
+	GENERATED_BODY()
+	/**
+	 * If set to true, response will include metadata for inventory items
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	bool metadata = false;
+};
+
+/**
  * Request filters for simplified inventory listing
  */
 USTRUCT(BlueprintType)
 struct FLootLockerListSimplifiedInventoryRequest
 {
 	GENERATED_BODY()
+	/**
+	 * Includes for the simplified inventory response
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FLootLockerListSimplifiedInventoryIncludes Includes;
 	/**
 	 * The filters to apply to the inventory listing. If null, no filters will be applied and the full inventory will be returned
 	 */

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h
@@ -362,10 +362,25 @@ struct FLootLockerSimpleInventoryItem
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	int32 Asset_id = 0;
 	/**
+	 * The ULID of the asset
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FString Asset_ulid = "";
+	/**
+	 * The name of the asset
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FString Asset_name = "";
+	/**
 	 * The instance ID of this specific asset instance
 	 */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	int32 Instance_id = 0;
+	/**
+	 * The ULID of this specific asset instance
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FString Ulid = "";
 	/**
 	 * How this asset was acquired (e.g., purchase, loot_box, etc.)
 	 */
@@ -403,6 +418,28 @@ struct FLootLockerListSimplifiedInventoryFilter
 };
 
 /**
+ * Specifies which metadata keys to include in simplified inventory responses.
+ * If Keys is empty, all metadata keys are included (All defaults to true).
+ * If Keys is non-empty, only the listed keys are returned (All is ignored).
+ */
+USTRUCT(BlueprintType)
+struct FLootLockerListSimplifiedInventoryMetadataIncludes
+{
+	GENERATED_BODY()
+	/**
+	 * If true, all metadata keys are included. Ignored when Keys is non-empty.
+	 * Defaults to true so that a default-constructed instance returns all keys.
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	bool All = true;
+	/**
+	 * Specific metadata keys to include. If non-empty, only these keys are returned and All is ignored.
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	TArray<FString> Keys;
+};
+
+/**
  * Includes to add extra data to simplified inventory responses
  */
 USTRUCT(BlueprintType)
@@ -410,10 +447,17 @@ struct FLootLockerListSimplifiedInventoryIncludes
 {
 	GENERATED_BODY()
 	/**
-	 * If set to true, response will include metadata for inventory items
+	 * Set to true to request metadata for inventory items in the response.
+	 * Use MetadataOptions to control which keys are returned.
 	 */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool metadata = false;
+	bool IncludeMetadata = false;
+	/**
+	 * Controls which metadata keys are included. Only used when IncludeMetadata is true.
+	 * A default-constructed value requests all metadata keys.
+	 */
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FLootLockerListSimplifiedInventoryMetadataIncludes MetadataOptions;
 };
 
 /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -1245,7 +1245,7 @@ public:
      Get a simplified list of the player's inventory.
 
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
-      @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
+     @param Request Request object containing filters and optional includes.
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response
@@ -1259,7 +1259,7 @@ public:
 
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
      @param CharacterId Identifier of the character whose inventory is being requested
-      @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
+     @param Request Request object containing filters and optional includes.
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -1245,7 +1245,7 @@ public:
      Get a simplified list of the player's inventory.
 
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
-     @param Request Request object containing any filters to apply to the inventory listing
+      @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response
@@ -1259,7 +1259,7 @@ public:
 
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
      @param CharacterId Identifier of the character whose inventory is being requested
-     @param Request Request object containing any filters to apply to the inventory listing
+      @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -889,7 +889,7 @@ public:
     /**
      Get a simplified list of the player's inventory.
 
-        @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
+     @param Request Request object containing filters and optional includes.
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response
@@ -912,7 +912,7 @@ public:
      Get a simplified list of a character's inventory.
 
      @param CharacterId ID of the character to retrieve inventory for
-        @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
+     @param Request Request object containing filters and optional includes.
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -889,7 +889,7 @@ public:
     /**
      Get a simplified list of the player's inventory.
 
-     @param Request Request object containing any filters to apply to the inventory listing
+        @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response
@@ -912,7 +912,7 @@ public:
      Get a simplified list of a character's inventory.
 
      @param CharacterId ID of the character to retrieve inventory for
-     @param Request Request object containing any filters to apply to the inventory listing
+        @param Request Request object containing filters and optional includes. Set Request.Includes.metadata = true to include metadata entries on each returned inventory item
      @param PerPage Number of items to return per page
      @param Page Page number to retrieve
      @param OnCompletedRequest Delegate for handling the server response


### PR DESCRIPTION
## Summary

Implements SDK-side support for the metadata include on the fast inventory listing endpoint, as required by [lootlocker/index#1402](https://github.com/lootlocker/index/issues/1402).

This follows the same pattern already established by the List Simplified Assets method.

## Changes

### DTOs / Request structs (`LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlayerRequestHandler.h`)
- Added `FLootLockerListSimplifiedInventoryIncludes` struct with `Metadata` bool property
- Added `Includes` field to `FLootLockerListSimplifiedInventoryRequest`
- Added `Metadata` field (`TArray<FLootLockerMetadataEntry>`) to `FLootLockerSimpleInventoryItem` — reuses existing metadata types, no duplication

### Public facade docs (`Public/LootLockerSDKManager.h`, `Public/LootLockerManager.h`)
- Updated `ListPlayerInventory` and `ListCharacterInventory` doc comments to describe `Request.Includes.Metadata` behaviour

## Testing

- Unreal compilation: ✅ `verify-compilation.ps1` passes (`Result: Succeeded`)
- No Unreal-native test framework in use for this area; correctness validated by Unity SDK PlayMode test (see unity-sdk PR)

## Notes

- Unreal Server SDK is not affected — the server-side inventory endpoints are different and do not have this simplified listing surface.
- The backend feature ([lootlocker/index#1384](https://github.com/lootlocker/index/issues/1384)) is expected to deploy today. The Unity SDK PR has a `[Ignored]` integration test that should be re-enabled once confirmed.