### PR TITLE
feat: configurable multi-user session mode

### DIFF
--- a/.github/scripts/run-tests.ps1
+++ b/.github/scripts/run-tests.ps1
@@ -19,16 +19,28 @@
     starts with "LootLocker.", so the default "LootLocker" runs all of them.
     Use a more specific substring to run a subset — e.g. "LootLocker.Balances".
 
+.PARAMETER NoBuild
+    Skip the BuildPlugin step and reuse the previously built binaries. Useful
+    for iterating on tests without waiting for a full rebuild. Ignored (build
+    always runs) when -Clean is also specified.
+
 .PARAMETER Clean
     Delete the previous build output before building. Omit for a faster
-    incremental build (UAT reuses cached artifacts).
+    incremental build (UAT reuses cached artifacts). Overrides -NoBuild.
+
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for UnrealEditor-Cmd.exe to exit after tests finish.
+    If exceeded the process is killed and the run is reported as failed.
+    Defaults to 600 (10 minutes).
 
 .NOTES
     Exit codes: 0 = all tests passed, 1 = one or more tests failed or setup error.
 #>
 param(
     [string]$TestFilter = "LootLocker",
-    [switch]$Clean
+    [switch]$NoBuild,
+    [switch]$Clean,
+    [int]$TimeoutSeconds = 600
 )
 
 $ErrorActionPreference = 'Stop'
@@ -89,27 +101,15 @@ if (-not $PluginFile) {
     exit 1
 }
 
+$ShouldBuild = $Clean -or (-not $NoBuild)
+
 # ---------------------------------------------------------------------------
-# 2. Temporarily disable UBA (same reason as in verify-compilation.ps1)
+# 2. Temporarily disable UBA + 3. Build the plugin
 # ---------------------------------------------------------------------------
 $UbtConfigDir    = Join-Path $env:APPDATA "Unreal Engine\UnrealBuildTool"
 $UbtConfigFile   = Join-Path $UbtConfigDir "BuildConfiguration.xml"
 $UbtConfigBackup = $UbtConfigFile + ".run-tests-backup"
 $WroteUbtConfig  = $false
