### PR TITLE
feat: add Stripe Checkout session endpoint (task-1370)

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
@@ -100,9 +100,9 @@ FString ULootLockerPurchasesRequestHandler::RefundByEntitlementIds(const FLootLo
     return LLAPI<FLootLockerRefundByEntitlementIdsResponse>::CallAPI(FLootLockerRefundByEntitlementIdsRequest{ EntitlementIds }, ULootLockerGameEndpoints::RefundByEntitlementIds, {}, {}, PlayerData, OnCompleted);
 }
 
-FString ULootLockerPurchasesRequestHandler::CreateStripeCheckoutSession(const FLootLockerPlayerData& PlayerData, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompleted)
+FString ULootLockerPurchasesRequestHandler::CreateStripeCheckoutSession(const FLootLockerPlayerData& PlayerData, const FString& CatalogItemId, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompleted)
 {
-    const FLootLockerCreateStripeCheckoutSessionRequest Request{ CatalogItemId, ItemName };
+    const FLootLockerCreateStripeCheckoutSessionRequest Request{ CatalogItemId };
     return LLAPI<FLootLockerCreateStripeCheckoutSessionResponse>::CallAPI(Request, ULootLockerGameEndpoints::CreateStripeCheckoutSession, {}, {}, PlayerData, OnCompleted);
 }
 

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
@@ -100,6 +100,12 @@ FString ULootLockerPurchasesRequestHandler::RefundByEntitlementIds(const FLootLo
     return LLAPI<FLootLockerRefundByEntitlementIdsResponse>::CallAPI(FLootLockerRefundByEntitlementIdsRequest{ EntitlementIds }, ULootLockerGameEndpoints::RefundByEntitlementIds, {}, {}, PlayerData, OnCompleted);
 }
 
