### PR TITLE
feat(auth): add GetPlayerBanStatus endpoint and ban info in error data

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBanRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBanRequestHandler.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 LootLocker
+
+#include "GameAPI/LootLockerBanRequestHandler.h"
+#include "LootLockerConfig.h"
+#include "LootLockerGameEndpoints.h"
+#include "Utils/LootLockerUtilities.h"
+
+FString ULootLockerBanRequestHandler::GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest)
+{
+    const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
+    FLootLockerBanStatusRequest Request;
+    Request.game_api_key = Config->LootLockerGameKey;
+    Request.player_id = PlayerUlid;
+    return LLAPI<FLootLockerBanStatusResponse>::CallAPI(Request, ULootLockerGameEndpoints::GetPlayerBanStatusEndpoint, {}, {}, FLootLockerPlayerData(), OnCompletedRequest);
+}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -31,6 +31,7 @@ FLootLockerEndPoints ULootLockerGameEndpoints::SteamSessionEndpoint = InitEndpoi
 FLootLockerEndPoints ULootLockerGameEndpoints::StartDiscordSessionEndpoint = InitEndpoint("session/discord", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::RefreshDiscordSessionEndpoint = InitEndpoint("session/discord", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::PlaystationNetworkV3SessionEndpoint = InitEndpoint("session/psn-v3/v1/login", ELootLockerHTTPMethod::POST);
+FLootLockerEndPoints ULootLockerGameEndpoints::GetPlayerBanStatusEndpoint = InitEndpoint("session/ban-status", ELootLockerHTTPMethod::POST);
 
 // Connected Accounts
 FLootLockerEndPoints ULootLockerGameEndpoints::ListConnectedAccountsEndpoint = InitEndpoint("v1/connected-accounts", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -320,6 +320,14 @@ FString ULootLockerManager::EndSession(const FString& ForPlayerWithUlid, const F
     }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusResponseBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::GetPlayerBanStatus(PlayerUlid, FLootLockerBanStatusDelegate::CreateLambda([OnCompletedRequest](const FLootLockerBanStatusResponse& Response)
+    {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
 //==================================================
 // Connected Accounts
 //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -246,6 +246,11 @@ FString ULootLockerSDKManager::EndSession(const FLootLockerDefaultDelegate& OnCo
     return ULootLockerAuthenticationRequestHandler::EndSession(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), OnCompleteRequest);
 }
 
+FString ULootLockerSDKManager::GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest)
+{
+    return ULootLockerBanRequestHandler::GetPlayerBanStatus(PlayerUlid, OnCompletedRequest);
+}
+
 //==================================================
 // Connected Accounts
 //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
@@ -33,7 +33,7 @@ struct FLootLockerBanStatusResponse : public FLootLockerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool is_banned = false;
     /// Details about the active ban. Populated when is_banned is true.
-    /// Check Code == "player_banned" or is_banned before accessing these fields.
+    /// Check is_banned before accessing these fields. On failure, ErrorData.Code contains the error code.
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FLootLockerBanInfo ban;
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LootLockerResponse.h"
+#include "LootLockerErrorData.h"
+#include "LootLockerPlayerData.h"
+#include "LootLockerBanRequestHandler.generated.h"
+
+//==================================================
+// Request / Response Definitions
+//==================================================
+
+/// @addtogroup Authentication
+/// @{
+
+USTRUCT(BlueprintType)
+struct FLootLockerBanStatusRequest
+{
+    GENERATED_BODY()
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+    FString game_api_key = "";
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+    FString player_id = "";
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerBanStatusResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /// Whether the player is currently banned.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool is_banned = false;
+    /// Details about the active ban. Populated when is_banned is true.
+    /// Check Code == "player_banned" or is_banned before accessing these fields.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerBanInfo ban;
+};
+
+/// @}
+
+//==================================================
+// Delegate
+//==================================================
+
+DECLARE_DELEGATE_OneParam(FLootLockerBanStatusDelegate, FLootLockerBanStatusResponse);
+
+//==================================================
+// Handler
+//==================================================
+
+UCLASS()
+class LOOTLOCKERSDK_API ULootLockerBanRequestHandler : public UObject
+{
+    GENERATED_BODY()
+public:
+    ULootLockerBanRequestHandler() {}
+
+    /**
+     * Get the ban status for a player.
+     * Use this after receiving a 403 player_banned response from a session start to retrieve
+     * the ban reason and duration. Does not require an active player session.
+     * @param PlayerUlid The ULID of the player to query
+     * @param OnCompletedRequest Delegate called when the request completes
+     * @return A unique id for this request used to match callbacks
+     */
+    static FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest);
+};

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerErrorData.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerErrorData.h
@@ -5,6 +5,26 @@
 #include "CoreMinimal.h"
 #include "LootLockerErrorData.generated.h"
 
+/// Details about a player's active ban.
+USTRUCT(BlueprintType)
+struct FLootLockerBanInfo
+{
+    GENERATED_BODY()
+    /// The reason for the ban. One of "manual" or "chargeback".
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString ban_reason = "";
+    /// The time the ban was issued, as an ISO 8601 timestamp.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString banned_on = "";
+    /// The time the ban expires, as an ISO 8601 timestamp.
+    /// Empty string when the ban is permanent; check the Permanent field to confirm.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString banned_until = "";
+    /// True if the ban has no expiry date.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool permanent = false;
+};
+
 USTRUCT(BlueprintType)
 struct FLootLockerErrorData
 {
@@ -29,4 +49,8 @@ struct FLootLockerErrorData
     /// A free text description of the problem and potential suggestions for fixing it
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString Message = "";
+    /// When Code is "player_banned", contains sanitized details about the active ban.
+    /// Fields will have default (empty/false) values for all other error codes.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerBanInfo ban;
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -64,6 +64,7 @@ public:
     static FLootLockerEndPoints StartDiscordSessionEndpoint;
     static FLootLockerEndPoints RefreshDiscordSessionEndpoint;
     static FLootLockerEndPoints PlaystationNetworkV3SessionEndpoint;
+    static FLootLockerEndPoints GetPlayerBanStatusEndpoint;
 
     // Connected Accounts
     static FLootLockerEndPoints ListConnectedAccountsEndpoint;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -7,6 +7,7 @@
 #include "GameAPI/LootLockerAssetInstancesRequestHandler.h"
 #include "GameAPI/LootLockerAssetsRequestHandler.h"
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
+#include "GameAPI/LootLockerBanRequestHandler.h"
 #include "GameAPI/LootLockerBalanceRequestHandler.h"
 #include "GameAPI/LootLockerBroadcastRequestHandler.h"
 #include "GameAPI/LootLockerCatalogRequestHandler.h"
@@ -74,6 +75,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerAppleGameCenterSessionResponseBP, F
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerMetaSessionResponseBP, FLootLockerMetaSessionResponse, Var);
 /** Blueprint response delegate for Discord authentication session responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FDiscordSessionResponseBP, FLootLockerDiscordSessionResponse, Var);
+/** Blueprint response delegate for player ban status responses */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerBanStatusResponseBP, FLootLockerBanStatusResponse, Response);
 
 //==================================================
 // Connected Accounts Delegates
@@ -1000,6 +1003,20 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication")
     static UPARAM(DisplayName = "RequestId") FString EndSession(const FString& ForPlayerWithUlid, const FLootLockerDefaultResponseBP& OnEndSessionRequestCompleted);
+
+    /**
+     Get the ban status for a player.
+
+     Use this after a session start fails with error code `player_banned` to retrieve the ban
+     reason and duration so the game client can surface it to the player.
+     This endpoint authenticates with a game API key and does not require an active player session.
+
+     @param PlayerUlid The ULID of the player to query
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication", meta = (AdvancedDisplay = "PlayerUlid", PlayerUlid = ""))
+    static UPARAM(DisplayName = "RequestId") FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusResponseBP& OnCompletedRequest);
 
     //==================================================
     // Connected Accounts

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -1015,7 +1015,7 @@ public:
      @param OnCompletedRequest Delegate for handling the server response
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
-    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication", meta = (AdvancedDisplay = "PlayerUlid", PlayerUlid = ""))
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication")
     static UPARAM(DisplayName = "RequestId") FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusResponseBP& OnCompletedRequest);
 
     //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -6,6 +6,7 @@
 #include "GameAPI/LootLockerAssetInstancesRequestHandler.h"
 #include "GameAPI/LootLockerAssetsRequestHandler.h"
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
+#include "GameAPI/LootLockerBanRequestHandler.h"
 #include "GameAPI/LootLockerBalanceRequestHandler.h"
 #include "GameAPI/LootLockerBroadcastRequestHandler.h"
 #include "GameAPI/LootLockerCatalogRequestHandler.h"
@@ -529,6 +530,19 @@ public:
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     static FString EndSession(const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Get the ban status for a player.
+
+     Use this after a session start fails with error code `player_banned` to retrieve the ban
+     reason and duration so the game client can surface it to the player.
+     This endpoint authenticates with a game API key and does not require an active player session.
+
+     @param PlayerUlid The ULID of the player to query
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest);
 
     /// @}
 


### PR DESCRIPTION
## Summary

Implements [lootlocker/index#1501](https://github.com/lootlocker/index/issues/1501) — Add player ban reason to SDKs.

Two changes:
1. **New `GetPlayerBanStatus` method** — calls `POST /game/session/ban-status` using the game API key (no player session required). Returns whether a player is banned and, if so, the ban details.
2. **Ban info on session 403** — when a session start returns 403 with `code: "player_banned"`, the `FLootLockerErrorData.ban` field is now populated with the ban reason, timestamps, and permanent flag.

## Files changed

### New files
- `Public/GameAPI/LootLockerBanRequestHandler.h` — `FLootLockerBanStatusRequest`, `FLootLockerBanStatusResponse`, `FLootLockerBanStatusDelegate`, `ULootLockerBanRequestHandler`
- `Private/GameAPI/LootLockerBanRequestHandler.cpp` — implementation

### Modified files
- `Public/LootLockerErrorData.h` — added `FLootLockerBanInfo` USTRUCT and `ban` field on `FLootLockerErrorData`
- `Public/LootLockerGameEndpoints.h` — added `GetPlayerBanStatusEndpoint`
- `Private/LootLockerGameEndpoints.cpp` — registered `session/ban-status` POST endpoint
- `Public/LootLockerSDKManager.h` — added `GetPlayerBanStatus` static method and `#include` for ban handler
- `Private/LootLockerSDKManager.cpp` — implementation delegating to `ULootLockerBanRequestHandler`
- `Public/LootLockerManager.h` — added `FLootLockerBanStatusResponseBP` dynamic delegate and `GetPlayerBanStatus` Blueprint-callable method
- `Private/LootLockerManager.cpp` — implementation wrapping the C++ delegate

## Verification
Local compile check passed (UE 5.7, Win64, Development + Shipping configurations, all 93 actions succeeded).