### PR TITLE
feat: add ll.action_name to broadcast language response

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBroadcastRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBroadcastRequestHandler.cpp
@@ -84,6 +84,11 @@ FLootLockerBroadcastLanguage::FLootLockerBroadcastLanguage(const FLootLockerInte
             action = Localization.value;
             continue;
         }
+        else if (Localization.key == TEXT("ll.action_name"))
+        {
+            action_name = Localization.value;
+            continue;
+        }
         
         // Add other localizations to the map and list
         localizations.Add(Localization.key, Localization.value);

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBroadcastRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBroadcastRequestHandler.h
@@ -163,6 +163,12 @@ struct FLootLockerBroadcastLanguage
     FString action = "";
     
     /**
+     * The action name for this broadcast message
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString action_name = "";
+    
+    /**
      * List of the keys available in the localizations dictionary
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")


### PR DESCRIPTION
## Summary

Adds `ll.action_name` as a dedicated convenience field on `FLootLockerBroadcastLanguage`, alongside the existing `headline`, `body`, `image_url`, and `action` fields.

Previously, `ll.action_name` fell through to the generic `localizations` map. It is now lifted to the named `action_name` property.

## Changes

- `LootLockerBroadcastRequestHandler.h`: Added `action_name` UPROPERTY to `FLootLockerBroadcastLanguage`.
- `LootLockerBroadcastRequestHandler.cpp`: Added `else if (Localization.key == TEXT("ll.action_name"))` branch in `FLootLockerBroadcastLanguage::FLootLockerBroadcastLanguage(const FLootLockerInternalBroadcastLanguage&)`.

## Tracking issue

Resolves lootlocker/index#1379