+FString ULootLockerPurchasesRequestHandler::CreateStripeCheckoutSession(const FLootLockerPlayerData& PlayerData, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompleted)
+{
+    const FLootLockerCreateStripeCheckoutSessionRequest Request{ CatalogItemId, ItemName };
+    return LLAPI<FLootLockerCreateStripeCheckoutSessionResponse>::CallAPI(Request, ULootLockerGameEndpoints::CreateStripeCheckoutSession, {}, {}, PlayerData, OnCompleted);
+}
+
 FString ULootLockerPurchasesRequestHandler::RedeemEpicStorePurchase(const FLootLockerPlayerData& PlayerData, const FString& AccountId, const FString& BearerToken, const TArray<FString>& EntitlementIds, const FString& SandboxId, const FLootLockerDefaultDelegate& OnCompleted)
 {
     FLootLockerRedeemEpicStorePurchaseForPlayerRequest PurchaseRequest{

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -215,6 +215,7 @@ FLootLockerEndPoints ULootLockerGameEndpoints::BeginSteamPurchaseRedemption = In
 FLootLockerEndPoints ULootLockerGameEndpoints::QuerySteamPurchaseRedemptionStatus = InitEndpoint("store/steam/redeem/query", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::FinalizeSteamPurchaseRedemption = InitEndpoint("store/steam/redeem/finalise", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::RefundByEntitlementIds = InitEndpoint("refund/v1", ELootLockerHTTPMethod::POST);
+FLootLockerEndPoints ULootLockerGameEndpoints::CreateStripeCheckoutSession = InitEndpoint("store/stripe/checkout", ELootLockerHTTPMethod::POST);
 
 FLootLockerEndPoints ULootLockerGameEndpoints::InitiateAsyncPurchase = InitEndpoint("purchase/inspired-ibex/v1", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::PollAsyncPurchaseStatus = InitEndpoint("purchase/inspired-ibex/v1/{0}", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1524,6 +1524,14 @@ FString ULootLockerManager::RefundByEntitlementIds(const FString& ForPlayerWithU
         }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::CreateStripeCheckoutSession(const FString& ForPlayerWithUlid, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegateBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::CreateStripeCheckoutSession(CatalogItemId, ItemName, FLootLockerCreateStripeCheckoutSessionDelegate::CreateLambda([OnCompletedRequest](FLootLockerCreateStripeCheckoutSessionResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
 FString ULootLockerManager::InitiateAsyncPurchaseSingleCatalogItem(const FString& ForPlayerWithUlid, const FString& WalletId, const FString& ItemId, const int Quantity, const FLootLockerAsyncPurchaseInitiatedDelegateBP& OnCompletedRequest)
 {
     TArray<FLootLockerCatalogItemAndQuantityPair> Items;

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1524,9 +1524,9 @@ FString ULootLockerManager::RefundByEntitlementIds(const FString& ForPlayerWithU
         }), ForPlayerWithUlid);
 }
 
-FString ULootLockerManager::CreateStripeCheckoutSession(const FString& ForPlayerWithUlid, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegateBP& OnCompletedRequest)
+FString ULootLockerManager::CreateStripeCheckoutSession(const FString& ForPlayerWithUlid, const FString& CatalogItemId, const FLootLockerCreateStripeCheckoutSessionDelegateBP& OnCompletedRequest)
 {
-    return ULootLockerSDKManager::CreateStripeCheckoutSession(CatalogItemId, ItemName, FLootLockerCreateStripeCheckoutSessionDelegate::CreateLambda([OnCompletedRequest](FLootLockerCreateStripeCheckoutSessionResponse Response)
+    return ULootLockerSDKManager::CreateStripeCheckoutSession(CatalogItemId, FLootLockerCreateStripeCheckoutSessionDelegate::CreateLambda([OnCompletedRequest](FLootLockerCreateStripeCheckoutSessionResponse Response)
         {
             OnCompletedRequest.ExecuteIfBound(Response);
         }), ForPlayerWithUlid);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1124,6 +1124,11 @@ FString ULootLockerSDKManager::RefundByEntitlementIds(const TArray<FString>& Ent
     return ULootLockerPurchasesRequestHandler::RefundByEntitlementIds(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), EntitlementIds, OnCompletedRequest);
 }
 
+FString ULootLockerSDKManager::CreateStripeCheckoutSession(const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    return ULootLockerPurchasesRequestHandler::CreateStripeCheckoutSession(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogItemId, ItemName, OnCompletedRequest);
+}
+
 FString ULootLockerSDKManager::InitiateAsyncPurchaseCatalogItems(const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
 {
     return ULootLockerPurchasesRequestHandler::InitiateAsyncPurchase(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), WalletId, Items, OnCompletedRequest);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1124,9 +1124,9 @@ FString ULootLockerSDKManager::RefundByEntitlementIds(const TArray<FString>& Ent
     return ULootLockerPurchasesRequestHandler::RefundByEntitlementIds(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), EntitlementIds, OnCompletedRequest);
 }
 
-FString ULootLockerSDKManager::CreateStripeCheckoutSession(const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+FString ULootLockerSDKManager::CreateStripeCheckoutSession(const FString& CatalogItemId, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
 {
-    return ULootLockerPurchasesRequestHandler::CreateStripeCheckoutSession(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogItemId, ItemName, OnCompletedRequest);
+    return ULootLockerPurchasesRequestHandler::CreateStripeCheckoutSession(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogItemId, OnCompletedRequest);
 }
 
 FString ULootLockerSDKManager::InitiateAsyncPurchaseCatalogItems(const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -539,7 +539,12 @@ struct FLootLockerCreateStripeCheckoutSessionResponse : public FLootLockerRespon
      * The URL of the Stripe-hosted checkout page. Open this in a browser or webview to let the player complete the payment.
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    FString url = "";
+    FString checkout_link = "";
+    /**
+     * The LootLocker entitlement id tied to this purchase. Use this to track purchase progress via the entitlements endpoint.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString entitlement_id = "";
 };
 
 DECLARE_DELEGATE_OneParam(FLootLockerCreateStripeCheckoutSessionDelegate, FLootLockerCreateStripeCheckoutSessionResponse);

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -521,11 +521,6 @@ struct FLootLockerCreateStripeCheckoutSessionRequest
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString Catalog_item_id = "";
-    /**
-     * The display name of the item shown on the Stripe Checkout page
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    FString Item_name = "";
 };
 
 /**
@@ -587,7 +582,7 @@ public:
 
     static FString RefundByEntitlementIds(const FLootLockerPlayerData& PlayerData, const TArray<FString>& EntitlementIds, const FLootLockerRefundByEntitlementIdsDelegate& OnCompleted);
 
-    static FString CreateStripeCheckoutSession(const FLootLockerPlayerData& PlayerData, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompleted);
+    static FString CreateStripeCheckoutSession(const FLootLockerPlayerData& PlayerData, const FString& CatalogItemId, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompleted);
 
     static FString InitiateAsyncPurchase(const FLootLockerPlayerData& PlayerData, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompleted);
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -509,6 +509,41 @@ DECLARE_DELEGATE_OneParam(FLootLockerBeginSteamPurchaseRedemptionDelegate, FLoot
 DECLARE_DELEGATE_OneParam(FLootLockerQuerySteamPurchaseRedemptionStatusDelegate, FLootLockerQuerySteamPurchaseRedemptionStatusResponse);
 DECLARE_DELEGATE_OneParam(FLootLockerRefundByEntitlementIdsDelegate, FLootLockerRefundByEntitlementIdsResponse);
 
+/**
+ * Request to create a Stripe Checkout session for a catalog item
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerCreateStripeCheckoutSessionRequest
+{
+    GENERATED_BODY()
+    /**
+     * The ULID of the catalog item to purchase
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Catalog_item_id = "";
+    /**
+     * The display name of the item shown on the Stripe Checkout page
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Item_name = "";
+};
+
+/**
+ * Response from creating a Stripe Checkout session
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerCreateStripeCheckoutSessionResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+     * The URL of the Stripe-hosted checkout page. Open this in a browser or webview to let the player complete the payment.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString url = "";
+};
+
+DECLARE_DELEGATE_OneParam(FLootLockerCreateStripeCheckoutSessionDelegate, FLootLockerCreateStripeCheckoutSessionResponse);
+
 UCLASS()
 class LOOTLOCKERSDK_API ULootLockerPurchasesRequestHandler : public UObject
 {
@@ -546,6 +581,8 @@ public:
     static FString FinalizeSteamPurchaseRedemption(const FLootLockerPlayerData& PlayerData, const FString& EntitlementId, const FLootLockerDefaultDelegate& OnCompleted);
 
     static FString RefundByEntitlementIds(const FLootLockerPlayerData& PlayerData, const TArray<FString>& EntitlementIds, const FLootLockerRefundByEntitlementIdsDelegate& OnCompleted);
+
+    static FString CreateStripeCheckoutSession(const FLootLockerPlayerData& PlayerData, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompleted);
 
     static FString InitiateAsyncPurchase(const FLootLockerPlayerData& PlayerData, const FString& WalletId, const TArray<FLootLockerCatalogItemAndQuantityPair>& Items, const FLootLockerAsyncPurchaseInitiatedDelegate& OnCompleted);
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -254,6 +254,8 @@ public:
     static FLootLockerEndPoints FinalizeSteamPurchaseRedemption;
     static FLootLockerEndPoints RefundByEntitlementIds;
 
+    static FLootLockerEndPoints CreateStripeCheckoutSession;
+
     static FLootLockerEndPoints InitiateAsyncPurchase;
     static FLootLockerEndPoints PollAsyncPurchaseStatus;
     static FLootLockerEndPoints RetryAsyncPurchase;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -290,6 +290,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerBeginSteamPurchaseRedemptionDelegat
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerQuerySteamPurchaseRedemptionStatusDelegateBP, FLootLockerQuerySteamPurchaseRedemptionStatusResponse, Response);
 /** Blueprint response delegate for refund by entitlement IDs responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerRefundByEntitlementIdsResponseDelegate, FLootLockerRefundByEntitlementIdsResponse, Response);
+/** Blueprint response delegate for creating a Stripe Checkout session */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerCreateStripeCheckoutSessionDelegateBP, FLootLockerCreateStripeCheckoutSessionResponse, Response);
 /** Blueprint response delegate for initiating an async purchase */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerAsyncPurchaseInitiatedDelegateBP, FLootLockerAsyncPurchaseInitiatedResponse, Response);
 /** Blueprint response delegate for polling the status of an async purchase */
@@ -2871,6 +2873,21 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString RefundByEntitlementIds(const FString& ForPlayerWithUlid, const TArray<FString>& EntitlementIds, const FLootLockerRefundByEntitlementIdsResponseDelegate& OnCompletedRequest);
+
+    /**
+      Create a Stripe Checkout session for a catalog item.
+      This initiates a Stripe-hosted checkout flow. The response contains a url — open it in a browser or
+      webview so the player can complete the payment on Stripe's hosted checkout page.
+      Stripe in-app purchases must be configured in the LootLocker dashboard for this to work.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
+      @param CatalogItemId The ULID of the catalog item to purchase
+      @param ItemName The display name of the item shown on the Stripe Checkout page
+      @param OnCompletedRequest Delegate for handling the server response
+      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString CreateStripeCheckoutSession(const FString& ForPlayerWithUlid, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegateBP& OnCompletedRequest);
 
     /**
       Initiate an async purchase of a single catalog item using a specified wallet.

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -2876,18 +2876,19 @@ public:
 
     /**
       Create a Stripe Checkout session for a catalog item.
-      This initiates a Stripe-hosted checkout flow. The response contains a url — open it in a browser or
-      webview so the player can complete the payment on Stripe's hosted checkout page.
+
+      This initiates a Stripe-hosted checkout flow. The response contains a <c>checkout_link</c> — open it in a browser or webview so the player can complete the payment on Stripe's hosted checkout page.
+      The response also contains an <c>entitlement_id</c> which can be used to track the purchase progress via the entitlements endpoint.
+
       Stripe in-app purchases must be configured in the LootLocker dashboard for this to work.
 
       @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
       @param CatalogItemId The ULID of the catalog item to purchase
-      @param ItemName The display name of the item shown on the Stripe Checkout page
       @param OnCompletedRequest Delegate for handling the server response
       @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
-    static UPARAM(DisplayName = "RequestId") FString CreateStripeCheckoutSession(const FString& ForPlayerWithUlid, const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegateBP& OnCompletedRequest);
+    static UPARAM(DisplayName = "RequestId") FString CreateStripeCheckoutSession(const FString& ForPlayerWithUlid, const FString& CatalogItemId, const FLootLockerCreateStripeCheckoutSessionDelegateBP& OnCompletedRequest);
 
     /**
       Initiate an async purchase of a single catalog item using a specified wallet.

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -2563,18 +2563,17 @@ public:
     /**
      Create a Stripe Checkout session for a catalog item.
 
-     Initiates a Stripe-hosted checkout flow. The response contains a url — open it in a browser or
-     webview so the player can complete the payment on Stripe's hosted checkout page.
+     This initiates a Stripe-hosted checkout flow. The response contains a <c>checkout_link</c> — open it in a browser or webview so the player can complete the payment on Stripe's hosted checkout page.
+     The response also contains an <c>entitlement_id</c> which can be used to track the purchase progress via the entitlements endpoint.
 
      Stripe in-app purchases must be configured in the LootLocker dashboard for this to work.
 
      @param CatalogItemId The ULID of the catalog item to purchase
-     @param ItemName The display name of the item shown on the Stripe Checkout page
      @param OnCompletedRequest Delegate for handling the server response
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
-    static FString CreateStripeCheckoutSession(const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+    static FString CreateStripeCheckoutSession(const FString& CatalogItemId, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
     //==================================================
     // Triggers

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -2560,6 +2560,22 @@ public:
      */
     static FString RefundByEntitlementIds(const TArray<FString>& EntitlementIds, const FLootLockerRefundByEntitlementIdsDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
+    /**
+     Create a Stripe Checkout session for a catalog item.
+
+     Initiates a Stripe-hosted checkout flow. The response contains a url — open it in a browser or
+     webview so the player can complete the payment on Stripe's hosted checkout page.
+
+     Stripe in-app purchases must be configured in the LootLocker dashboard for this to work.
+
+     @param CatalogItemId The ULID of the catalog item to purchase
+     @param ItemName The display name of the item shown on the Stripe Checkout page
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString CreateStripeCheckoutSession(const FString& CatalogItemId, const FString& ItemName, const FLootLockerCreateStripeCheckoutSessionDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
     //==================================================
     // Triggers
     //==================================================


### PR DESCRIPTION
## Summary

Adds client-side support for the new Stripe Checkout endpoint (`POST /game/store/stripe/checkout`) introduced by the backend.

Closes / tracks: lootlocker/index#1370

---

### Changes

**`Public/LootLockerGameEndpoints.h`** / **`Private/LootLockerGameEndpoints.cpp`**
- Added `CreateStripeCheckoutSession` endpoint definition pointing to `store/stripe/checkout` (POST).

**`Public/GameAPI/LootLockerPurchasesRequestHandler.h`**
- Added `FLootLockerCreateStripeCheckoutSessionRequest` struct (`Catalog_item_id`, `Item_name`).
- Added `FLootLockerCreateStripeCheckoutSessionResponse` struct (`url` — the Stripe-hosted checkout page URL).
- Added `FLootLockerCreateStripeCheckoutSessionDelegate` delegate.
- Added `CreateStripeCheckoutSession` method declaration.

**`Private/GameAPI/LootLockerPurchasesRequestHandler.cpp`**
- Added `CreateStripeCheckoutSession` implementation using `LLAPI<FLootLockerCreateStripeCheckoutSessionResponse>::CallAPI`.

**`Public/LootLockerSDKManager.h`** / **`Private/LootLockerSDKManager.cpp`**
- Added `CreateStripeCheckoutSession` C++ API surface method.

**`Public/LootLockerManager.h`** / **`Private/LootLockerManager.cpp`**
- Added `FLootLockerCreateStripeCheckoutSessionDelegateBP` dynamic delegate.
- Added `CreateStripeCheckoutSession` Blueprint-callable method.

### How it works

1. The game calls `ULootLockerManager::CreateStripeCheckoutSession(ForPlayerWithUlid, CatalogItemId, ItemName, Delegate)` (Blueprint) or the `ULootLockerSDKManager` equivalent (C++).
2. The backend creates a Stripe Checkout Session and returns a `url`.
3. The game opens that URL in a browser/webview so the player can complete the payment on Stripe's hosted checkout page.