### PR TITLE
feat: add LL-Request-Id and LL-Retry-Attempt headers to all HTTP requests (task-1156)

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -43,7 +43,7 @@ bool ULootLockerHttpClient::ResponseIsSuccess(const FHttpResponsePtr& InResponse
     return EHttpResponseCodes::IsOk(InResponse->GetResponseCode());
 }
 
-FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, bool bIsRetryAttempt)
+FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, bool bIsRetryAttempt, const FString& RequestIdOverride)
 {
 	FHttpModule* HttpModule = &FHttpModule::Get();
     if(SDKVersion.IsEmpty())
@@ -57,6 +57,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     }
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = HttpModule->CreateRequest();
 	Request->SetURL(endPoint);
+    const FString requestId = RequestIdOverride.IsEmpty() ? FGuid::NewGuid().ToString() : RequestIdOverride;
     if (!PlayerData.Token.IsEmpty())
     {
         Request->SetHeader(TEXT("x-session-token"), PlayerData.Token);
@@ -66,6 +67,11 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     Request->SetHeader(TEXT("LL-SDK-Version"), SDKVersion);
     Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
     Request->SetHeader(TEXT("Accept"), TEXT("application/json"));
+    Request->SetHeader(TEXT("LL-Request-Id"), requestId);
+    if (bIsRetryAttempt)
+    {
+        Request->SetHeader(TEXT("LL-Retry-Attempt"), TEXT("1"));
+    }
 
     for (TTuple<FString, FString> CustomHeader : customHeaders)
     {
@@ -83,8 +89,6 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     {
         DelimitedHeaders += TEXT("    ") + Header + TEXT("\n");
     }
-
-    FString requestId = FGuid::NewGuid().ToString();
 
 	Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, endPoint, requestType, data, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, bIsRetryAttempt](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
 	{
@@ -128,7 +132,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
                     *requestType, *endPoint, response.StatusCode));
                 
                 // Store original request data for retry
-                FLootLockerRetryRequestData RetryData(endPoint, requestType, data, onCompleteRequest, PlayerData, customHeaders);
+                FLootLockerRetryRequestData RetryData(endPoint, requestType, requestId, data, onCompleteRequest, PlayerData, customHeaders);
                 
                 // Attempt session refresh
                 RefreshSessionForPlatform(PlayerData, [RetryData, response, onCompleteRequest](bool bRefreshSuccess) {
@@ -155,7 +159,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     return requestId;
 }
 
-FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, bool bIsRetryAttempt)
+FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, bool bIsRetryAttempt, const FString& RequestIdOverride)
 {
     FHttpModule* HttpModule = &FHttpModule::Get();
     if (SDKVersion.IsEmpty())
@@ -168,6 +172,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     }
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = HttpModule->CreateRequest();
 	Request->SetURL(endPoint);
+    const FString requestId = RequestIdOverride.IsEmpty() ? FGuid::NewGuid().ToString() : RequestIdOverride;
 
     FString Boundary = "lootlockerboundary";
 
@@ -178,6 +183,11 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
 	Request->SetHeader(TEXT("User-Agent"), UserAgent);
 	Request->SetHeader(TEXT("LL-Instance-Identifier"), UserInstanceIdentifier);
     Request->SetHeader(TEXT("LL-SDK-Version"), SDKVersion);
+    Request->SetHeader(TEXT("LL-Request-Id"), requestId);
+    if (bIsRetryAttempt)
+    {
+        Request->SetHeader(TEXT("LL-Retry-Attempt"), TEXT("1"));
+    }
 
     Request->SetHeader(TEXT("Content-Type"), TEXT("multipart/form-data; boundary=" + Boundary));
 
@@ -242,8 +252,6 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     Request->SetContent(Data);
 
     FString playerUlid = PlayerData.PlayerUlid;
-    FString requestId = FGuid::NewGuid().ToString();
-
     Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, requestType, endPoint, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, FilePath, AdditionalFields, bIsRetryAttempt](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
         {
             if (!Response.IsValid())
@@ -280,7 +288,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
                         *requestType, *endPoint, response.StatusCode));
                     
                     // Store original request data for retry