-
-if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
-if (Test-Path $UbtConfigFile) { Copy-Item $UbtConfigFile $UbtConfigBackup -Force }
-
-$noUbaXml = @'
-<?xml version="1.0" encoding="utf-8" ?>
-<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
-  <BuildConfiguration>
-    <bAllowUBAExecutor>false</bAllowUBAExecutor>
-  </BuildConfiguration>
-</Configuration>
-'@
-[IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
-$WroteUbtConfig = $true
 
 function Restore-UbtConfig {
     if ($script:WroteUbtConfig) {
@@ -122,72 +122,93 @@ function Restore-UbtConfig {
     }
 }
 
-Write-Step "Note: Disabled UBA local executor (restored after tests)."
-Write-Step ""
+if ($ShouldBuild) {
+    # Temporarily disable UBA (same reason as in verify-compilation.ps1)
+    if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
+    if (Test-Path $UbtConfigFile) { Copy-Item $UbtConfigFile $UbtConfigBackup -Force }
 
-# ---------------------------------------------------------------------------
-# 3. Build the plugin (ensures the latest test code is compiled into binaries)
-# ---------------------------------------------------------------------------
-Write-Step "Step 1/3 - Building plugin via RunUAT BuildPlugin ..."
-Write-Step "Plugin  : $($PluginFile.FullName)"
-Write-Step "Engine  : $UnrealRoot"
-Write-Step "Output  : $BuildOutput"
-Write-Step ""
+    $noUbaXml = @'
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+  </BuildConfiguration>
+</Configuration>
+'@
+    [IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
+    $WroteUbtConfig = $true
+    Write-Step "Note: Disabled UBA local executor (restored after tests)."
+    Write-Step ""
 
-$BuildLogDir = Split-Path $BuildLog
-if (-not (Test-Path $BuildLogDir)) { New-Item -ItemType Directory -Path $BuildLogDir -Force | Out-Null }
-if (Test-Path $BuildLog) { Remove-Item $BuildLog -Force }
+    # Build the plugin (ensures the latest test code is compiled into binaries)
+    Write-Step "Step 1/3 - Building plugin via RunUAT BuildPlugin ..."
+    Write-Step "Plugin  : $($PluginFile.FullName)"
+    Write-Step "Engine  : $UnrealRoot"
+    Write-Step "Output  : $BuildOutput"
+    Write-Step ""
 
-if ($Clean) {
-    if (Test-Path $BuildOutput) {
-        Write-Step "Cleaning previous build output..."
-        & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+    $BuildLogDir = Split-Path $BuildLog
+    if (-not (Test-Path $BuildLogDir)) { New-Item -ItemType Directory -Path $BuildLogDir -Force | Out-Null }
+    if (Test-Path $BuildLog) { Remove-Item $BuildLog -Force }
+
+    if ($Clean) {
         if (Test-Path $BuildOutput) {
-            Write-Warn "Warning: Could not fully remove previous build output - UAT will attempt to overwrite."
+            Write-Step "Cleaning previous build output..."
+            & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+            if (Test-Path $BuildOutput) {
+                Write-Warn "Warning: Could not fully remove previous build output - UAT will attempt to overwrite."
+            }
         }
+    } elseif (Test-Path $BuildOutput) {
+        Write-Step "Reusing existing build output (pass -Clean to force a full rebuild)."
     }
-} elseif (Test-Path $BuildOutput) {
-    Write-Step "Reusing existing build output (pass -Clean to force a full rebuild)."
-}
 
-$prevEAP = $ErrorActionPreference
-$ErrorActionPreference = 'Continue'
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
 
-$buildLines  = [System.Collections.Generic.List[string]]::new()
-$buildStream = [System.IO.StreamWriter]::new($BuildLog, $false, [System.Text.Encoding]::UTF8)
+    $buildLines  = [System.Collections.Generic.List[string]]::new()
+    $buildStream = [System.IO.StreamWriter]::new($BuildLog, $false, [System.Text.Encoding]::UTF8)
 
-$uatArgs = @(
-    "BuildPlugin"
-    "-Plugin=`"$($PluginFile.FullName)`""
-    "-Package=`"$BuildOutput`""
-    "-Rocket"
-    "-TargetPlatforms=Win64"
-    "-VS2022"
-)
+    $uatArgs = @(
+        "BuildPlugin"
+        "-Plugin=`"$($PluginFile.FullName)`""
+        "-Package=`"$BuildOutput`""
+        "-Rocket"
+        "-TargetPlatforms=Win64"
+        "-VS2022"
+    )
 
-try {
-    & $RunUAT @uatArgs 2>&1 | ForEach-Object {
-        $line = "$_"
-        $buildLines.Add($line)
-        $buildStream.WriteLine($line)
-        $buildStream.Flush()
-        Write-Host $line
+    try {
+        & $RunUAT @uatArgs 2>&1 | ForEach-Object {
+            $line = "$_"
+            $buildLines.Add($line)
+            $buildStream.WriteLine($line)
+            $buildStream.Flush()
+            Write-Host $line
+        }
+    } finally {
+        $buildStream.Close()
     }
-} finally {
-    $buildStream.Close()
-}
-$buildExit = $LASTEXITCODE
-$ErrorActionPreference = $prevEAP
+    $buildExit = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
 
-if ($buildExit -ne 0) {
-    Restore-UbtConfig
-    Write-Fail "BUILD FAILED - cannot run tests without compiled binaries."
-    Write-Step "Full build log: $BuildLog"
-    exit 1
+    if ($buildExit -ne 0) {
+        Restore-UbtConfig
+        Write-Fail "BUILD FAILED - cannot run tests without compiled binaries."
+        Write-Step "Full build log: $BuildLog"
+        exit 1
+    }
+    Write-Step ""
+    Write-Ok "Plugin built successfully."
+    Write-Step ""
+} else {
+    if (-not (Test-Path $BuildOutput)) {
+        Write-Fail "ERROR: No previous build found at $BuildOutput - run without -NoBuild first."
+        exit 1
+    }
+    Write-Warn "Skipping build (-NoBuild). Reusing existing binaries in: $BuildOutput"
+    Write-Step ""
 }
-Write-Step ""
-Write-Ok "Plugin built successfully."
-Write-Step ""
 
 # ---------------------------------------------------------------------------
 # 4. Set up VerificationProject pointing at the compiled plugin output
@@ -248,7 +269,10 @@ $TestLogDir = Split-Path $TestLog
 if (-not (Test-Path $TestLogDir)) { New-Item -ItemType Directory -Path $TestLogDir -Force | Out-Null }
 if (Test-Path $TestLog) { Remove-Item $TestLog -Force }
 
-$execCmd    = "automation RunTests $TestFilter;quit"
+# UE's -ExecCmds treats ',' as a command separator, so translate to '+' which
+# is the automation system's own OR-filter separator.
+$automationFilter = $TestFilter -replace ',', '+'
+$execCmd    = "automation RunTests $automationFilter;quit"
 $editorArgs = @(
     "`"$ProjectFile`""
     "-unattended"
@@ -256,29 +280,90 @@ $editorArgs = @(
     "-nosound"
     "-NoSplash"
     "-NoPause"
+    "-NoTargetPlatforms"
     "-stdout"
     "-FullStdOutLogOutput"
     "-SkipBadPlugins"
+    "-LogCmds=`"LogTemp Verbose`""
     "-ExecCmds=`"$execCmd`""
 )
 
+$prevEAP = $ErrorActionPreference
 $ErrorActionPreference = 'Continue'
 $outputLines = [System.Collections.Generic.List[string]]::new()
 $testStream  = [System.IO.StreamWriter]::new($TestLog, $false, [System.Text.Encoding]::UTF8)
+$timedOut    = $false
+
+# Run the editor inside a separate runspace so the main thread can enforce a
+# hard timeout. We keep PowerShell's native & call operator (not
+# ProcessStartInfo redirection) so UE's -stdout/-FullStdOutLogOutput flags
+# work correctly — UE suppresses output when stdout is redirected at the OS level.
+$outputQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+$ueRunspace  = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace()
+$ueRunspace.Open()
+$ueRunspace.SessionStateProxy.SetVariable('EditorCmd',   $EditorCmd)
+$ueRunspace.SessionStateProxy.SetVariable('editorArgs',  $editorArgs)
+$ueRunspace.SessionStateProxy.SetVariable('outputQueue', $outputQueue)
+
+$uePowerShell = [System.Management.Automation.PowerShell]::Create()
+$uePowerShell.Runspace = $ueRunspace
+[void]$uePowerShell.AddScript({
+    & $EditorCmd @editorArgs 2>&1 | ForEach-Object { $outputQueue.Enqueue("$_") }
+})
+
+# Snapshot existing UE pids so we can kill only our new instance on timeout.
+$priorUEPids = @(Get-Process -Name "UnrealEditor-Cmd" -ErrorAction SilentlyContinue |
+                 Select-Object -ExpandProperty Id)
+$ueProc   = $null
+$ueHandle = $uePowerShell.BeginInvoke()
 
 try {
-    & $EditorCmd @editorArgs 2>&1 | ForEach-Object {
-        $line = "$_"
-        $outputLines.Add($line)
-        $testStream.WriteLine($line)
+    # Wait up to 30 s for our editor process to appear so we have its PID for a targeted kill.
+    $spawnDeadline = [DateTime]::Now.AddSeconds(30)
+    while ($null -eq $ueProc -and [DateTime]::Now -lt $spawnDeadline -and -not $ueHandle.IsCompleted) {
+        $ueProc = Get-Process -Name "UnrealEditor-Cmd" -ErrorAction SilentlyContinue |
+                  Where-Object { $priorUEPids -notcontains $_.Id } |
+                  Select-Object -First 1
+        if ($null -eq $ueProc) { Start-Sleep -Milliseconds 500 }
+    }
+
+    $deadline = [DateTime]::Now.AddSeconds($TimeoutSeconds)
+    while (-not $ueHandle.IsCompleted) {
+        $item = $null
+        while ($outputQueue.TryDequeue([ref]$item)) {
+            $outputLines.Add($item)
+            $testStream.WriteLine($item)
+            $testStream.Flush()
+            Write-Host $item
+            $item = $null
+        }
+        if ([DateTime]::Now -gt $deadline) {
+            $timedOut = $true
+            Write-Warn ""
+            Write-Warn "TIMEOUT: killing UnrealEditor-Cmd.exe (no exit within $TimeoutSeconds s)"
+            if ($null -ne $ueProc -and -not $ueProc.HasExited) { $ueProc.Kill() }
+            $uePowerShell.Stop()
+            break
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    if (-not $timedOut) { try { [void]$uePowerShell.EndInvoke($ueHandle) } catch {} }
+    # Drain any output still queued after the runspace finished.
+    $item = $null
+    while ($outputQueue.TryDequeue([ref]$item)) {
+        $outputLines.Add($item)
+        $testStream.WriteLine($item)
         $testStream.Flush()
-        Write-Host $line
+        Write-Host $item
+        $item = $null
     }
 } finally {
     $testStream.Close()
+    $uePowerShell.Dispose()
+    $ueRunspace.Close()
+    $ueRunspace.Dispose()
     Restore-UbtConfig
 }
-$editorExit = $LASTEXITCODE
 $ErrorActionPreference = $prevEAP
 
 # ---------------------------------------------------------------------------
@@ -291,6 +376,12 @@ $ErrorActionPreference = $prevEAP
 Write-Step ""
 Write-Step "--- Test results ---"
 Write-Step ""
+
+if ($timedOut) {
+    Write-Fail "TIMED OUT - UnrealEditor-Cmd.exe did not exit within $TimeoutSeconds seconds"
+    Write-Step "Full log: $TestLog"
+    exit 1
+}
 
 $passedLines = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Passed|Success)\}?"
 $failedLines  = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Failed|Fail)\}?"

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -3,6 +3,7 @@
 #include "LootLockerConfig.h"
 #include "Misc/Paths.h"
 #include "Misc/DateTime.h"
+#include "Misc/ConfigCacheIni.h"
 
 namespace {
     // Used for runtime log level override
@@ -96,6 +97,39 @@ bool ULootLockerConfig::IsPresenceAutoDisconnectOnFocusChangeEnabled()
 {
     const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
     return Config->bEnablePresence && Config->bEnablePresenceAutoDisconnectOnFocusChange;
+}
+
+// ========================================================================
+// MULTI USER CONFIGURATION IMPLEMENTATION
+// ========================================================================
+
+void ULootLockerConfig::MigrateSettingsIfNeeded()
+{
+	// Check whether MultiUserSessionMode has ever been written to the INI file.
+	// If the key is absent (pre-migration install), choose the correct default:
+	//   - Existing project (API key already configured) -> Hotseat, for backwards compatibility.
+	//   - New install (no API key yet)                  -> SingleSession, the simpler default.
+	// After writing the value the key will be present on all subsequent loads and this block is skipped.
+	const FString IniFilePath = FPaths::ProjectConfigDir() / TEXT("DefaultGame.ini");
+	FString ExistingValue;
+	const bool bWasExplicitlySet = GConfig && GConfig->GetString(
+		TEXT("/Script/LootLockerSDK.LootLockerConfig"),
+		TEXT("MultiUserSessionMode"),
+		ExistingValue,
+		IniFilePath
+	);
+
+	if (!bWasExplicitlySet)
+	{
+		MultiUserSessionMode = LootLockerGameKey.IsEmpty()
+			? ELootLockerMultiUserSessionMode::SingleSession
+			: ELootLockerMultiUserSessionMode::Hotseat;
+#if ENGINE_MAJOR_VERSION >= 5
+		TryUpdateDefaultConfigFile();
+#else
+		UpdateDefaultConfigFile();
+#endif
+	}
 }
 
 bool ULootLockerConfig::IsPresenceEnabledInEditor()

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -110,7 +110,9 @@ void ULootLockerConfig::MigrateSettingsIfNeeded()
 	//   - Existing project (API key already configured) -> Hotseat, for backwards compatibility.
 	//   - New install (no API key yet)                  -> SingleSession, the simpler default.
 	// After writing the value the key will be present on all subsequent loads and this block is skipped.
-	const FString IniFilePath = FPaths::ProjectConfigDir() / TEXT("DefaultGame.ini");
+	// Use GetDefaultConfigFilename() so the read target matches the write target used by
+	// TryUpdateDefaultConfigFile()/UpdateDefaultConfigFile(), regardless of platform or test harness.
+	const FString IniFilePath = GetDefaultConfigFilename();
 	FString ExistingValue;
 	const bool bWasExplicitlySet = GConfig && GConfig->GetString(
 		TEXT("/Script/LootLockerSDK.LootLockerConfig"),
@@ -124,10 +126,14 @@ void ULootLockerConfig::MigrateSettingsIfNeeded()
 		MultiUserSessionMode = LootLockerGameKey.IsEmpty()
 			? ELootLockerMultiUserSessionMode::SingleSession
 			: ELootLockerMultiUserSessionMode::Hotseat;
+#if WITH_EDITOR
+		// Only persist to disk in Editor contexts — packaged builds may be installed to
+		// read-only locations, and the runtime value set above is sufficient there.
 #if ENGINE_MAJOR_VERSION >= 5
 		TryUpdateDefaultConfigFile();
 #else
 		UpdateDefaultConfigFile();
+#endif
 #endif
 	}
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -2,6 +2,7 @@
 
 #include "LootLockerSDKManager.h"
 
+#include "LootLockerConfig.h"
 #include "LootLockerStateData.h"
 #include "LootLockerPresenceManager.h"
 #include "LootLockerHttpClient.h"
@@ -301,6 +302,17 @@ FString ULootLockerSDKManager::ConnectRemoteSessionAccount(const FString& Code, 
 
 FString ULootLockerSDKManager::TransferIdentityProvidersBetweenAccounts(const FString& FromPlayerWithUlid,	const FString& ToPlayerWithUlid, TArray<ELootLockerAccountProvider> ProvidersToTransfer, const FLootLockerListConnectedAccountsResponseDelegate& OnComplete)
 {
+    const ELootLockerMultiUserSessionMode CurrentMode = GetDefault<ULootLockerConfig>()->MultiUserSessionMode;
+    if (CurrentMode == ELootLockerMultiUserSessionMode::SingleSession || CurrentMode == ELootLockerMultiUserSessionMode::ProfileSwitching)
+    {
+        const FString ModeString = UEnum::GetValueAsString(CurrentMode);
+        auto ErrorResponse = LootLockerResponseFactory::Error<FLootLockerListConnectedAccountsResponse>(
+            FString::Printf(TEXT("TransferIdentityProvidersBetweenAccounts requires Hotseat multi-user session mode because it needs two simultaneously active local sessions. Current mode: %s"), *ModeString),
+            LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT,
+            FromPlayerWithUlid);
+        OnComplete.ExecuteIfBound(ErrorResponse);
+        return "";
+    }
     const auto& fromPlayer = GetSavedStateOrDefaultOrEmptyForPlayer(FromPlayerWithUlid);
     const auto& toPlayer = GetSavedStateOrDefaultOrEmptyForPlayer(ToPlayerWithUlid);
     return ULootLockerConnectedAccountsRequestHandler::TransferIdentityProvidersBetweenAccounts(fromPlayer, toPlayer, ProvidersToTransfer, OnComplete);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -149,46 +149,45 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 	}
 	FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Saved LootLocker player state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
 
-	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	ActivePlayerData.Add(PlayerData.PlayerUlid, MakeShared<FLootLockerPlayerData>(PlayerData));
+	
 	{
-		// Wipe all saved state for other players. The new player has already been saved above,
-		// so clearing after the successful save prevents irreversible data loss on IO errors.
-		ClearAllSavedStatesExceptForPlayer(PlayerData.PlayerUlid);
+		FLootLockerStateMetaData metaState = LoadMetaState();
+		metaState.SavedPlayerStateUlids.AddUnique(PlayerData.PlayerUlid);
+		SetMetaState(metaState);
 	}
 
-	// Note: after ClearAllSavedStatesExceptForPlayer() the meta state retains only this player.
-	FLootLockerStateMetaData metaState = LoadMetaState();
-
-	if (Mode == ELootLockerMultiUserSessionMode::ProfileSwitching)
+	switch (Mode)
 	{
-		// Deactivate all other players (keep in cold cache) and set the new player as the sole active default.
-		SetAllPlayersToInactiveExceptForPlayer(PlayerData.PlayerUlid);
-		metaState = LoadMetaState(); // reload after the deactivation may have updated default
-		metaState.DefaultPlayer = PlayerData.PlayerUlid;
-	}
-	else if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
-	{
-		// Only one player ever exists — always make them the default.
-		metaState.DefaultPlayer = PlayerData.PlayerUlid;
-		SetDefaultPlayerUlid(PlayerData.PlayerUlid);
-	}
-	else
-	{
-		// Hotseat (and NotSet, which resolves to Hotseat at runtime): the first authenticated
-		// player in the session is the default; subsequent authentications do not change it.
-		if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0)
+	case ELootLockerMultiUserSessionMode::SingleSession:
 		{
-			metaState.DefaultPlayer = PlayerData.PlayerUlid;
-			SetDefaultPlayerUlid(PlayerData.PlayerUlid);
+			// Wipe all saved state for other players. The new player has already been saved above,
+			// so clearing after the successful save prevents irreversible data loss on IO errors.
+			// This also sets the new player as the default and updates the meta state
+			ClearAllSavedStatesExceptForPlayer(PlayerData.PlayerUlid);
+		}
+		break;
+	case ELootLockerMultiUserSessionMode::ProfileSwitching:
+		{
+			// Deactivate all other players (keep in cold cache) and set the new player as the sole active default.
+			// This also sets the new player as the default and updates the meta state
+			SetAllPlayersToInactiveExceptForPlayer(PlayerData.PlayerUlid);
+		}
+		break;
+	case ELootLockerMultiUserSessionMode::NotSet:
+	case ELootLockerMultiUserSessionMode::Hotseat:
+	default:
+		{
+			FLootLockerStateMetaData metaState = LoadMetaState();
+			// Hotseat (and NotSet, which resolves to Hotseat at runtime): the first authenticated
+			// player in the session is the default; subsequent authentications do not change it.
+			if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0 || (ActivePlayerData.Num() == 1 && ActivePlayerData.Contains(PlayerData.PlayerUlid)))
+			{
+				SetDefaultPlayerUlid(PlayerData.PlayerUlid);
+			}
 		}
 	}
 
-	if (!metaState.SavedPlayerStateUlids.Contains(PlayerData.PlayerUlid))
-	{
-		metaState.SavedPlayerStateUlids.Add(PlayerData.PlayerUlid);
-		SetMetaState(metaState);
-	}
-	ActivePlayerData.Add(PlayerData.PlayerUlid, MakeShared<FLootLockerPlayerData>(PlayerData));
 	ULootLockerPresenceManager::NotifyPlayerActivated(PlayerData.PlayerUlid);
 }
 

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -3,6 +3,7 @@
 
 #include "LootLockerStateData.h"
 
+#include "LootLockerConfig.h"
 #include "LootLockerPlayerData.h"
 #include "LootLockerPresenceManager.h"
 #include "LootLockerSDK.h"
@@ -139,6 +140,15 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 		return;
 	}
 
+	const ELootLockerMultiUserSessionMode Mode = GetDefault<ULootLockerConfig>()->MultiUserSessionMode;
+
+	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	{
+		// Wipe all existing player state before saving the new player.
+		// There should only ever be one player in the system.
+		ClearAllSavedStates();
+	}
+
 	FString TargetSaveSlot = PlayerDataSaveSlot + "_" + PlayerData.PlayerUlid;
 	if (!UGameplayStatics::SaveGameToSlot(ULootLockerPlayerDataSaveGame::Create(PlayerData), TargetSaveSlot, SaveIndex)) {
 		FLootLockerLogger::LogWarning(FString::Printf(TEXT("Failed to save LootLocker state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
@@ -146,12 +156,33 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 	}
 	FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Saved LootLocker player state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
 
+	// Note: after ClearAllSavedStates() the meta state is freshly empty — LoadMetaState() returns a clean slate.
 	FLootLockerStateMetaData metaState = LoadMetaState();
-	if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0)
+
+	if (Mode == ELootLockerMultiUserSessionMode::ProfileSwitching)
 	{
+		// Deactivate all other players (keep in cold cache) and set the new player as the sole active default.
+		SetAllPlayersToInactiveExceptForPlayer(PlayerData.PlayerUlid);
+		metaState = LoadMetaState(); // reload after the deactivation may have updated default
+		metaState.DefaultPlayer = PlayerData.PlayerUlid;
+	}
+	else if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	{
+		// Only one player ever exists — always make them the default.
 		metaState.DefaultPlayer = PlayerData.PlayerUlid;
 		SetDefaultPlayerUlid(PlayerData.PlayerUlid);
 	}
+	else
+	{
+		// Hotseat (and NotSet, which resolves to Hotseat at runtime): the first authenticated
+		// player in the session is the default; subsequent authentications do not change it.
+		if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0)
+		{
+			metaState.DefaultPlayer = PlayerData.PlayerUlid;
+			SetDefaultPlayerUlid(PlayerData.PlayerUlid);
+		}
+	}
+
 	if (!metaState.SavedPlayerStateUlids.Contains(PlayerData.PlayerUlid))
 	{
 		metaState.SavedPlayerStateUlids.Add(PlayerData.PlayerUlid);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -142,13 +142,6 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 
 	const ELootLockerMultiUserSessionMode Mode = GetDefault<ULootLockerConfig>()->MultiUserSessionMode;
 
-	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
-	{
-		// Wipe all existing player state before saving the new player.
-		// There should only ever be one player in the system.
-		ClearAllSavedStates();
-	}
-
 	FString TargetSaveSlot = PlayerDataSaveSlot + "_" + PlayerData.PlayerUlid;
 	if (!UGameplayStatics::SaveGameToSlot(ULootLockerPlayerDataSaveGame::Create(PlayerData), TargetSaveSlot, SaveIndex)) {
 		FLootLockerLogger::LogWarning(FString::Printf(TEXT("Failed to save LootLocker state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
@@ -156,7 +149,14 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 	}
 	FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Saved LootLocker player state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
 
-	// Note: after ClearAllSavedStates() the meta state is freshly empty — LoadMetaState() returns a clean slate.
+	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	{
+		// Wipe all saved state for other players. The new player has already been saved above,
+		// so clearing after the successful save prevents irreversible data loss on IO errors.
+		ClearAllSavedStatesExceptForPlayer(PlayerData.PlayerUlid);
+	}
+
+	// Note: after ClearAllSavedStatesExceptForPlayer() the meta state retains only this player.
 	FLootLockerStateMetaData metaState = LoadMetaState();
 
 	if (Mode == ELootLockerMultiUserSessionMode::ProfileSwitching)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -20,6 +20,50 @@
  */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FLootLockerConfigurationUpdateDelegate, const FString&, SettingName);
 
+/**
+ * Controls how the SDK handles multiple player sessions when a new authentication succeeds.
+ * Determines which player is considered the "default" for API calls that do not specify a player ULID.
+ */
+UENUM(BlueprintType, Category = "LootLocker")
+enum class ELootLockerMultiUserSessionMode : uint8
+{
+	/**
+	 * [Not yet configured] The SDK will automatically set the correct mode the first time the project is
+	 * loaded with this version of the SDK: new installs (no API key) get SingleSession, existing projects
+	 * get Hotseat for backwards compatibility. This value should never be set manually.
+	 */
+	NotSet          UMETA(Hidden),
+
+	/**
+	 * Multiple active sessions are allowed simultaneously.
+	 * The first player to authenticate in a game session becomes the default.
+	 * Subsequent authentications are additive — they join the active pool but do not change the default.
+	 * All player data is retained in persistent cache between sessions.
+	 *
+	 * Best for: local multiplayer, couch co-op, or any game where multiple players share a device at the same time.
+	 */
+	Hotseat         UMETA(DisplayName = "Hotseat"),
+
+	/**
+	 * Only one player session exists at any given time.
+	 * Each new authentication completely wipes all previous session data before saving the new player as the sole active default.
+	 * There is always exactly one player in the system; no historical data is kept.
+	 *
+	 * Best for: standard single-player games where only one account should ever exist on the device.
+	 */
+	SingleSession   UMETA(DisplayName = "Single Session"),
+
+	/**
+	 * Only one player is active at a time, but historical player sessions are retained in a cold cache.
+	 * Each new authentication makes that player the sole active and default while all previously active
+	 * players are deactivated — but their session data remains on-device.
+	 * You can switch back to a previously-authenticated player without re-authenticating.
+	 *
+	 * Best for: games with an account selection screen, or games where players switch between accounts.
+	 */
+	ProfileSwitching UMETA(DisplayName = "Profile Switching"),
+};
+
 UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "LootLocker SDK Settings"))
 class LOOTLOCKERSDK_API ULootLockerConfig : public UObject
 {
@@ -63,6 +107,7 @@ public:
 	virtual void PostInitProperties() override
 	{
 		IsValidGameVersion = IsSemverString(GameVersion);
+		MigrateSettingsIfNeeded();
 		if(bEnableFileLogging)
 		{
 			EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerLog" : LogFileName);
@@ -203,6 +248,26 @@ public:
 	/** Enable presence features in the editor (for testing purposes) */
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Enable In Editor", EditCondition = "bEnablePresence", EditConditionHides))
 	bool bEnablePresenceInEditor = true;
+
+	// ========================================================================
+	// MULTI USER CONFIGURATION
+	// ========================================================================
+
+	/**
+	 * Controls how the SDK handles multiple player sessions when a new authentication succeeds.
+	 *
+	 * Hotseat: Multiple active sessions allowed. The first authenticated player is default; subsequent
+	 * authentications are additive. Best for local multiplayer / couch co-op.
+	 *
+	 * Single Session: Only one player session exists at a time. New authentications wipe all previous
+	 * session data. Best for standard single-player games.
+	 *
+	 * Profile Switching: Only one player active at a time, but historical players kept in cold cache.
+	 * Each new authentication deactivates all others and becomes the sole active default. Best for
+	 * games with account selection screens.
+	 */
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Multi User", Meta = (DisplayName = "Multi User Session Mode"))
+	ELootLockerMultiUserSessionMode MultiUserSessionMode = ELootLockerMultiUserSessionMode::NotSet;
 private:
 	FString LogFilePath = "";
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
@@ -218,6 +283,12 @@ private:
 #if ENGINE_MAJOR_VERSION >= 5
 	inline static const std::regex SemverPattern = std::regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?(?:\\.(0|[1-9]\\d*))?$" );
 #endif
+
+	/** Performs a one-time migration of settings that were introduced after initial project setup.
+	 *  Specifically handles MultiUserSessionMode: if not present in DefaultGame.ini (pre-migration install),
+	 *  sets Hotseat for existing projects (backwards compatible) or SingleSession for new installs,
+	 *  then persists the result so subsequent loads skip this check. */
+	void MigrateSettingsIfNeeded();
 
 public:
     ULootLockerConfig();

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -1128,6 +1128,10 @@ public:
      IMPORTANT: This is destructive for the source player; transferred providers will no longer authenticate that player.
      Limitations: Source must own the providers; destination must not already have them; providers must be active in game settings.
 
+     NOTE: Requires ELootLockerMultiUserSessionMode::Hotseat to be configured (ULootLockerConfig::MultiUserSessionMode),
+     because this method needs two simultaneously active local sessions. It returns an error if the current mode is
+     SingleSession or ProfileSwitching.
+
      @param FromPlayerWithUlid ULID of the authenticated source player (providers moved FROM)
      @param ToPlayerWithUlid ULID of the authenticated destination player (providers moved TO)
      @param ProvidersToTransfer List of identity providers to transfer

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -644,6 +644,10 @@ public:
 
      Destructive: providers move from source to target player. Entire operation fails if any provider cannot be transferred.
 
+     NOTE: Requires ELootLockerMultiUserSessionMode::Hotseat to be configured (ULootLockerConfig::MultiUserSessionMode),
+     because this method needs two simultaneously active local sessions. It returns an error if the current mode is
+     SingleSession or ProfileSwitching.
+
      Limitations:
       - Source must own each provider
       - Target must not already have provider

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerTestGame.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerTestGame.cpp
@@ -681,6 +681,7 @@ void FLootLockerTestGame::InitializeLootLockerSDK() const
 	Config->LootLockerGameKey = GetActiveApiKey();
 	Config->GameVersion       = TEXT("0.0.0.1");
 	Config->DomainKey         = GameDomainKey;
+	Config->MultiUserSessionMode = ELootLockerMultiUserSessionMode::Hotseat;
 
 	// If the domain key is empty (e.g. env-var shortcut), check for a companion env var
 	if (Config->DomainKey.IsEmpty())

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserManagement.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserManagement.cpp
@@ -26,6 +26,7 @@ void FTestLootLockerMultiUserManagement::Define()
 		bOk = Game.EnableGuestLogin();
 		if (!bOk) { Done.Execute(); return; }
 		Game.InitializeLootLockerSDK();
+		GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::Hotseat;
 
 		// Start player 1 as the main session
 		test_util::StartSession();

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserSessionModes.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserSessionModes.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2021 LootLocker
+
+#include <future>
+
+#include "LootLockerConfig.h"
+#include "LootLockerPlatformManager.h"
+#include "LootLockerSDKManager.h"
+#include "LootLockerSessionOptionals.h"
+#include "LootLockerStateData.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationCommon.h"
+#include "TestUtils.h"
+#include "LootLockerTestGame.h"
+
+#if ENGINE_MAJOR_VERSION > 4
+BEGIN_DEFINE_SPEC(FTestLootLockerMultiUserSessionModes, "LootLocker.MultiUserSessionModes",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+	FLootLockerTestGame Game;
+END_DEFINE_SPEC(FTestLootLockerMultiUserSessionModes)
+
+void FTestLootLockerMultiUserSessionModes::Define()
+{
+	LatentBeforeEach(EAsyncExecution::ThreadPool, [this](const FDoneDelegate& Done)
+	{
+		bool bOk = FLootLockerTestGame::CreateGame(Game, TEXT("MultiUserSessionModes"));
+		if (!bOk) { Done.Execute(); return; }
+		bOk = Game.EnableGuestLogin();
+		if (!bOk) { Done.Execute(); return; }
+		Game.InitializeLootLockerSDK();
+		ULootLockerStateData::ClearAllSavedStates();
+		Done.Execute();
+	});
+
+	LatentAfterEach(EAsyncExecution::ThreadPool, [this](const FDoneDelegate& Done)
+	{
+		Game.DeleteGame();
+		Done.Execute();
+	});
+
+	Describe("SingleSession", [this]()
+	{
+		LatentIt("SecondAuth_ClearsFirst", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::SingleSession;
+
+			test_util::StartSession();
+			const FString Player1Ulid = ULootLockerStateData::GetSavedStateForFirstPlayer().PlayerUlid;
+			if (Player1Ulid.IsEmpty()) { AddError(TEXT("First session failed")); TestDone.Execute(); return; }
+
+			// When
+			const test_util::FTestPlayerSession P2 = test_util::StartAdditionalSession();
+			if (!P2.bSuccess) { AddError(TEXT("Second session failed")); TestDone.Execute(); return; }
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+			const FString DefaultUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+
+			TestEqual("SingleSession should retain only 1 cached player", CachedUlids.Num(), 1);
+			TestEqual("SingleSession should retain only 1 active player", ActiveUlids.Num(), 1);
+			TestFalse("First player should have been cleared from cache", CachedUlids.Contains(Player1Ulid));
+			TestTrue("Second player should remain in cache", CachedUlids.Contains(P2.PlayerUlid));
+			TestEqual("Second player should be the default", DefaultUlid, P2.PlayerUlid);
+
+			TestDone.Execute();
+		});
+
+		LatentIt("ReauthSamePlayer_DoesNotClearPlayer", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::SingleSession;
+
+			const FString Identifier = TEXT("reauth_test_user");
+
+			// First login
+			ULootLockerStateData::ClearAllSavedStates();
+			const auto [Promise1, Delegate1] = test_util::CreateDelegate<FLootLockerAuthenticationResponse, FLootLockerSessionResponse>();
+			ULootLockerSDKManager::GuestLogin(Delegate1, Identifier, FLootLockerSessionOptionals{});
+			const auto Response1 = test_util::WaitAndGet(Promise1, 60);
+			if (!Response1.success) { AddError(TEXT("First login failed")); TestDone.Execute(); return; }
+			FLootLockerPlayerData PD1 = FLootLockerPlayerData::Create(
+				Response1.session_token, TEXT(""), Response1.player_identifier, Response1.player_ulid,
+				Response1.public_uid, TEXT(""), TEXT(""), TEXT(""),
+				ULootLockerPlatforms::GetPlatformRepresentationForPlatform(ELootLockerPlatform::Guest),
+				FDateTime::Now().ToString(), Response1.player_created_at);
+			ULootLockerStateData::SavePlayerData(PD1);
+			const FString Player1Ulid = Response1.player_ulid;
+
+			// When — re-authenticate using the same identifier
+			const auto [Promise2, Delegate2] = test_util::CreateDelegate<FLootLockerAuthenticationResponse, FLootLockerSessionResponse>();
+			ULootLockerSDKManager::GuestLogin(Delegate2, Identifier, FLootLockerSessionOptionals{});
+			const auto Response2 = test_util::WaitAndGet(Promise2, 60);
+			if (!Response2.success) { AddError(TEXT("Re-auth login failed")); TestDone.Execute(); return; }
+			FLootLockerPlayerData PD2 = FLootLockerPlayerData::Create(
+				Response2.session_token, TEXT(""), Response2.player_identifier, Response2.player_ulid,
+				Response2.public_uid, TEXT(""), TEXT(""), TEXT(""),
+				ULootLockerPlatforms::GetPlatformRepresentationForPlatform(ELootLockerPlatform::Guest),
+				FDateTime::Now().ToString(), Response2.player_created_at);
+			ULootLockerStateData::SavePlayerData(PD2);
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+
+			TestEqual("Re-authenticating same identifier should return same ULID", Response2.player_ulid, Player1Ulid);
+			TestEqual("SingleSession should retain only 1 cached player after re-auth", CachedUlids.Num(), 1);
+			TestEqual("SingleSession should retain only 1 active player after re-auth", ActiveUlids.Num(), 1);
+			TestTrue("Re-authenticated player should still be cached", CachedUlids.Contains(Player1Ulid));
+
+			TestDone.Execute();
+		});
+	});
+
+	Describe("ProfileSwitching", [this]()
+	{
+		LatentIt("SecondAuth_DeactivatesFirstButKeepsBothCached", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::ProfileSwitching;
+
+			test_util::StartSession();
+			const FString Player1Ulid = ULootLockerStateData::GetSavedStateForFirstPlayer().PlayerUlid;
+			if (Player1Ulid.IsEmpty()) { AddError(TEXT("First session failed")); TestDone.Execute(); return; }
+
+			// When
+			const test_util::FTestPlayerSession P2 = test_util::StartAdditionalSession();
+			if (!P2.bSuccess) { AddError(TEXT("Second session failed")); TestDone.Execute(); return; }
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+			const FString DefaultUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+
+			TestEqual("ProfileSwitching should retain both players in cache", CachedUlids.Num(), 2);
+			TestEqual("ProfileSwitching should leave only 1 active player", ActiveUlids.Num(), 1);
+			TestTrue("First player should still be in cache", CachedUlids.Contains(Player1Ulid));
+			TestTrue("Second player should be in cache", CachedUlids.Contains(P2.PlayerUlid));
+			TestFalse("First player should be inactive", ActiveUlids.Contains(Player1Ulid));
+			TestTrue("Second player should be active", ActiveUlids.Contains(P2.PlayerUlid));
+			TestEqual("Second player should be the default", DefaultUlid, P2.PlayerUlid);
+
+			TestDone.Execute();
+		});
+	});
+
+	Describe("Hotseat", [this]()
+	{
+		LatentIt("MultipleAuths_AllRemainActive_FirstIsDefault", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::Hotseat;
+
+			test_util::StartSession();
+			const FString Player1Ulid = ULootLockerStateData::GetSavedStateForFirstPlayer().PlayerUlid;
+			if (Player1Ulid.IsEmpty()) { AddError(TEXT("First session failed")); TestDone.Execute(); return; }
+
+			// When — start two more sessions
+			const test_util::FTestPlayerSession P2 = test_util::StartAdditionalSession();
+			if (!P2.bSuccess) { AddError(TEXT("Second session failed")); TestDone.Execute(); return; }
+
+			const test_util::FTestPlayerSession P3 = test_util::StartAdditionalSession();
+			if (!P3.bSuccess) { AddError(TEXT("Third session failed")); TestDone.Execute(); return; }
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+			const FString DefaultUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+
+			TestEqual("Hotseat should retain all 3 players in cache", CachedUlids.Num(), 3);
+			TestEqual("Hotseat should keep all 3 players active", ActiveUlids.Num(), 3);
+			TestTrue("First player should be in cache", CachedUlids.Contains(Player1Ulid));
+			TestTrue("Second player should be in cache", CachedUlids.Contains(P2.PlayerUlid));
+			TestTrue("Third player should be in cache", CachedUlids.Contains(P3.PlayerUlid));
+			TestEqual("First player should remain the default in Hotseat mode", DefaultUlid, Player1Ulid);
+
+			TestDone.Execute();
+		});
+	});
+}
+#endif


### PR DESCRIPTION
## Summary

Resolves lootlocker/index#1521

Adds a configurable `ELootLockerMultiUserSessionMode` UENUM to `ULootLockerConfig` that controls how the SDK handles new authentications with respect to the active/default player. This addresses the common developer confusion where requests go to the "wrong player" because a previously-cached default persists across sessions.

## New setting: Multi User Session Mode

Three modes are available:

| Mode | Active sessions | Cache | Default rule | Best for |
|------|----------------|-------|--------------|----------|
| **Hotseat** (previous default) | Multiple | All retained | First auth in session | Local multiplayer / couch co-op |
| **Single Session** *(new install default)* | One | Previous wiped on new auth | Always latest auth | Standard single-player games |
| **Profile Switching** | One | Historic retained in cold cache | Always latest auth | Games with account selection screens |

The setting appears in **Project Settings → Plugins → LootLockerSDK → LootLocker | Multi User**.

## Backwards compatibility

A `NotSet` sentinel value (hidden from the editor dropdown via `UMETA(Hidden)`) handles the pre-migration case. `PostInitProperties()` calls `MigrateSettingsIfNeeded()` which:
- Uses `GConfig->GetString(...)` to check whether `MultiUserSessionMode` has ever been written to `DefaultGame.ini`
- If absent (pre-migration): API key present → `Hotseat`; API key absent → `SingleSession`
- Persists the result via `TryUpdateDefaultConfigFile()` / `UpdateDefaultConfigFile()` so subsequent loads skip the check

## Changes

- `LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h`
  - New `ELootLockerMultiUserSessionMode` UENUM with UMETA tooltips (NotSet hidden)
  - New `MultiUserSessionMode` UPROPERTY in `"LootLocker|Multi User"` category
  - `MigrateSettingsIfNeeded()` declaration; call added to `PostInitProperties()`

- `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp`
  - `#include "Misc/ConfigCacheIni.h"` added
  - `MigrateSettingsIfNeeded()` implementation

- `LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp`
  - `#include "LootLockerConfig.h"` added
  - `SavePlayerData()` branches on the configured mode:
    - `SingleSession`: calls `ClearAllSavedStates()` before saving
    - `ProfileSwitching`: calls `SetAllPlayersToInactiveExceptForPlayer()`, sets new player as default
    - `Hotseat` / `NotSet`: preserves the previous first-auth-is-default behaviour