### PR TITLE
feat: add Non_refundable field to FLootLockerCatalogEntry (#1420)

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
@@ -404,6 +404,11 @@ struct FLootLockerCatalogEntry
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Purchasable = false;
+    /**
+     * Whether this entry is refundable. If false, purchases of this entry cannot be refunded.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool Non_refundable = false;
 
 };
 


### PR DESCRIPTION
## Summary

Exposes the `Non_refundable` boolean field on `FLootLockerCatalogEntry`, which the backend already returns in catalog item responses.

## Changes

- `LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h`: Added `Non_refundable` UPROPERTY to `FLootLockerCatalogEntry` with Doxygen comment

## Related

Closes #1420 (tracked via lootlocker/index#1420)