### PR TITLE
feat(error-report): add dedicated error report endpoint (#1480)

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/LootLockerSDK.Build.cs
+++ b/LootLockerSDK/Source/LootLockerSDK/LootLockerSDK.Build.cs
@@ -6,6 +6,7 @@ public class LootLockerSDK : ModuleRules
 {
     public static bool bEnableGoogleSubsystemHelper = false;
     public static bool bShowOutdatedSDKMessage = false; // Set to true when submitting to fab for engine versions < the last 3
+    public static bool bEnableBetaErrorReporting = false;
     public LootLockerSDK(ReadOnlyTargetRules Target) : base(Target)
     {
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
@@ -70,6 +71,10 @@ public class LootLockerSDK : ModuleRules
         if (bShowOutdatedSDKMessage)
         {
 	        PublicDefinitions.Add("LOOTLOCKER_SHOW_OUTDATED_SDK_MESSAGE=1");
+        }
+        if (bEnableBetaErrorReporting)
+        {
+            PublicDefinitions.Add("LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING=1");
         }
     }
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerErrorReportRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerErrorReportRequestHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "GameAPI/LootLockerErrorReportRequestHandler.h"
 #include "LootLockerGameEndpoints.h"
+#include "Utils/LootLockerUtilities.h"
 
 FString ULootLockerErrorReportRequestHandler::ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerResponseDelegate& OnComplete)
 {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerErrorReportRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerErrorReportRequestHandler.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2021 LootLocker
+
+#include "GameAPI/LootLockerErrorReportRequestHandler.h"
+#include "LootLockerGameEndpoints.h"
+
+FString ULootLockerErrorReportRequestHandler::ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerResponseDelegate& OnComplete)
+{
+    return LLAPI<FLootLockerResponse>::CallAPI(Report, ULootLockerGameEndpoints::ReportSDKError, {}, {}, PlayerData, OnComplete);
+}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerErrorReportRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerErrorReportRequestHandler.cpp
@@ -4,7 +4,7 @@
 #include "LootLockerGameEndpoints.h"
 #include "Utils/LootLockerUtilities.h"
 
-FString ULootLockerErrorReportRequestHandler::ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerResponseDelegate& OnComplete)
+FString ULootLockerErrorReportRequestHandler::ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerSendErrorReportDelegate& OnComplete)
 {
     return LLAPI<FLootLockerResponse>::CallAPI(Report, ULootLockerGameEndpoints::ReportSDKError, {}, {}, PlayerData, OnComplete);
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -289,6 +289,9 @@ FLootLockerEndPoints ULootLockerGameEndpoints::Crashes = InitEndpoint("v1/crash"
 FLootLockerEndPoints ULootLockerGameEndpoints::ListFeedbackCategories = InitEndpoint("feedback/category/entity/{0}", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::SendFeedback = InitEndpoint("feedback", ELootLockerHTTPMethod::POST);
 
+// Error Reporting
+FLootLockerEndPoints ULootLockerGameEndpoints::ReportSDKError = InitEndpoint("error-report", ELootLockerHTTPMethod::POST);
+
 // Metadata
 FLootLockerEndPoints ULootLockerGameEndpoints::ListMetadata = InitEndpoint("metadata/source/{0}/id/{1}", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::GetMultisourceMetadata = InitEndpoint("metadata/multisource", ELootLockerHTTPMethod::POST);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -599,11 +599,6 @@ bool ULootLockerHttpClient::TryGetFailedRequestReportForRequestId(const FString&
 
 void ULootLockerHttpClient::StoreFailedRequestReport(const FLootLockerResponse& FailedResponse, const FString& RequestBody, const TArray<FString>& AllRequestHeaders, const FHttpResponsePtr& HttpResponse, int32 RetryAttempts, const FDateTime& RequestStartTime)
 {
-    if (LootLockerFailureFeedbackCategoryId.IsEmpty())
-    {
-        // Failure reporting is disabled
-        return;
-    }
     if (FailedResponse.StatusCode == 401)
     {
         FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Request unauthorized - cannot construct valid error report for a request that was unauthorized. Player ULID: %s"), *FailedResponse.Context.PlayerUlid));

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -151,7 +151,9 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
                 return; // Don't call the original callback yet
             }
 
+#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
             StoreFailedRequestReport(response, data, AllHeaders, Response, RetryAttemptCount, requestStartTime);
+#endif
 		}
         else
         {
@@ -310,7 +312,9 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
                     return; // Don't call the original callback yet
                 }
 
+#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING                
                 StoreFailedRequestReport(response, FString(), AllHeaders, Response, RetryAttemptCount, requestStartTime);
+#endif
             }
     		else
             {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -681,3 +681,7 @@ void ULootLockerHttpClient::StoreFailedRequestReport(const FLootLockerResponse& 
     FailedRequestHistory[OldestIndex] = Report;
 }
 
+FString ULootLockerHttpClient::GetSDKVersion()
+{
+    return SDKVersion;
+}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -151,7 +151,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
                 return; // Don't call the original callback yet
             }
 
-#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
+#ifdef LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
             StoreFailedRequestReport(response, data, AllHeaders, Response, RetryAttemptCount, requestStartTime);
 #endif
 		}
@@ -312,7 +312,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
                     return; // Don't call the original callback yet
                 }
 
-#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING                
+#ifdef LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING                
                 StoreFailedRequestReport(response, FString(), AllHeaders, Response, RetryAttemptCount, requestStartTime);
 #endif
             }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1952,7 +1952,7 @@ FString ULootLockerManager::SendUGCFeedback(const FString& ForPlayerWithUlid, co
 
 FString ULootLockerManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseBP& OnComplete)
 {
-    return ULootLockerSDKManager::SendLootLockerErrorReport(UserDescription, FailedResponse, FLootLockerSendFeedbackResponseDelegate::CreateLambda([OnComplete](const FLootLockerResponse& Response)
+    return ULootLockerSDKManager::SendLootLockerErrorReport(UserDescription, FailedResponse, FLootLockerSendErrorReportDelegate::CreateLambda([OnComplete](const FLootLockerResponse& Response)
     {
         OnComplete.ExecuteIfBound(Response);
     }));

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1410,6 +1410,7 @@ FString ULootLockerSDKManager::SendUGCFeedback(const FString& Ulid, const FStrin
 
 FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendErrorReportDelegate& OnComplete)
 {
+#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
     if (FailedResponse.success)
     {
         FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report for a successful response", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
@@ -1464,6 +1465,11 @@ FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDesc
 
     FLootLockerPlayerData PlayerData = GetSavedStateOrDefaultOrEmptyForPlayer(FailedResponse.Context.PlayerUlid);
     return ULootLockerErrorReportRequestHandler::ReportSDKError(PlayerData, RequestBody, OnComplete);
+#else
+    FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Error reporting is not enabled for this build. To enable, define LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING and ensure the game is configured for the feature in the console.", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_FEATURE_NOT_ENABLED, FailedResponse.Context.PlayerUlid);
+    OnComplete.ExecuteIfBound(Error);
+    return "";
+#endif
 }
 
 // Metadata

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1410,7 +1410,7 @@ FString ULootLockerSDKManager::SendUGCFeedback(const FString& Ulid, const FStrin
 
 FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendErrorReportDelegate& OnComplete)
 {
-#if LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
+#ifdef LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING
     if (FailedResponse.success)
     {
         FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report for a successful response", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
@@ -1466,7 +1466,7 @@ FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDesc
     FLootLockerPlayerData PlayerData = GetSavedStateOrDefaultOrEmptyForPlayer(FailedResponse.Context.PlayerUlid);
     return ULootLockerErrorReportRequestHandler::ReportSDKError(PlayerData, RequestBody, OnComplete);
 #else
-    FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Error reporting is not enabled for this build. To enable, define LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING and ensure the game is configured for the feature in the console.", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_FEATURE_NOT_ENABLED, FailedResponse.Context.PlayerUlid);
+    FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Error reporting is not enabled for this build. To enable, define LOOTLOCKER_BETA_ENABLE_ERROR_REPORTING and ensure the game is configured for the feature in the console.", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
     OnComplete.ExecuteIfBound(Error);
     return "";
 #endif

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1408,7 +1408,7 @@ FString ULootLockerSDKManager::SendUGCFeedback(const FString& Ulid, const FStrin
 
 }
 
-FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseDelegate& OnComplete)
+FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendErrorReportDelegate& OnComplete)
 {
     if (FailedResponse.success)
     {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1460,7 +1460,7 @@ FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDesc
     RequestBody.server_timestamp = Report.server_timestamp;
     RequestBody.client_timestamp = Report.client_timestamp;
     RequestBody.player_ulid = Report.player_ulid;
-    RequestBody.sdk_version = ULootLockerHttpClient::SDKVersion;
+    RequestBody.sdk_version = ULootLockerHttpClient::GetSDKVersion();
 
     FLootLockerPlayerData PlayerData = GetSavedStateOrDefaultOrEmptyForPlayer(FailedResponse.Context.PlayerUlid);
     return ULootLockerErrorReportRequestHandler::ReportSDKError(PlayerData, RequestBody, OnComplete);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1442,50 +1442,28 @@ FString ULootLockerSDKManager::SendLootLockerErrorReport(const FString& UserDesc
         return "";
     }
 
-    Report.user_description = UserDescription;
-    FString ReportJsonString = LootLockerUtilities::UStructToJsonString(Report);
+    FLootLockerErrorReportRequest RequestBody;
+    RequestBody.user_description = UserDescription;
+    RequestBody.client_request_id = Report.client_request_id;
+    RequestBody.server_request_id = Report.server_request_id;
+    RequestBody.trace_id = Report.trace_id;
+    RequestBody.status_code = Report.status_code;
+    RequestBody.message = Report.message;
+    RequestBody.endpoint = Report.endpoint;
+    RequestBody.http_method = Report.http_method;
+    RequestBody.response_json_body = Report.response_json_body;
+    RequestBody.response_headers = Report.response_headers;
+    RequestBody.request_body = Report.request_body;
+    RequestBody.request_headers = Report.request_headers;
+    RequestBody.retry_attempts = Report.retry_attempts;
+    RequestBody.request_duration_seconds = Report.request_duration_seconds;
+    RequestBody.server_timestamp = Report.server_timestamp;
+    RequestBody.client_timestamp = Report.client_timestamp;
+    RequestBody.player_ulid = Report.player_ulid;
+    RequestBody.sdk_version = ULootLockerHttpClient::SDKVersion;
+
     FLootLockerPlayerData PlayerData = GetSavedStateOrDefaultOrEmptyForPlayer(FailedResponse.Context.PlayerUlid);
-    FString PlayerUlid = FailedResponse.Context.PlayerUlid;
-
-    const FString DeferredRequestId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens);
-
-    FString CategoryId = ULootLockerHttpClient::GetFailureFeedbackCategoryId();
-    if (CategoryId.Equals(TEXT("Not Initialized")))
-    {
-        ULootLockerHttpClient::RefreshFailureFeedbackCategoryId(
-            FLootLockerRefreshFailureFeedbackCategoryIdDelegate::CreateLambda([PlayerData, ReportJsonString, PlayerUlid, OnComplete, DeferredRequestId](bool bFound)
-            {
-                if (!bFound)
-                {
-                    FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report because failure reporting is not enabled. Ensure a feedback category named 'lootlocker_request_failure' exists", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, PlayerUlid);
-                    Error.Context.RequestId = DeferredRequestId;
-                    OnComplete.ExecuteIfBound(Error);
-                    return;
-                }
-                ULootLockerFeedbackRequestHandler::SendFeedback(
-                    PlayerData,
-                    TEXT(""),
-                    ReportJsonString,
-                    ULootLockerHttpClient::GetFailureFeedbackCategoryId(),
-                    ELootLockerFeedbackType::Game,
-                    FLootLockerSendFeedbackResponseDelegate::CreateLambda([OnComplete, DeferredRequestId](const FLootLockerResponse& Response)
-                    {
-                        FLootLockerResponse ResponseWithStableRequestId = Response;
-                        ResponseWithStableRequestId.Context.RequestId = DeferredRequestId;
-                        OnComplete.ExecuteIfBound(ResponseWithStableRequestId);
-                    })
-                );
-            })
-        );
-        return DeferredRequestId;
-    }
-    if (CategoryId.IsEmpty())
-    {
-        FLootLockerResponse Error = LootLockerResponseFactory::Error<FLootLockerResponse>("Cannot send error report because failure reporting is not enabled. Ensure a feedback category named 'lootlocker_request_failure' exists", LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT, FailedResponse.Context.PlayerUlid);
-        OnComplete.ExecuteIfBound(Error);
-        return "";
-    }
-    return ULootLockerFeedbackRequestHandler::SendFeedback(PlayerData, TEXT(""), ReportJsonString, CategoryId, ELootLockerFeedbackType::Game, OnComplete);
+    return ULootLockerErrorReportRequestHandler::ReportSDKError(PlayerData, RequestBody, OnComplete);
 }
 
 // Metadata

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerErrorReportRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerErrorReportRequestHandler.h
@@ -5,7 +5,6 @@
 #include "CoreMinimal.h"
 #include "LootLockerResponse.h"
 #include "LootLockerPlayerData.h"
-#include "LootLockerFailedRequestReport.h"
 #include "LootLockerErrorReportRequestHandler.generated.h"
 
 //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerErrorReportRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerErrorReportRequestHandler.h
@@ -58,6 +58,8 @@ struct FLootLockerErrorReportRequest
 // Handler
 //==================================================
 
+DECLARE_DELEGATE_OneParam(FLootLockerSendErrorReportDelegate, FLootLockerResponse);
+
 UCLASS()
 class LOOTLOCKERSDK_API ULootLockerErrorReportRequestHandler : public UObject
 {
@@ -70,5 +72,5 @@ public:
      * @param OnComplete Delegate called when the request completes
      * @return A unique id for this request used to match callbacks
      */
-    static FString ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerResponseDelegate& OnComplete);
+    static FString ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerSendErrorReportDelegate& OnComplete);
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerErrorReportRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerErrorReportRequestHandler.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LootLockerResponse.h"
+#include "LootLockerPlayerData.h"
+#include "LootLockerFailedRequestReport.h"
+#include "LootLockerErrorReportRequestHandler.generated.h"
+
+//==================================================
+// Request Definitions
+//==================================================
+
+USTRUCT(BlueprintType)
+struct FLootLockerErrorReportRequest
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString user_description;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString client_request_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString server_request_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString trace_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int32 status_code = 0;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString message;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString endpoint;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString http_method;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString response_json_body;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> response_headers;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString request_body;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> request_headers;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int32 retry_attempts = 0;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    float request_duration_seconds = 0.0f;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString server_timestamp;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString client_timestamp;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString player_ulid;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString sdk_version;
+};
+
+//==================================================
+// Handler
+//==================================================
+
+UCLASS()
+class LOOTLOCKERSDK_API ULootLockerErrorReportRequestHandler : public UObject
+{
+    GENERATED_BODY()
+public:
+    /**
+     * Send a report about a failed LootLocker request to the dedicated error-report endpoint.
+     * @param PlayerData Player session data used to authenticate the request
+     * @param Report Report data populated from the failed request history
+     * @param OnComplete Delegate called when the request completes
+     * @return A unique id for this request used to match callbacks
+     */
+    static FString ReportSDKError(const FLootLockerPlayerData& PlayerData, const FLootLockerErrorReportRequest& Report, const FLootLockerResponseDelegate& OnComplete);
+};

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -328,6 +328,9 @@ public:
     static FLootLockerEndPoints ListFeedbackCategories;
     static FLootLockerEndPoints SendFeedback;
 
+    // Error Reporting
+    static FLootLockerEndPoints ReportSDKError;
+
     // Metadata
     static FLootLockerEndPoints ListMetadata;
     static FLootLockerEndPoints GetMultisourceMetadata;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerHttpClient.h
@@ -50,6 +50,8 @@ public:
      */
     static bool TryGetFailedRequestReportForRequestId(const FString& RequestId, FLootLockerFailedRequestReport& OutReport);
 
+    static FString GetSDKVersion();
+
 private:
     static bool ResponseIsSuccess(const FHttpResponsePtr& InResponse, bool bWasSuccessful);
     

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -3256,7 +3256,7 @@ public:
      @param OnComplete Delegate for handling the server response
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
     */
-    static FString SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendFeedbackResponseDelegate& OnComplete);
+    static FString SendLootLockerErrorReport(const FString& UserDescription, const FLootLockerResponse& FailedResponse, const FLootLockerSendErrorReportDelegate& OnComplete);
 
     /// @}
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -14,6 +14,7 @@
 #include "GameAPI/LootLockerCurrencyRequestHandler.h"
 #include "GameAPI/LootLockerDropTablesRequestHandler.h"
 #include "GameAPI/LootLockerEntitlementRequestHandler.h"
+#include "GameAPI/LootLockerErrorReportRequestHandler.h"
 #include "GameAPI/LootLockerFeedbackRequestHandler.h"
 #include "GameAPI/LootLockerFollowersRequestHandler.h"
 #include "GameAPI/LootLockerFriendsRequestHandler.h"
@@ -3249,7 +3250,6 @@ public:
      This is intended for cases where a request fails and you want to report the details to LootLocker for debugging.
      It will not work for successful requests, unauthorized requests (HTTP 401), or throttled requests (HTTP 429).
      The request must have failed with a server response containing error details.
-     Requires a feedback category named "lootlocker_request_failure" to exist in the game's feedback categories.
 
      @param UserDescription Optional description from the developer or player about the circumstances of the failure
      @param FailedResponse The response from the failed request to report


### PR DESCRIPTION
## Summary

Replaces the feedback-based error reporting path with a direct call to the new dedicated `error-report` POST endpoint, matching the Unity SDK implementation.

## Changes

- **New**: `LootLockerErrorReportRequestHandler.h/.cpp` — `FLootLockerErrorReportRequest` struct and `ULootLockerErrorReportRequestHandler::ReportSDKError()` handler
- **New endpoint**: `ULootLockerGameEndpoints::ReportSDKError` → `POST error-report`
- **Updated**: `SendLootLockerErrorReport` in `LootLockerSDKManager` now calls the dedicated endpoint directly instead of going through the feedback category system
- **Removed**: dependency on feedback category lookup, deferred request flow, and `lootlocker_request_failure` category requirement
- Includes `sdk_version` in the report payload (sourced from `ULootLockerHttpClient::SDKVersion`)

## Related

Closes #1480 (Unreal SDK part)
Unity SDK PR: lootlocker/unity-sdk#459
Go backend PR: lootlocker/go-backend#631