-                    FLootLockerRetryRequestData RetryData(endPoint, requestType, FilePath, AdditionalFields, onCompleteRequest, PlayerData, customHeaders);
+                    FLootLockerRetryRequestData RetryData(endPoint, requestType, requestId, FilePath, AdditionalFields, onCompleteRequest, PlayerData, customHeaders);
                     
                     // Attempt session refresh
                     RefreshSessionForPlatform(PlayerData, [RetryData, response, onCompleteRequest](bool bRefreshSuccess) {
@@ -502,11 +510,11 @@ void ULootLockerHttpClient::RetryOriginalRequest(const FLootLockerRetryRequestDa
     if (RetryData.bIsFileUpload)
     {
         UploadFile(RetryData.EndPoint, RetryData.RequestType, RetryData.FilePath, RetryData.AdditionalFields, 
-                  RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, true);
+                  RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, true, RetryData.OriginalRequestId);
     }
     else
     {
         SendApi(RetryData.EndPoint, RetryData.RequestType, RetryData.Data, 
-               RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, true);
+               RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, true, RetryData.OriginalRequestId);
     }
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -43,7 +43,7 @@ bool ULootLockerHttpClient::ResponseIsSuccess(const FHttpResponsePtr& InResponse
     return EHttpResponseCodes::IsOk(InResponse->GetResponseCode());
 }
 
-FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, bool bIsRetryAttempt, const FString& RequestIdOverride)
+FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, int32 RetryAttemptCount, const FString& RequestIdOverride)
 {
 	FHttpModule* HttpModule = &FHttpModule::Get();
     if(SDKVersion.IsEmpty())
@@ -68,9 +68,9 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
     Request->SetHeader(TEXT("Accept"), TEXT("application/json"));
     Request->SetHeader(TEXT("LL-Request-Id"), requestId);
-    if (bIsRetryAttempt)
+    if (RetryAttemptCount > 0)
     {
-        Request->SetHeader(TEXT("LL-Retry-Attempt"), TEXT("1"));
+        Request->SetHeader(TEXT("LL-Retry-Attempt"), FString::FromInt(RetryAttemptCount));
     }
 
     for (TTuple<FString, FString> CustomHeader : customHeaders)
@@ -90,7 +90,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
         DelimitedHeaders += TEXT("    ") + Header + TEXT("\n");
     }
 
