### PR TITLE
feat: Add failed response error reporting using the feedback system

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -20,6 +20,8 @@
 const FString ULootLockerHttpClient::UserAgent = FString::Format(TEXT("X-UnrealEngine-Agent/{0}"), { ENGINE_VERSION_STRING });
 const FString ULootLockerHttpClient::UserInstanceIdentifier = FGuid::NewGuid().ToString();
 FString ULootLockerHttpClient::SDKVersion = "";
+TArray<FLootLockerFailedRequestReport> ULootLockerHttpClient::FailedRequestHistory;
+FString ULootLockerHttpClient::LootLockerFailureFeedbackCategoryId = TEXT("Not Initialized");
 
 ULootLockerHttpClient::ULootLockerHttpClient()
 {
@@ -82,7 +84,8 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
     Request->SetContentAsString(data);
 
     FString playerUlid = PlayerData.PlayerUlid;
-    FString requestTime = FDateTime::Now().ToString();
+    FDateTime requestStartTime = FDateTime::Now();
+    FString requestTime = requestStartTime.ToString();
     FString DelimitedHeaders = "";
     TArray<FString> AllHeaders = Request->GetAllHeaders();
     for (auto Header : AllHeaders)
@@ -90,7 +93,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
         DelimitedHeaders += TEXT("    ") + Header + TEXT("\n");
     }
 
-	Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, endPoint, requestType, data, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, RetryAttemptCount](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
+	Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, endPoint, requestType, data, playerUlid, requestTime, requestStartTime, DelimitedHeaders, AllHeaders, requestId, PlayerData, customHeaders, RetryAttemptCount](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
 	{
         if (!Response.IsValid())
         {
@@ -147,6 +150,8 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
                 });
                 return; // Don't call the original callback yet
             }
+
+            StoreFailedRequestReport(response, data, AllHeaders, Response, RetryAttemptCount, requestStartTime);
 		}
         else
         {
@@ -204,7 +209,8 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
 
     Request->SetVerb(requestType);
 
-    FString requestTime = FDateTime::Now().ToString();
+    FDateTime requestStartTime = FDateTime::Now();
+    FString requestTime = requestStartTime.ToString();
     TArray<uint8> UpFileRawData;
     if (!FFileHelper::LoadFileToArray(UpFileRawData, *FilePath)) {
         FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("HTTP Response was invalid", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_HTTP, PlayerData.PlayerUlid);
@@ -252,7 +258,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     Request->SetContent(Data);
 
     FString playerUlid = PlayerData.PlayerUlid;
-    Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, requestType, endPoint, playerUlid, requestTime, DelimitedHeaders, requestId, PlayerData, customHeaders, FilePath, AdditionalFields, RetryAttemptCount](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
+    Request->OnProcessRequestComplete().BindLambda([onCompleteRequest, requestType, endPoint, playerUlid, requestTime, requestStartTime, DelimitedHeaders, AllHeaders, requestId, PlayerData, customHeaders, FilePath, AdditionalFields, RetryAttemptCount](FHttpRequestPtr Req, const FHttpResponsePtr& Response, bool bWasSuccessful)
         {
             if (!Response.IsValid())
             {
@@ -303,6 +309,8 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
                     });
                     return; // Don't call the original callback yet
                 }
+
+                StoreFailedRequestReport(response, FString(), AllHeaders, Response, RetryAttemptCount, requestStartTime);
             }
     		else
             {
@@ -518,3 +526,159 @@ void ULootLockerHttpClient::RetryOriginalRequest(const FLootLockerRetryRequestDa
                RetryData.OnCompleteRequest, UpdatedPlayerData, RetryData.CustomHeaders, RetryData.RetryAttemptCount, RetryData.OriginalRequestId);
     }
 }
