### PR TITLE
fix: replace SaveConfig() with TryUpdateDefaultConfigFile() to prevent DefaultGame.ini corruption

### DIFF
--- a/.github/scripts/run-tests.ps1
+++ b/.github/scripts/run-tests.ps1
@@ -1,0 +1,309 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+    Builds the LootLocker Unreal SDK plugin and runs its automation tests headlessly.
+
+.DESCRIPTION
+    1. Builds the plugin via RunUAT BuildPlugin (same as verify-compilation.ps1) so
+       compiled binaries are available.
+    2. Creates a minimal VerificationProject in Temp~/VerificationProject/ with a
+       directory junction pointing to the compiled Build~/PluginBuild/ output.
+    3. Invokes UnrealEditor-Cmd.exe with -ExecCmds to run the specified tests.
+    4. Parses the output for pass/fail and exits 0 on success, 1 on failure.
+
+    See .github/instructions/verification.md for setup instructions.
+
+.PARAMETER TestFilter
+    Automation test filter passed to "automation RunTests <filter>".
+    Defaults to "LootLocker.Config".
+
+.NOTES
+    Exit codes: 0 = all tests passed, 1 = one or more tests failed or setup error.
+#>
+param(
+    [string]$TestFilter = "LootLocker.Config"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot      = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$SettingsFile  = Join-Path $RepoRoot "unreal-dev-settings.json"
+$BuildOutput   = Join-Path $RepoRoot "Build~\PluginBuild"
+$BuildLog      = Join-Path $RepoRoot "Build~\UAT.log"
+$ProjectDir    = Join-Path $RepoRoot "Temp~\VerificationProject"
+$ProjectName   = "VerificationProject"
+$ProjectFile   = Join-Path $ProjectDir "$ProjectName.uproject"
+$PluginLinkDir = Join-Path $ProjectDir "Plugins\LootLockerSDK"
+$TestLog       = Join-Path $RepoRoot "Temp~\automation-tests.log"
+
+function Write-Step { param([string]$Msg) Write-Host $Msg }
+function Write-Ok   { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
+function Write-Fail { param([string]$Msg) Write-Host $Msg -ForegroundColor Red }
+function Write-Warn { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
+
+Write-Step "============================================"
+Write-Step "  LootLocker Unreal SDK - Automation Tests"
+Write-Step "============================================"
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 1. Load settings
+# ---------------------------------------------------------------------------
+if (-not (Test-Path $SettingsFile)) {
+    Write-Warn "SETUP REQUIRED: 'unreal-dev-settings.json' not found at repo root."
+    Write-Step '  { "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }'
+    exit 1
+}
+
+$Settings   = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+$UnrealRoot = $Settings.unreal_engine_path
+
+if ([string]::IsNullOrWhiteSpace($UnrealRoot) -or -not (Test-Path $UnrealRoot)) {
+    Write-Fail "ERROR: Unreal Engine path not found: $UnrealRoot"
+    exit 1
+}
+
+$RunUAT    = Join-Path $UnrealRoot "Engine\Build\BatchFiles\RunUAT.bat"
+$EditorCmd = Join-Path $UnrealRoot "Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
+
+if (-not (Test-Path $RunUAT)) {
+    Write-Fail "ERROR: RunUAT.bat not found at: $RunUAT"
+    exit 1
+}
+if (-not (Test-Path $EditorCmd)) {
+    Write-Fail "ERROR: UnrealEditor-Cmd.exe not found at: $EditorCmd"
+    exit 1
+}
+
+$PluginFile = Get-ChildItem -Path (Join-Path $RepoRoot "LootLockerSDK") -Filter "*.uplugin" |
+              Select-Object -First 1
+if (-not $PluginFile) {
+    Write-Fail "ERROR: No .uplugin file found under $RepoRoot\LootLockerSDK"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 2. Temporarily disable UBA (same reason as in verify-compilation.ps1)
+# ---------------------------------------------------------------------------
+$UbtConfigDir    = Join-Path $env:APPDATA "Unreal Engine\UnrealBuildTool"
+$UbtConfigFile   = Join-Path $UbtConfigDir "BuildConfiguration.xml"
+$UbtConfigBackup = $UbtConfigFile + ".run-tests-backup"
+$WroteUbtConfig  = $false
+
+if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
+if (Test-Path $UbtConfigFile) { Copy-Item $UbtConfigFile $UbtConfigBackup -Force }
+
+$noUbaXml = @'
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+  </BuildConfiguration>
+</Configuration>
+'@
+[IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
+$WroteUbtConfig = $true
+
+function Restore-UbtConfig {
+    if ($script:WroteUbtConfig) {
+        if (Test-Path $script:UbtConfigBackup) {
+            Move-Item $script:UbtConfigBackup $script:UbtConfigFile -Force
+        } else {
+            Remove-Item $script:UbtConfigFile -Force -ErrorAction SilentlyContinue
+        }
+        $script:WroteUbtConfig = $false
+    }
+}
+
+Write-Step "Note: Disabled UBA local executor (restored after tests)."
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 3. Build the plugin (ensures the latest test code is compiled into binaries)
+# ---------------------------------------------------------------------------
+Write-Step "Step 1/3 - Building plugin via RunUAT BuildPlugin ..."
+Write-Step "Plugin  : $($PluginFile.FullName)"
+Write-Step "Engine  : $UnrealRoot"
+Write-Step "Output  : $BuildOutput"
+Write-Step ""
+
+$BuildLogDir = Split-Path $BuildLog
+if (-not (Test-Path $BuildLogDir)) { New-Item -ItemType Directory -Path $BuildLogDir -Force | Out-Null }
+if (Test-Path $BuildLog) { Remove-Item $BuildLog -Force }
+
+if (Test-Path $BuildOutput) {
+    & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+    if (Test-Path $BuildOutput) {
+        Write-Warn "Warning: Could not fully remove previous build output - UAT will attempt to overwrite."
+    }
+}
+
+$prevEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+
+$buildLines  = [System.Collections.Generic.List[string]]::new()
+$buildStream = [System.IO.StreamWriter]::new($BuildLog, $false, [System.Text.Encoding]::UTF8)
+
+$uatArgs = @(
+    "BuildPlugin"
+    "-Plugin=`"$($PluginFile.FullName)`""
+    "-Package=`"$BuildOutput`""
+    "-Rocket"
+    "-TargetPlatforms=Win64"
+    "-VS2022"
+)
+
+try {
+    & $RunUAT @uatArgs 2>&1 | ForEach-Object {
+        $line = "$_"
+        $buildLines.Add($line)
+        $buildStream.WriteLine($line)
+        $buildStream.Flush()
+        Write-Host $line
+    }
+} finally {
+    $buildStream.Close()
+}
+$buildExit = $LASTEXITCODE
+$ErrorActionPreference = $prevEAP
+
+if ($buildExit -ne 0) {
+    Restore-UbtConfig
+    Write-Fail "BUILD FAILED - cannot run tests without compiled binaries."
+    Write-Step "Full build log: $BuildLog"
+    exit 1
+}
+Write-Step ""
+Write-Ok "Plugin built successfully."
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 4. Set up VerificationProject pointing at the compiled plugin output
+# ---------------------------------------------------------------------------
+Write-Step "Step 2/3 - Setting up VerificationProject ..."
+
+if (-not (Test-Path $ProjectDir)) {
+    New-Item -ItemType Directory -Path $ProjectDir -Force | Out-Null
+}
+
+# Always (re)write the uproject so disabled-plugin list stays current.
+$uproject = @{
+    FileVersion       = 3
+    EngineAssociation = ""
+    Category          = ""
+    Description       = ""
+    Plugins           = @(
+        @{ Name = "LootLockerSDK";   Enabled = $true  }
+        # Engine plugins that fail to load without a full Marketplace installation
+        @{ Name = "Bridge";          Enabled = $false }
+        @{ Name = "MegascansPlugin"; Enabled = $false }
+        @{ Name = "Fab";             Enabled = $false }
+    )
+} | ConvertTo-Json -Depth 5
+[IO.File]::WriteAllText($ProjectFile, $uproject)
+
+$PluginsDir = Join-Path $ProjectDir "Plugins"
+if (-not (Test-Path $PluginsDir)) {
+    New-Item -ItemType Directory -Path $PluginsDir -Force | Out-Null
+}
+
+# Recreate the junction if it does not exist or points at a stale target.
+if (Test-Path $PluginLinkDir) {
+    $linkItem      = Get-Item $PluginLinkDir -Force
+    $needsRecreate = ($linkItem.LinkType -ne "Junction") -or
+                     ($linkItem.Target -and ($linkItem.Target -ne $BuildOutput))
+    if ($needsRecreate) {
+        & cmd /c "rmdir `"$PluginLinkDir`"" 2>&1 | Out-Null
+        if (Test-Path $PluginLinkDir) { Remove-Item $PluginLinkDir -Recurse -Force }
+    }
+}
+if (-not (Test-Path $PluginLinkDir)) {
+    Write-Step "Creating plugin junction: Plugins\LootLockerSDK -> $BuildOutput"
+    New-Item -ItemType Junction -Path $PluginLinkDir -Target $BuildOutput | Out-Null
+}
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 5. Run automation tests via UnrealEditor-Cmd.exe
+# ---------------------------------------------------------------------------
+Write-Step "Step 3/3 - Running automation tests ..."
+Write-Step "Project  : $ProjectFile"
+Write-Step "Filter   : $TestFilter"
+Write-Step "Log      : $TestLog"
+Write-Step ""
+
+$TestLogDir = Split-Path $TestLog
+if (-not (Test-Path $TestLogDir)) { New-Item -ItemType Directory -Path $TestLogDir -Force | Out-Null }
+if (Test-Path $TestLog) { Remove-Item $TestLog -Force }
+
+$execCmd    = "automation RunTests $TestFilter;quit"
+$editorArgs = @(
+    "`"$ProjectFile`""
+    "-unattended"
+    "-nullrhi"
+    "-nosound"
+    "-NoSplash"
+    "-NoPause"
+    "-stdout"
+    "-FullStdOutLogOutput"
+    "-SkipBadPlugins"
+    "-ExecCmds=`"$execCmd`""
+)
+
+$ErrorActionPreference = 'Continue'
+$outputLines = [System.Collections.Generic.List[string]]::new()
+$testStream  = [System.IO.StreamWriter]::new($TestLog, $false, [System.Text.Encoding]::UTF8)
+
+try {
+    & $EditorCmd @editorArgs 2>&1 | ForEach-Object {
+        $line = "$_"
+        $outputLines.Add($line)
+        $testStream.WriteLine($line)
+        $testStream.Flush()
+        Write-Host $line
+    }
+} finally {
+    $testStream.Close()
+    Restore-UbtConfig
+}
+$editorExit = $LASTEXITCODE
+$ErrorActionPreference = $prevEAP
+
+# ---------------------------------------------------------------------------
+# 6. Parse results
+#    UE automation outputs lines like:
+#      LogAutomationController: Test Completed. Result={Passed|Failed} ...
+#      LogAutomationController: Automation Test Succeeded
+#      LogAutomationController: Automation Test Failed
+# ---------------------------------------------------------------------------
+Write-Step ""
+Write-Step "--- Test results ---"
+Write-Step ""
+
+$passedLines = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Passed|Success)\}?"
+$failedLines  = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Failed|Fail)\}?"
+$totalPassed = ($passedLines | Measure-Object).Count
+$totalFailed = ($failedLines | Measure-Object).Count
+
+if ($failedLines) {
+    $failedLines | ForEach-Object { Write-Host $_.Line -ForegroundColor Red }
+    Write-Step ""
+}
+
+Write-Step "----------------------------------"
+Write-Step "Passed : $totalPassed"
+Write-Step "Failed : $totalFailed"
+Write-Step ""
+
+if ($totalFailed -eq 0 -and $totalPassed -gt 0) {
+    Write-Ok "ALL TESTS PASSED"
+    exit 0
+} elseif ($totalPassed -eq 0 -and $totalFailed -eq 0) {
+    Write-Fail "NO TESTS RAN - check the log for startup errors"
+    Write-Step "Full log: $TestLog"
+    exit 1
+} else {
+    Write-Fail "TESTS FAILED"
+    Write-Step "Full log: $TestLog"
+    exit 1
+}

--- a/.github/scripts/run-tests.ps1
+++ b/.github/scripts/run-tests.ps1
@@ -15,13 +15,13 @@
 
 .PARAMETER TestFilter
     Automation test filter passed to "automation RunTests <filter>".
-    Defaults to "LootLocker.Config".
+    Defaults to "LootLocker" which runs all LootLocker tests.
 
 .NOTES
     Exit codes: 0 = all tests passed, 1 = one or more tests failed or setup error.
 #>
 param(
-    [string]$TestFilter = "LootLocker.Config"
+    [string]$TestFilter = "LootLocker"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,6 @@ DemoProject/DerivedDataCache/*
 # Local Unreal SDK dev settings (machine-specific, contains path to UE installation)
 unreal-dev-settings.json
 
-# Temporary build output from .github/scripts/verify-compilation.ps1
+# Temporary build/test output from .github/scripts/
 Build~/
+Temp~/

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -44,7 +44,7 @@ void ULootLockerConfig::EnableFileLogging(const FString& FileName)
     FString DateAppendix = FDateTime::UtcNow().ToString(TEXT("%Y-%m-%d"));
     Config->LogFilePath = FPaths::Combine(LogDir, FileName + TEXT("_") + DateAppendix + TEXT(".log"));
     Config->LongLogFilePath = FPaths::ConvertRelativePathToFull(Config->LogFilePath);
-    Config->SaveConfig();
+    Config->TryUpdateDefaultConfigFile();
 }
 
 void ULootLockerConfig::DisableFileLogging()
@@ -53,7 +53,7 @@ void ULootLockerConfig::DisableFileLogging()
     Config->bEnableFileLogging = false;
     Config->LogFilePath = TEXT("");
     Config->LongLogFilePath = "";
-    Config->SaveConfig();
+    Config->TryUpdateDefaultConfigFile();
 }
 
 bool ULootLockerConfig::IsFileLoggingEnabled()

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerConfigSaveTest.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerConfigSaveTest.cpp
@@ -26,7 +26,7 @@
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
     FLootLockerConfigSavePreservesOtherIniSettingsTest,
     "LootLocker.Config.SaveConfigPreservesOtherIniSettings",
-    EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::SmokeFilter
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::SmokeFilter
 )
 
 bool FLootLockerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& Parameters)
@@ -52,13 +52,37 @@ bool FLootLockerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& 
     // 3. Write a "sentinel" entry into a section that LootLocker has nothing to
     //    do with, simulating settings from another plugin stored in the same
     //    DefaultGame.ini.
+    //
+    //    We write directly with FFileHelper (not via GConfig) to avoid issues
+    //    with GConfig's path normalisation or missing Config/ directory in a
+    //    freshly-created test project.
     // -------------------------------------------------------------------------
-    const TCHAR* SentinelSection = TEXT("/Script/IssueRegression1411.SentinelConfig");
-    const TCHAR* SentinelKey     = TEXT("SentinelValue_1411");
-    const TCHAR* SentinelValue   = TEXT("MUST_BE_PRESERVED_ACROSS_SAVECONFIG");
+    const FString SentinelSection = TEXT("/Script/IssueRegression1411.SentinelConfig");
+    const FString SentinelKey     = TEXT("SentinelValue_1411");
+    const FString SentinelValue   = TEXT("MUST_BE_PRESERVED_ACROSS_SAVECONFIG");
 
-    GConfig->SetString(SentinelSection, SentinelKey, SentinelValue, ConfigFilename);
-    GConfig->Flush(false, ConfigFilename);
+    // Ensure the Config directory exists (it may not in a brand-new test project).
+    IPlatformFile::GetPlatformPhysical().CreateDirectoryTree(*FPaths::GetPath(ConfigFilename));
+
+    // Read any existing content, then append the sentinel section.
+    FString InitialContent;
+    FFileHelper::LoadFileToString(InitialContent, *ConfigFilename);
+
+    if (!InitialContent.IsEmpty() && !InitialContent.EndsWith(TEXT("\n")))
+    {
+        InitialContent += TEXT("\r\n");
+    }
+    InitialContent += FString::Printf(
+        TEXT("[%s]\r\n%s=%s\r\n"), *SentinelSection, *SentinelKey, *SentinelValue);
+
+    if (!TestTrue("Setup: should be able to write sentinel to config file",
+            FFileHelper::SaveStringToFile(InitialContent, *ConfigFilename)))
+    {
+        return false;
+    }
+
+    // Reload the file into GConfig so in-memory and on-disk state match.
+    GConfig->LoadFile(ConfigFilename);
 
     // Confirm the sentinel is on disk before we do any LootLocker operations.
     FString DiskContentsBeforeEnable;
@@ -73,21 +97,31 @@ bool FLootLockerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& 
     // -------------------------------------------------------------------------
     // 4. EnableFileLogging — this triggered the bug before the fix.
     // -------------------------------------------------------------------------
-    ULootLockerConfig::EnableFileLogging(TEXT("LootLockerTestLog_1411"));
+    const FString TestLogFileName = TEXT("LootLockerTestLog_1411");
+    ULootLockerConfig::EnableFileLogging(TestLogFileName);
 
     // Read the file directly from disk (bypasses GConfig in-memory state).
     FString DiskContentsAfterEnable;
     TestTrue("Config file should still be readable from disk after EnableFileLogging",
         FFileHelper::LoadFileToString(DiskContentsAfterEnable, *ConfigFilename));
 
+    // The sentinel from another plugin must still be there.
     const bool bSentinelSurvivesEnable = DiskContentsAfterEnable.Contains(SentinelValue);
     TestTrue(
         "After EnableFileLogging, settings from unrelated sections must not be erased "
         "from DefaultGame.ini.  A FAIL here indicates issue #1411 is not fixed.",
         bSentinelSurvivesEnable);
 
+    // The enable flag and file name must be persisted so the setting actually works.
+    TestTrue(
+        "After EnableFileLogging, bEnableFileLogging=True must be written to DefaultGame.ini on disk",
+        DiskContentsAfterEnable.Contains(TEXT("bEnableFileLogging=True")));
+    TestTrue(
+        "After EnableFileLogging, the log file name must be written to DefaultGame.ini on disk",
+        DiskContentsAfterEnable.Contains(TestLogFileName));
+
     // -------------------------------------------------------------------------
-    // 5. DisableFileLogging — same check.
+    // 5. DisableFileLogging — same checks.
     // -------------------------------------------------------------------------
     ULootLockerConfig::DisableFileLogging();
 
@@ -101,10 +135,18 @@ bool FLootLockerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& 
         "from DefaultGame.ini.  A FAIL here indicates issue #1411 is not fixed.",
         bSentinelSurvivesDisable);
 
+    // The disable must also be persisted.
+    TestTrue(
+        "After DisableFileLogging, bEnableFileLogging=False must be written to DefaultGame.ini on disk",
+        DiskContentsAfterDisable.Contains(TEXT("bEnableFileLogging=False")));
+
     // -------------------------------------------------------------------------
-    // 6. Cleanup — remove the sentinel and restore the original logging config.
+    // 6. Cleanup — remove the sentinel from the file and restore the original
+    //    logging config.
     // -------------------------------------------------------------------------
-    GConfig->RemoveKey(SentinelSection, SentinelKey, ConfigFilename);
+    // Remove the sentinel section from the file directly (same pattern we used
+    // to write it) so subsequent test runs start clean.
+    GConfig->RemoveKey(*SentinelSection, *SentinelKey, ConfigFilename);
     GConfig->Flush(false, ConfigFilename);
 
     if (bWasEnabled)
@@ -113,7 +155,7 @@ bool FLootLockerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& 
             OriginalLogFileName.IsEmpty() ? TEXT("LootLockerLog") : OriginalLogFileName);
     }
 
-    return bSentinelSurvivesEnable && bSentinelSurvivesDisable;
+    return true;
 }
 
 #endif // ENGINE_MAJOR_VERSION > 4

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerConfigSaveTest.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerConfigSaveTest.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 LootLocker
+
+// Regression test for issue #1411:
+// EnableFileLogging() and DisableFileLogging() must not overwrite settings in
+// DefaultGame.ini that belong to other sections/plugins.
+//
+// Run headless from the command line (no backend connection required):
+//   UnrealEditor.exe "YourProject.uproject" -run=automation
+//     -ExecCmds="automation RunTests LootLocker.Config.SaveConfigPreservesOtherIniSettings"
+//     -unattended -nullrhi -nosound -stdout
+
+#include "LootLockerConfig.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/ConfigCacheIni.h"
+
+#if ENGINE_MAJOR_VERSION > 4
+
+/**
+ * Verifies that calling EnableFileLogging / DisableFileLogging does not wipe
+ * other sections in DefaultGame.ini (regression for issue #1411).
+ *
+ * The test is tagged SmokeFilter so it can run without network access and will
+ * be included in any local or CI smoke pass.
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FLootLockerConfigSavePreservesOtherIniSettingsTest,
+    "LootLocker.Config.SaveConfigPreservesOtherIniSettings",
+    EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::SmokeFilter
+)
+
+bool FLootLockerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& Parameters)
+{
+    // -------------------------------------------------------------------------
+    // 1. Locate the DefaultGame.ini that ULootLockerConfig writes to.
+    // -------------------------------------------------------------------------
+    ULootLockerConfig* MutableConfig = GetMutableDefault<ULootLockerConfig>();
+    const FString ConfigFilename = MutableConfig->GetDefaultConfigFilename();
+
+    if (!TestFalse("DefaultGame.ini path should not be empty", ConfigFilename.IsEmpty()))
+    {
+        return false;
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Save original file-logging state so we can restore it after the test.
+    // -------------------------------------------------------------------------
+    const bool bWasEnabled = ULootLockerConfig::IsFileLoggingEnabled();
+    const FString OriginalLogFileName = MutableConfig->LogFileName;
+
+    // -------------------------------------------------------------------------
+    // 3. Write a "sentinel" entry into a section that LootLocker has nothing to
+    //    do with, simulating settings from another plugin stored in the same
+    //    DefaultGame.ini.
+    // -------------------------------------------------------------------------
+    const TCHAR* SentinelSection = TEXT("/Script/IssueRegression1411.SentinelConfig");
+    const TCHAR* SentinelKey     = TEXT("SentinelValue_1411");
+    const TCHAR* SentinelValue   = TEXT("MUST_BE_PRESERVED_ACROSS_SAVECONFIG");
+
+    GConfig->SetString(SentinelSection, SentinelKey, SentinelValue, ConfigFilename);
+    GConfig->Flush(false, ConfigFilename);
+
+    // Confirm the sentinel is on disk before we do any LootLocker operations.
+    FString DiskContentsBeforeEnable;
+    if (!TestTrue("Config file should be readable from disk",
+            FFileHelper::LoadFileToString(DiskContentsBeforeEnable, *ConfigFilename)))
+    {
+        return false;
+    }
+    TestTrue("Sentinel value should be present on disk before calling EnableFileLogging",
+        DiskContentsBeforeEnable.Contains(SentinelValue));
+
+    // -------------------------------------------------------------------------
+    // 4. EnableFileLogging — this triggered the bug before the fix.
+    // -------------------------------------------------------------------------
+    ULootLockerConfig::EnableFileLogging(TEXT("LootLockerTestLog_1411"));
+
+    // Read the file directly from disk (bypasses GConfig in-memory state).
+    FString DiskContentsAfterEnable;
+    TestTrue("Config file should still be readable from disk after EnableFileLogging",
+        FFileHelper::LoadFileToString(DiskContentsAfterEnable, *ConfigFilename));
+
+    const bool bSentinelSurvivesEnable = DiskContentsAfterEnable.Contains(SentinelValue);
+    TestTrue(
+        "After EnableFileLogging, settings from unrelated sections must not be erased "
+        "from DefaultGame.ini.  A FAIL here indicates issue #1411 is not fixed.",
+        bSentinelSurvivesEnable);
+
+    // -------------------------------------------------------------------------
+    // 5. DisableFileLogging — same check.
+    // -------------------------------------------------------------------------
+    ULootLockerConfig::DisableFileLogging();
+
+    FString DiskContentsAfterDisable;
+    TestTrue("Config file should still be readable from disk after DisableFileLogging",
+        FFileHelper::LoadFileToString(DiskContentsAfterDisable, *ConfigFilename));
+
+    const bool bSentinelSurvivesDisable = DiskContentsAfterDisable.Contains(SentinelValue);
+    TestTrue(
+        "After DisableFileLogging, settings from unrelated sections must not be erased "
+        "from DefaultGame.ini.  A FAIL here indicates issue #1411 is not fixed.",
+        bSentinelSurvivesDisable);
+
+    // -------------------------------------------------------------------------
+    // 6. Cleanup — remove the sentinel and restore the original logging config.
+    // -------------------------------------------------------------------------
+    GConfig->RemoveKey(SentinelSection, SentinelKey, ConfigFilename);
+    GConfig->Flush(false, ConfigFilename);
+
+    if (bWasEnabled)
+    {
+        ULootLockerConfig::EnableFileLogging(
+            OriginalLogFileName.IsEmpty() ? TEXT("LootLockerLog") : OriginalLogFileName);
+    }
+
+    return bSentinelSurvivesEnable && bSentinelSurvivesDisable;
+}
+
+#endif // ENGINE_MAJOR_VERSION > 4


### PR DESCRIPTION
## Summary

Fixes issue https://github.com/lootlocker/index/issues/1411.

`SaveConfig()` in `EnableFileLogging()` and `DisableFileLogging()` was calling `GConfig->Flush(false, DefaultGame.ini)` internally. That flush rewrites the entire `DefaultGame.ini` from GConfig's in-memory state, which can silently wipe settings that other plugins or systems had written to the same file if there is any divergence between GConfig's memory and the on-disk state.

### Fix

Replace `Config->SaveConfig()` with `Config->TryUpdateDefaultConfigFile()` in both
`EnableFileLogging()` and `DisableFileLogging()`.

`TryUpdateDefaultConfigFile()` is the UE5-recommended approach for updating a `DefaultConfig`-class's ini settings: it writes **only the diff** of changed properties for this class's section, without triggering a full-file flush that can corrupt unrelated settings.

### Test

A headless regression test is added in `Tests/LootLockerConfigSaveTest.cpp`:

1. Writes a **sentinel value in a foreign section** of `DefaultGame.ini` (simulating another plugin's settings).  
2. Calls `EnableFileLogging()` then `DisableFileLogging()`.  
3. Reads the file **directly from disk** (bypasses GConfig in-memory state).  
4. Asserts the sentinel is still present after each operation.

Run headless without network access:
```
UnrealEditor.exe "YourProject.uproject" -run=automation \
  -ExecCmds="automation RunTests LootLocker.Config.SaveConfigPreservesOtherIniSettings" \
  -unattended -nullrhi -nosound -stdout
```

## Changes

| File | Change |
|------|--------|
| `Private/LootLockerConfig.cpp` | `SaveConfig()` → `TryUpdateDefaultConfigFile()` in `EnableFileLogging` and `DisableFileLogging` |
| `Tests/LootLockerConfigSaveTest.cpp` | New headless regression test |