-	Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, endPoint, requestType, data, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, bIsRetryAttempt](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
+	Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, endPoint, requestType, data, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, RetryAttemptCount](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
 	{
         if (!Response.IsValid())
         {
@@ -126,13 +126,13 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
             LogFailedRequestInformation(response, DelimitedHeaders);
             
             // Check if we should attempt session refresh
-            if (ShouldRefreshSession(response.StatusCode, PlayerData, bIsRetryAttempt))
+            if (ShouldRefreshSession(response.StatusCode, PlayerData, RetryAttemptCount))
             {
                 FLootLockerLogger::LogVeryVerbose(FString::Printf(TEXT("Attempting session refresh for %s request to %s (Status: %d)"), 
                     *requestType, *endPoint, response.StatusCode));
                 
                 // Store original request data for retry
-                FLootLockerRetryRequestData RetryData(endPoint, requestType, requestId, data, onCompleteRequest, PlayerData, customHeaders);
+                FLootLockerRetryRequestData RetryData(endPoint, requestType, requestId, data, onCompleteRequest, PlayerData, customHeaders, RetryAttemptCount + 1);
                 
                 // Attempt session refresh
                 RefreshSessionForPlatform(PlayerData, [RetryData, response, onCompleteRequest](bool bRefreshSuccess) {
@@ -159,7 +159,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     return requestId;
 }
 
-FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, bool bIsRetryAttempt, const FString& RequestIdOverride)
+FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders, int32 RetryAttemptCount, const FString& RequestIdOverride)
 {
     FHttpModule* HttpModule = &FHttpModule::Get();
     if (SDKVersion.IsEmpty())
@@ -184,9 +184,9 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
 	Request->SetHeader(TEXT("LL-Instance-Identifier"), UserInstanceIdentifier);
     Request->SetHeader(TEXT("LL-SDK-Version"), SDKVersion);
     Request->SetHeader(TEXT("LL-Request-Id"), requestId);
-    if (bIsRetryAttempt)
+    if (RetryAttemptCount > 0)
     {
-        Request->SetHeader(TEXT("LL-Retry-Attempt"), TEXT("1"));
+        Request->SetHeader(TEXT("LL-Retry-Attempt"), FString::FromInt(RetryAttemptCount));
     }
 
     Request->SetHeader(TEXT("Content-Type"), TEXT("multipart/form-data; boundary=" + Boundary));
@@ -252,7 +252,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     Request->SetContent(Data);
 
     FString playerUlid = PlayerData.PlayerUlid;
-    Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, requestType, endPoint, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, FilePath, AdditionalFields, bIsRetryAttempt](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
+    Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, requestType, endPoint, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, FilePath, AdditionalFields, RetryAttemptCount](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
         {
             if (!Response.IsValid())
             {
@@ -282,13 +282,13 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
                 LogFailedRequestInformation(response, DelimitedHeaders);
                 
                 // Check if we should attempt session refresh
-                if (ShouldRefreshSession(response.StatusCode, PlayerData, bIsRetryAttempt))
+                if (ShouldRefreshSession(response.StatusCode, PlayerData, RetryAttemptCount))
                 {
                     FLootLockerLogger::LogVeryVerbose(FString::Printf(TEXT("Attempting session refresh for %s file upload to %s (Status: %d)"), 
                         *requestType, *endPoint, response.StatusCode));
                     
                     // Store original request data for retry
-                    FLootLockerRetryRequestData RetryData(endPoint, requestType, requestId, FilePath, AdditionalFields, onCompleteRequest, PlayerData, customHeaders);
+                    FLootLockerRetryRequestData RetryData(endPoint, requestType, requestId, FilePath, AdditionalFields, onCompleteRequest, PlayerData, customHeaders, RetryAttemptCount + 1);
                     
                     // Attempt session refresh
                     RefreshSessionForPlatform(PlayerData, [RetryData, response, onCompleteRequest](bool bRefreshSuccess) {
@@ -315,10 +315,10 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     return requestId;
 }
 
-bool ULootLockerHttpClient::ShouldRefreshSession(int32 StatusCode, const FLootLockerPlayerData& PlayerData, bool bIsRetryAttempt)
+bool ULootLockerHttpClient::ShouldRefreshSession(int32 StatusCode, const FLootLockerPlayerData& PlayerData, int32 RetryAttemptCount)
 {
     // Don't attempt refresh if this is already a retry attempt
-    if (bIsRetryAttempt)
+    if (RetryAttemptCount > 0)
     {
         FLootLockerLogger::LogVerbose(TEXT("Skipping session refresh - this is already a retry attempt"));
         return false;
@@ -510,11 +510,11 @@ void ULootLockerHttpClient::RetryOriginalRequest(const FLootLockerRetryRequestDa
     if (RetryData.bIsFileUpload)
     {
         UploadFile(RetryData.EndPoint, RetryData.RequestType, RetryData.FilePath, RetryData.AdditionalFields, 
-                  RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, true, RetryData.OriginalRequestId);
+                  RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, RetryData.RetryAttemptCount, RetryData.OriginalRequestId);
     }
     else
     {
         SendApi(RetryData.EndPoint, RetryData.RequestType, RetryData.Data, 
-               RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, true, RetryData.OriginalRequestId);
+               RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, RetryData.RetryAttemptCount, RetryData.OriginalRequestId);
     }
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
@@ -16,8 +16,8 @@ class LOOTLOCKERSDK_API ULootLockerHttpClient : public UObject
      
 public:
     ULootLockerHttpClient();
-    static FString SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), bool bIsRetryAttempt = false, const FString& RequestIdOverride = TEXT(""));
-    static FString UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), bool bIsRetryAttempt = false, const FString& RequestIdOverride = TEXT(""));
+    static FString SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), int32 RetryAttemptCount = 0, const FString& RequestIdOverride = TEXT(""));
+    static FString UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), int32 RetryAttemptCount = 0, const FString& RequestIdOverride = TEXT(""));
 
     static void LogSuccessfulRequestInformation(const FLootLockerResponse& Response, const FString& AllHeadersDelimited);
     static void LogFailedRequestInformation(const FLootLockerResponse& Response, const FString& AllHeadersDelimited);
@@ -25,7 +25,7 @@ private:
     static bool ResponseIsSuccess(const FHttpResponsePtr& InResponse, bool bWasSuccessful);
     
     // Token refresh functionality
-    static bool ShouldRefreshSession(int32 StatusCode, const FLootLockerPlayerData& PlayerData, bool bIsRetryAttempt = false);
+    static bool ShouldRefreshSession(int32 StatusCode, const FLootLockerPlayerData& PlayerData, int32 RetryAttemptCount = 0);
     static bool CanRefreshSession(const FLootLockerPlayerData& PlayerData);
     static void RefreshSessionForPlatform(const FLootLockerPlayerData& PlayerData, TFunction<void(bool)> OnRefreshCompleted);
     
@@ -40,7 +40,7 @@ private:
         FLootLockerPlayerData PlayerData;
         TMap<FString, FString> CustomHeaders;
         bool bIsFileUpload = false;
-        bool bIsRetryAttempt = false;
+        int32 RetryAttemptCount = 0;
         FString FilePath;
         TMap<FString, FString> AdditionalFields;
         
@@ -49,16 +49,16 @@ private:
         // Constructor for regular API calls
         FLootLockerRetryRequestData(const FString& InEndPoint, const FString& InRequestType, const FString& InOriginalRequestId, const FString& InData, 
                                    const FResponseCallback& InOnCompleteRequest, const FLootLockerPlayerData& InPlayerData, 
-                                   const TMap<FString, FString>& InCustomHeaders, bool InIsRetryAttempt = false)
+                                   const TMap<FString, FString>& InCustomHeaders, int32 InRetryAttemptCount = 0)
             : EndPoint(InEndPoint), RequestType(InRequestType), OriginalRequestId(InOriginalRequestId), Data(InData), OnCompleteRequest(InOnCompleteRequest)