+
+// === Failure Reporting ===
+
+bool ULootLockerHttpClient::IsFailureReportingEnabled()
+{
+    return !LootLockerFailureFeedbackCategoryId.IsEmpty() && !LootLockerFailureFeedbackCategoryId.Equals(TEXT("Not Initialized"));
+}
+
+FString ULootLockerHttpClient::GetFailureFeedbackCategoryId()
+{
+    return LootLockerFailureFeedbackCategoryId;
+}
+
+void ULootLockerHttpClient::RefreshFailureFeedbackCategoryId(const FLootLockerRefreshFailureFeedbackCategoryIdDelegate& OnComplete)
+{
+    if (LootLockerFailureFeedbackCategoryId.IsEmpty())
+    {
+        // Already determined that no category exists
+        OnComplete.ExecuteIfBound(false);
+        return;
+    }
+
+    if (!LootLockerFailureFeedbackCategoryId.Equals(TEXT("Not Initialized")))
+    {
+        // Already initialized with a valid category id
+        OnComplete.ExecuteIfBound(true);
+        return;
+    }
+
+    // Look up feedback categories to find the "lootlocker_request_failure" category
+    FString DefaultPlayerUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+    ULootLockerSDKManager::ListGameFeedbackCategories(
+        FLootLockerListFeedbackCategoryResponseDelegate::CreateLambda([OnComplete](const FLootLockerFeedbackCategoryResponse& Response)
+        {
+            if (!Response.success)
+            {
+                FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Failed to retrieve feedback categories for error report. Status: %d, Message: %s"), Response.StatusCode, *Response.ErrorData.Message));
+                LootLockerFailureFeedbackCategoryId = TEXT("");
+                OnComplete.ExecuteIfBound(false);
+                return;
+            }
+            for (const FLootLockerFeedbackCategory& Category : Response.categories)
+            {
+                if (Category.name.Equals(TEXT("lootlocker_request_failure")))
+                {
+                    LootLockerFailureFeedbackCategoryId = Category.id;
+                    OnComplete.ExecuteIfBound(true);
+                    return;
+                }
+            }
+            LootLockerFailureFeedbackCategoryId = TEXT("");
+            FLootLockerLogger::LogVerbose(TEXT("Failed to find appropriate category to send error report under. Feedback categories retrieved successfully but no category with name 'lootlocker_request_failure' was found. LootLocker Error reporting turned off"));
+            OnComplete.ExecuteIfBound(false);
+        }),
+        DefaultPlayerUlid
+    );
+}
+
+bool ULootLockerHttpClient::TryGetFailedRequestReportForRequestId(const FString& RequestId, FLootLockerFailedRequestReport& OutReport)
+{
+    for (const FLootLockerFailedRequestReport& Report : FailedRequestHistory)
+    {
+        if (Report.client_request_id.Equals(RequestId))
+        {
+            OutReport = Report;
+            return true;
+        }
+    }
+    return false;
+}
+
+void ULootLockerHttpClient::StoreFailedRequestReport(const FLootLockerResponse& FailedResponse, const FString& RequestBody, const TArray<FString>& AllRequestHeaders, const FHttpResponsePtr& HttpResponse, int32 RetryAttempts, const FDateTime& RequestStartTime)
+{
+    if (LootLockerFailureFeedbackCategoryId.IsEmpty())
+    {
+        // Failure reporting is disabled
+        return;
+    }
+    if (FailedResponse.StatusCode == 401)
+    {
+        FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Request unauthorized - cannot construct valid error report for a request that was unauthorized. Player ULID: %s"), *FailedResponse.Context.PlayerUlid));
+        return;
+    }
+    if (FailedResponse.ErrorData.Retry_after_seconds > 0)
+    {
+        FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Request throttled - cannot construct valid error report for a request that was throttled. Retry after %d seconds. Player ULID: %s"), FailedResponse.ErrorData.Retry_after_seconds, *FailedResponse.Context.PlayerUlid));
+        return;
+    }
+    if (FailedResponse.ErrorData.Message.IsEmpty() && FailedResponse.ErrorData.Code.IsEmpty())
+    {
+        FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Failed response had no error data, cannot construct valid error report. Player ULID: %s"), *FailedResponse.Context.PlayerUlid));
+        return;
+    }
+
+    FLootLockerFailedRequestReport Report;
+    Report.client_request_id = FailedResponse.Context.RequestId;
+    Report.server_request_id = FailedResponse.ErrorData.Request_id;
+    Report.trace_id = FailedResponse.ErrorData.Trace_id;
+    Report.status_code = FailedResponse.StatusCode;
+    Report.message = FailedResponse.ErrorData.Message;
+    Report.endpoint = FailedResponse.Context.RequestURL;
+    Report.http_method = FailedResponse.Context.RequestMethod;
+    Report.response_json_body = LootLockerUtilities::ObfuscateJsonStringForLogging(FailedResponse.FullTextFromServer);
+    Report.request_body = LootLockerUtilities::ObfuscateJsonStringForLogging(RequestBody);
+    Report.retry_attempts = RetryAttempts;
+    Report.player_ulid = FailedResponse.Context.PlayerUlid;
+    Report.client_timestamp = RequestStartTime.ToIso8601();
+
+    FTimespan Duration = FDateTime::Now() - RequestStartTime;
+    Report.request_duration_seconds = static_cast<float>(Duration.GetTotalSeconds());
+
+    // Capture request headers, omitting sensitive auth headers
+    for (const FString& Header : AllRequestHeaders)
+    {
+        FString LowerHeader = Header.ToLower();
+        if (!LowerHeader.StartsWith(TEXT("x-session-token")) && !LowerHeader.StartsWith(TEXT("authorization")))
+        {
+            Report.request_headers.Add(Header);
+        }
+    }
+
+    // Capture response headers and server timestamp
+    if (HttpResponse.IsValid())
+    {
+        Report.response_headers = HttpResponse->GetAllHeaders();
+        FString DateHeader = HttpResponse->GetHeader(TEXT("Date"));
+        if (!DateHeader.IsEmpty())
+        {
+            Report.server_timestamp = DateHeader;
+        }
+    }
+
+    // Store in history, replacing the oldest entry if at capacity
+    if (FailedRequestHistory.Num() < MaxFailedRequestHistory)
+    {
+        FailedRequestHistory.Add(Report);
+        return;
+    }
+
+    int32 OldestIndex = 0;
+    FDateTime OldestTime(MAX_int64);
+    for (int32 i = 0; i < FailedRequestHistory.Num(); i++)
+    {
+        FDateTime EntryTime;
+        if (FDateTime::ParseIso8601(*FailedRequestHistory[i].client_timestamp, EntryTime))
+        {
+            if (EntryTime < OldestTime)
+            {
+                OldestTime = EntryTime;
+                OldestIndex = i;
+            }
+        }
+    }
+    FailedRequestHistory[OldestIndex] = Report;
+}
+

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -654,7 +654,11 @@ void ULootLockerHttpClient::StoreFailedRequestReport(const FLootLockerResponse& 
         FString DateHeader = HttpResponse->GetHeader(TEXT("Date"));
         if (!DateHeader.IsEmpty())
         {
-            Report.server_timestamp = DateHeader;
+            FDateTime ParsedDate;
+            if (FDateTime::ParseHttpDate(DateHeader, ParsedDate))
+            {
+                Report.server_timestamp = ParsedDate.ToIso8601();
+            }
         }
     }
 

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -2001,6 +2001,14 @@ FString ULootLockerManager::SendUGCFeedback(const FString& ForPlayerWithUlid, co
 
 }
 
