### PR TITLE
fix: Sanitize SDK error messages to remove LootLocker-specific wording

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -577,7 +577,7 @@ void ULootLockerHttpClient::RefreshFailureFeedbackCategoryId(const FLootLockerRe
                 }
             }
             LootLockerFailureFeedbackCategoryId = TEXT("");
-            FLootLockerLogger::LogVerbose(TEXT("Failed to find appropriate category to send error report under. Feedback categories retrieved successfully but no category with name 'lootlocker_request_failure' was found. LootLocker Error reporting turned off"));
+            FLootLockerLogger::LogVerbose(TEXT("Failed to find appropriate category to send error report under. Feedback categories retrieved successfully but no category with name 'lootlocker_request_failure' was found. Error reporting turned off"));
             OnComplete.ExecuteIfBound(false);
         }),
         DefaultPlayerUlid

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -2139,7 +2139,7 @@ void ULootLockerManager::ParseLootLockerMetadataEntry(const FLootLockerMetadataE
             MetadataTypeSwitch = ELootLockerMetadataParserOutputTypes::OnBase64;
             return;
         }
-        ErrorMessage = "Could not parse value \"" + ValueToParse + "\" because it is not a valid LootLocker Metadata Base64 Object";
+        ErrorMessage = "Could not parse value \"" + ValueToParse + "\" because it is not a valid Metadata Base64 Object";
         return;
     }
     default:

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPresenceClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerPresenceClient.cpp
@@ -545,7 +545,7 @@ void ULootLockerPresenceClient::OnMessage(const FString& Message)
     }
     else if (Message.Contains(TEXT("presence is not enabled")))
     {
-        FString ErrorMessage = FString::Printf(TEXT("Presence is not enabled for this game. Please enable it in the LootLocker console to use this feature."), *PlayerUlid);
+        FString ErrorMessage = FString::Printf(TEXT("Presence is not enabled for this game. Please have an administrator enable this feature."), *PlayerUlid);
         FLootLockerLogger::LogWarning(ErrorMessage);
         Disconnect(FLootLockerPresenceCallbackDelegate::CreateLambda([this, ErrorMessage](bool bSuccess, const FString& Message)
         {


### PR DESCRIPTION
## Summary

Addresses https://github.com/lootlocker/index/issues/1438 (duplicate: https://github.com/lootlocker/index/issues/1392).

Customers sometimes show SDK error messages directly to end users, who are unaware of LootLocker as a middleware provider. This PR replaces LootLocker-branded strings in user-surfaced error messages with neutral, end-user-friendly wording.

## Changes

| File | Change |
|------|--------|
| `Private/LootLockerPresenceClient.cpp` | Replace `"enable it in the LootLocker console"` with `"have an administrator enable this feature"` in presence-not-enabled error |
| `Private/LootLockerManager.cpp` | Remove `"LootLocker"` prefix from metadata Base64 parse error |
| `Private/LootLockerHttpClient.cpp` | Remove `"LootLocker Error reporting"` from verbose internal log |