-            , PlayerData(InPlayerData), CustomHeaders(InCustomHeaders), bIsFileUpload(false), bIsRetryAttempt(InIsRetryAttempt) {}
+            , PlayerData(InPlayerData), CustomHeaders(InCustomHeaders), bIsFileUpload(false), RetryAttemptCount(InRetryAttemptCount) {}
         
         // Constructor for file upload calls
         FLootLockerRetryRequestData(const FString& InEndPoint, const FString& InRequestType, const FString& InOriginalRequestId, const FString& InFilePath,
                                    const TMap<FString, FString>& InAdditionalFields, const FResponseCallback& InOnCompleteRequest, 
-                                   const FLootLockerPlayerData& InPlayerData, const TMap<FString, FString>& InCustomHeaders, bool InIsRetryAttempt = false)
+                                   const FLootLockerPlayerData& InPlayerData, const TMap<FString, FString>& InCustomHeaders, int32 InRetryAttemptCount = 0)
             : EndPoint(InEndPoint), RequestType(InRequestType), OriginalRequestId(InOriginalRequestId), OnCompleteRequest(InOnCompleteRequest)
-            , PlayerData(InPlayerData), CustomHeaders(InCustomHeaders), bIsFileUpload(true), bIsRetryAttempt(InIsRetryAttempt)
+            , PlayerData(InPlayerData), CustomHeaders(InCustomHeaders), bIsFileUpload(true), RetryAttemptCount(InRetryAttemptCount)
             , FilePath(InFilePath), AdditionalFields(InAdditionalFields) {}
     };
     

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
@@ -16,8 +16,8 @@ class LOOTLOCKERSDK_API ULootLockerHttpClient : public UObject
      
 public:
     ULootLockerHttpClient();
-    static FString SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), bool bIsRetryAttempt = false);
-    static FString UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), bool bIsRetryAttempt = false);
+    static FString SendApi(const FString& endPoint, const FString& requestType, const FString& data, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), bool bIsRetryAttempt = false, const FString& RequestIdOverride = TEXT(""));
+    static FString UploadFile(const FString& endPoint, const FString& requestType, const FString& FilePath, const TMap<FString, FString>& AdditionalFields, const FResponseCallback& onCompleteRequest, const FLootLockerPlayerData& PlayerData, TMap<FString, FString> customHeaders = TMap<FString, FString>(), bool bIsRetryAttempt = false, const FString& RequestIdOverride = TEXT(""));
 
     static void LogSuccessfulRequestInformation(const FLootLockerResponse& Response, const FString& AllHeadersDelimited);
     static void LogFailedRequestInformation(const FLootLockerResponse& Response, const FString& AllHeadersDelimited);