+FString ULootLockerManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseBP& OnComplete)
+{
+    return ULootLockerSDKManager::SendLootLockerErrorReport(UserDescription, FailedResponse, FLootLockerSendFeedbackResponseDelegate::CreateLambda([OnComplete](const FLootLockerResponse& Response)
+    {
+        OnComplete.ExecuteIfBound(Response);
+    }));
+}
+
 // Metadata
 
 FString ULootLockerManager::ListMetadata(const FString& ForPlayerWithUlid, const ELootLockerMetadataSources Source, const FString& SourceID, const int Page, const int PerPage, const bool IgnoreFiles, const FLootLockerListMetadataResponseBP& OnComplete)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -4,7 +4,9 @@
 
 #include "LootLockerStateData.h"
 #include "LootLockerPresenceManager.h"
+#include "LootLockerHttpClient.h"
 #include "GameAPI/LootLockerFriendsRequestHandler.h"
+#include "Utils/LootLockerUtilities.h"
 
 // Player State
 TArray<FString> ULootLockerSDKManager::GetActivePlayerUlids()
@@ -1436,6 +1438,71 @@ FString ULootLockerSDKManager::SendUGCFeedback(const FString& Ulid, const FStrin
 {
     return ULootLockerFeedbackRequestHandler::SendFeedback(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), Ulid, Description, CategoryID, ELootLockerFeedbackType::Ugc, OnComplete);
 
+}
+
+FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseDelegate& OnComplete)
+{
+    if (FailedResponse.success)
+    {
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report for a successful response", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        OnComplete.ExecuteIfBound(Error);
+        return "";
+    }
+    if (FailedResponse.Context.RequestId.IsEmpty())
+    {
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report: failed response is missing request context", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        OnComplete.ExecuteIfBound(Error);
+        return "";
+    }
+    if (FailedResponse.StatusCode == 401)
+    {
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report for an unauthorized request (HTTP 401). Session token is invalid", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        OnComplete.ExecuteIfBound(Error);
+        return "";
+    }
+    if (FailedResponse.ErrorData.Retry_after_seconds > 0)
+    {
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>(FString::Printf(TEXT("Cannot send error report for a throttled request. Retry after %d seconds"), FailedResponse.ErrorData.Retry_after_seconds), LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        OnComplete.ExecuteIfBound(Error);
+        return "";
+    }
+    FLootLockerFailedRequestReport Report;
+    if (!ULootLockerHttpClient::TryGetFailedRequestReportForRequestId(FailedResponse.Context.RequestId, Report))
+    {
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>(FString::Printf(TEXT("Cannot send error report: no stored details found for request id %s. The request may have been evicted from history"), *FailedResponse.Context.RequestId), LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        OnComplete.ExecuteIfBound(Error);
+        return "";
+    }
+
+    Report.user_description = UserDescription;
+    FString ReportJsonString = LootLockerUtilities::UStructToJsonString(Report);
+    FLootLockerPlayerData PlayerData = GetSavedStateOrDefaultOrEmptyForPlayer(FailedResponse.Context.PlayerUlid);
+    FString PlayerUlid = FailedResponse.Context.PlayerUlid;
+
+    FString CategoryId = ULootLockerHttpClient::GetFailureFeedbackCategoryId();
+    if (CategoryId.Equals(TEXT("Not Initialized")))
+    {
+        ULootLockerHttpClient::RefreshFailureFeedbackCategoryId(
+            FLootLockerRefreshFailureFeedbackCategoryIdDelegate::CreateLambda([PlayerData, ReportJsonString, PlayerUlid, OnComplete](bool bFound)
+            {
+                if (!bFound)
+                {
+                    FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report because failure reporting is not enabled. Ensure a feedback category named 'lootlocker_request_failure' exists", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, PlayerUlid);
+                    OnComplete.ExecuteIfBound(Error);
+                    return;
+                }
+                ULootLockerFeedbackRequestHandler::SendFeedback(PlayerData, TEXT(""), ReportJsonString, ULootLockerHttpClient::GetFailureFeedbackCategoryId(), ELootLockerFeedbackType::Game, OnComplete);
+            })
+        );
+        return "";
+    }
+    if (CategoryId.IsEmpty())
+    {
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report because failure reporting is not enabled. Ensure a feedback category named 'lootlocker_request_failure' exists", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        OnComplete.ExecuteIfBound(Error);
+        return "";
+    }
+    return ULootLockerFeedbackRequestHandler::SendFeedback(PlayerData, TEXT(""), ReportJsonString, CategoryId, ELootLockerFeedbackType::Game, OnComplete);
 }
 
 // Metadata

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1460,9 +1460,9 @@ FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDesc
         OnComplete.ExecuteIfBound(Error);
         return "";
     }
-    if (FailedResponse.ErrorData.Retry_after_seconds > 0)
+    if (FailedResponse.StatusCode == 429)
     {
-        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>(FString::Printf(TEXT("Cannot send error report for a throttled request. Retry after %d seconds"), FailedResponse.ErrorData.Retry_after_seconds), LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
+        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report for a throttled request (HTTP 429)", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
         OnComplete.ExecuteIfBound(Error);
         return "";
     }
@@ -1479,22 +1479,37 @@ FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDesc
     FLootLockerPlayerData PlayerData = GetSavedStateOrDefaultOrEmptyForPlayer(FailedResponse.Context.PlayerUlid);
     FString PlayerUlid = FailedResponse.Context.PlayerUlid;
 
+    const FString DeferredRequestId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens);
+
     FString CategoryId = ULootLockerHttpClient::GetFailureFeedbackCategoryId();
     if (CategoryId.Equals(TEXT("Not Initialized")))
     {
         ULootLockerHttpClient::RefreshFailureFeedbackCategoryId(
-            FLootLockerRefreshFailureFeedbackCategoryIdDelegate::CreateLambda([PlayerData, ReportJsonString, PlayerUlid, OnComplete](bool bFound)
+            FLootLockerRefreshFailureFeedbackCategoryIdDelegate::CreateLambda([PlayerData, ReportJsonString, PlayerUlid, OnComplete, DeferredRequestId](bool bFound)
             {
                 if (!bFound)
                 {
                     FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report because failure reporting is not enabled. Ensure a feedback category named 'lootlocker_request_failure' exists", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, PlayerUlid);
+                    Error.Context.RequestId = DeferredRequestId;
                     OnComplete.ExecuteIfBound(Error);
                     return;
                 }
-                ULootLockerFeedbackRequestHandler::SendFeedback(PlayerData, TEXT(""), ReportJsonString, ULootLockerHttpClient::GetFailureFeedbackCategoryId(), ELootLockerFeedbackType::Game, OnComplete);
+                ULootLockerFeedbackRequestHandler::SendFeedback(
+                    PlayerData,
+                    TEXT(""),
+                    ReportJsonString,
+                    ULootLockerHttpClient::GetFailureFeedbackCategoryId(),
+                    ELootLockerFeedbackType::Game,
+                    FLootLockerSendFeedbackResponseDelegate::CreateLambda([OnComplete, DeferredRequestId](const FLootLockerResponse& Response)
+                    {
+                        FLootLockerResponse ResponseWithStableRequestId = Response;
+                        ResponseWithStableRequestId.Context.RequestId = DeferredRequestId;
+                        OnComplete.ExecuteIfBound(ResponseWithStableRequestId);
+                    })
+                );
             })
         );
-        return "";
+        return DeferredRequestId;
     }
     if (CategoryId.IsEmpty())
     {

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFailedRequestReport.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFailedRequestReport.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LootLockerFailedRequestReport.generated.h"
+
+/**
+ * Data structure for storing information about failed requests for the purpose of error reporting.
+ * This is not used for successful requests to avoid unnecessary memory usage.
+ */
+USTRUCT(BlueprintType)
+struct FLootLockerFailedRequestReport
+{
+    GENERATED_BODY()
+
+    /** Optional developer-provided description of the events leading up to the failure */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString user_description;
+    /** The unique client-generated identifier for the request */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString client_request_id;
+    /** The unique server-generated identifier for the request (from error data) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString server_request_id;
+    /** The unique trace identifier for the request (from error data) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString trace_id;
+    /** The HTTP status code returned by the server (or 0 if no response) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int32 status_code = 0;
+    /** The error message from the server or client */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString message;
+    /** The endpoint URL the request was sent to */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString endpoint;
+    /** The HTTP method used for the request */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString http_method;
+    /** The raw JSON body of the response (obfuscated) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString response_json_body;
+    /** The response headers returned by the server */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> response_headers;
+    /** The raw JSON body of the request (obfuscated) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString request_body;
+    /** The request headers that were sent (sensitive headers removed) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> request_headers;
+    /** The number of times the request was retried before ultimately failing */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int32 retry_attempts = 0;
+    /** The duration in seconds from when the request was first sent to when it ultimately failed */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    float request_duration_seconds = 0.0f;
+    /** The server timestamp from the Date response header (ISO 8601) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString server_timestamp;
+    /** The client-side timestamp of when the request was made (ISO 8601) */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString client_timestamp;
+    /** The ULID of the player for whom the request was made */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString player_ulid;
+};

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
@@ -3,11 +3,14 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "LootLockerFailedRequestReport.h"
 #include "LootLockerPlayerData.h"
 #include "LootLockerRequestContext.h"
 #include "LootLockerResponse.h"
 #include "Interfaces/IHttpRequest.h"
 #include "LootLockerHttpClient.generated.h"
+
+DECLARE_DELEGATE_OneParam(FLootLockerRefreshFailureFeedbackCategoryIdDelegate, bool);
 
 UCLASS()
 class LOOTLOCKERSDK_API ULootLockerHttpClient : public UObject
@@ -21,6 +24,32 @@ public:
 
     static void LogSuccessfulRequestInformation(const FLootLockerResponse& Response, const FString& AllHeadersDelimited);
     static void LogFailedRequestInformation(const FLootLockerResponse& Response, const FString& AllHeadersDelimited);
+
+    // === Failure Reporting ===
+
+    /**
+     * Returns whether failure reporting is currently enabled.
+     * Failure reporting is enabled when a feedback category named "lootlocker_request_failure" has been found.
+     */
+    static bool IsFailureReportingEnabled();
+
+    /**
+     * Returns the feedback category id used for failure reporting, or an empty string if disabled.
+     */
+    static FString GetFailureFeedbackCategoryId();
+
+    /**
+     * Looks up the "lootlocker_request_failure" feedback category and caches its id for future use.
+     * Invokes OnComplete with true if the category was found, false otherwise.
+     */
+    static void RefreshFailureFeedbackCategoryId(const FLootLockerRefreshFailureFeedbackCategoryIdDelegate& OnComplete);
+
+    /**
+     * Attempts to retrieve the stored failure report for a given client request id.
+     * Returns true and populates OutReport if found, otherwise returns false.
+     */
+    static bool TryGetFailedRequestReportForRequestId(const FString& RequestId, FLootLockerFailedRequestReport& OutReport);
+
 private:
     static bool ResponseIsSuccess(const FHttpResponsePtr& InResponse, bool bWasSuccessful);
     
@@ -63,7 +92,14 @@ private:
     };
     
     static void RetryOriginalRequest(const FLootLockerRetryRequestData& RetryData);
-    
+
+    // === Failure Reporting (private) ===
+    static void StoreFailedRequestReport(const FLootLockerResponse& FailedResponse, const FString& RequestBody, const TArray<FString>& AllRequestHeaders, const FHttpResponsePtr& HttpResponse, int32 RetryAttempts, const FDateTime& RequestStartTime);
+
+    static TArray<FLootLockerFailedRequestReport> FailedRequestHistory;
+    static FString LootLockerFailureFeedbackCategoryId;
+    static constexpr int32 MaxFailedRequestHistory = 30;
+
     static const FString UserAgent;
     static const FString UserInstanceIdentifier;
     static FString SDKVersion;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -3651,6 +3651,22 @@ public:
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Feedback", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString SendUGCFeedback(const FString& ForPlayerWithUlid, const FString& Ulid, const FString& Description, const FString& CategoryID, const FLootLockerSendFeedbackResponseBP& OnComplete);
 
+    /**
+     Send a report about a failed LootLocker request to be viewable in the LootLocker dashboard.
+
+     This is intended for cases where a request fails and you want to report the details to LootLocker for debugging.
+     It will not work for successful requests, unauthorized requests (HTTP 401), or throttled requests (HTTP 429).
+     The request must have failed with a server response containing error details.
+     Requires a feedback category named "lootlocker_request_failure" to exist in the game's feedback categories.
+
+    @param UserDescription Optional description from the developer or player about the circumstances of the failure
+    @param FailedResponse The response from the failed request to report
+    @param OnComplete Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Feedback")
+    static UPARAM(DisplayName = "RequestId") FString SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseBP& OnComplete);
+
     //==================================================
     // Metadata
     //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -3320,6 +3320,21 @@ public:
     */
     static FString SendUGCFeedback(const FString & Ulid, const FString & Description, const FString & CategoryID, const FLootLockerSendFeedbackResponseDelegate & OnComplete, const FString& ForPlayerWithUlid = "");
 
+    /**
+     Send a report about a failed LootLocker request to be viewable in the LootLocker dashboard.
+
+     This is intended for cases where a request fails and you want to report the details to LootLocker for debugging.
+     It will not work for successful requests, unauthorized requests (HTTP 401), or throttled requests (HTTP 429).
+     The request must have failed with a server response containing error details.
+     Requires a feedback category named "lootlocker_request_failure" to exist in the game's feedback categories.
+
+     @param UserDescription Optional description from the developer or player about the circumstances of the failure
+     @param FailedResponse The response from the failed request to report
+     @param OnComplete Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseDelegate& OnComplete);
+
     /// @}
 
     //==================================================


### PR DESCRIPTION
## Tracking issue

<!-- Link the relevant lootlocker/index issue. Use "Closes lootlocker/index#NNN" to auto-close, or paste a plain URL. -->

Closes lootlocker/index#1473
Mimics https://github.com/lootlocker/unity-sdk/pull/452

---

## Description

Added functionality to send a failed LootLocker Response as a pre-structured feedback entry to LootLocker.