@@ -34,6 +34,7 @@ private:
     {
         FString EndPoint;
         FString RequestType;
+        FString OriginalRequestId;
         FString Data;
         FResponseCallback OnCompleteRequest;
         FLootLockerPlayerData PlayerData;
@@ -46,17 +47,17 @@ private:
         FLootLockerRetryRequestData() = default;
         
         // Constructor for regular API calls
-        FLootLockerRetryRequestData(const FString& InEndPoint, const FString& InRequestType, const FString& InData, 
+        FLootLockerRetryRequestData(const FString& InEndPoint, const FString& InRequestType, const FString& InOriginalRequestId, const FString& InData, 
                                    const FResponseCallback& InOnCompleteRequest, const FLootLockerPlayerData& InPlayerData, 
                                    const TMap<FString, FString>& InCustomHeaders, bool InIsRetryAttempt = false)
-            : EndPoint(InEndPoint), RequestType(InRequestType), Data(InData), OnCompleteRequest(InOnCompleteRequest)
+            : EndPoint(InEndPoint), RequestType(InRequestType), OriginalRequestId(InOriginalRequestId), Data(InData), OnCompleteRequest(InOnCompleteRequest)
             , PlayerData(InPlayerData), CustomHeaders(InCustomHeaders), bIsFileUpload(false), bIsRetryAttempt(InIsRetryAttempt) {}
         
         // Constructor for file upload calls
-        FLootLockerRetryRequestData(const FString& InEndPoint, const FString& InRequestType, const FString& InFilePath,
+        FLootLockerRetryRequestData(const FString& InEndPoint, const FString& InRequestType, const FString& InOriginalRequestId, const FString& InFilePath,
                                    const TMap<FString, FString>& InAdditionalFields, const FResponseCallback& InOnCompleteRequest, 
                                    const FLootLockerPlayerData& InPlayerData, const TMap<FString, FString>& InCustomHeaders, bool InIsRetryAttempt = false)
-            : EndPoint(InEndPoint), RequestType(InRequestType), OnCompleteRequest(InOnCompleteRequest)
+            : EndPoint(InEndPoint), RequestType(InRequestType), OriginalRequestId(InOriginalRequestId), OnCompleteRequest(InOnCompleteRequest)
             , PlayerData(InPlayerData), CustomHeaders(InCustomHeaders), bIsFileUpload(true), bIsRetryAttempt(InIsRetryAttempt)
             , FilePath(InFilePath), AdditionalFields(InAdditionalFields) {}
     };


### PR DESCRIPTION
## Summary

Adds two new outgoing request headers to improve backend observability (tracking issue: lootlocker/index#1156):

- **`LL-Request-Id`** — set on every request. Generated per-call via `FGuid::NewGuid()`, then threaded through retry flows so retries reuse the **same** ID as the original request.
- **`LL-Retry-Attempt`** — set to `"1"` when `bIsRetryAttempt = true`.

## Changes

- `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp`
  - `SendApi()`: generate `requestId` before setting headers; set `LL-Request-Id` and conditionally `LL-Retry-Attempt`; pass `requestId` into `FLootLockerRetryRequestData`.
  - `UploadFile()`: same treatment.
  - `RetryOriginalRequest()`: pass `RetryData.OriginalRequestId` as override to `SendApi`/`UploadFile`.
- `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h`
  - `SendApi` / `UploadFile` signatures: add `const FString& RequestIdOverride = TEXT("")` defaulted parameter.
  - `FLootLockerRetryRequestData`: add `FString OriginalRequestId` field and update both constructors.

## Testing

Locally compiled successfully. CI Compile Check covers correctness.

Closes lootlocker/index#1156 (partial — Unity and Unreal Server SDK in separate PRs)