### PR TITLE
feat(leaderboards): add Allow_manual_resets and Upcoming_resets to leaderboard details response

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
@@ -458,11 +458,6 @@ struct FLootLockerLeaderboardDetails
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
-     * Whether this leaderboard allows manual resets to be requested via the server API.
-     **/
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool Allow_manual_resets = false;
-    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -474,7 +469,6 @@ struct FLootLockerLeaderboardDetails
     TArray<FLootLockerLeaderboardReward> Rewards;
     /**
      * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
-     * Only populated when Allow_manual_resets is true.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;
@@ -530,11 +524,6 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
-     * Whether this leaderboard allows manual resets to be requested via the server API.
-     **/
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool Allow_manual_resets = false;
-    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -546,7 +535,6 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
     TArray<FLootLockerLeaderboardReward> Rewards;
     /**
      * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
-     * Only populated when Allow_manual_resets is true.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
@@ -380,6 +380,30 @@ struct FLootLockerLeaderboardReward
 };
 
 USTRUCT(BlueprintType)
+/**
+ * A pending manual reset for a leaderboard that has been requested but not yet processed.
+ **/
+struct FLootLockerLeaderboardUpcomingReset
+{
+    GENERATED_BODY()
+    /**
+     * The unique ID of this manual reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int Id = 0;
+    /**
+     * An optional human-readable name for this reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Name = "";
+    /**
+     * The UTC time at which this reset is scheduled to be processed (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Scheduled_for = "";
+};
+
+USTRUCT(BlueprintType)
 struct FLootLockerLeaderboardDetails
 {
     GENERATED_BODY()
@@ -434,6 +458,11 @@ struct FLootLockerLeaderboardDetails
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
+     * Whether this leaderboard allows manual resets to be requested via the server API.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool Allow_manual_resets = false;
+    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -443,6 +472,12 @@ struct FLootLockerLeaderboardDetails
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardReward> Rewards;
+    /**
+     * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
+     * Only populated when Allow_manual_resets is true.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;
 };
 
 USTRUCT(BlueprintType)
@@ -495,6 +530,11 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
+     * Whether this leaderboard allows manual resets to be requested via the server API.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool Allow_manual_resets = false;
+    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -504,6 +544,12 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardReward> Rewards;
+    /**
+     * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
+     * Only populated when Allow_manual_resets is true.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
## Summary

Part of [#1279](https://github.com/lootlocker/index/issues/1279) — Manual Leaderboard Resets (Phase 3: SDK support).

Adds two new fields to `FLootLockerLeaderboardDetails` and `FLootLockerLeaderboardDetailsResponse`:

- **`Allow_manual_resets`** (`bool`): whether this leaderboard allows manual resets to be requested via the server API.
- **`Upcoming_resets`** (`TArray<FLootLockerLeaderboardUpcomingReset>`): pending manual resets ordered by `Scheduled_for` ascending. Only populated when `Allow_manual_resets` is `true`.

Also introduces the new `FLootLockerLeaderboardUpcomingReset` struct with:
- `Id` (`int`): unique ID of the manual reset request
- `Name` (`FString`): optional human-readable name
- `Scheduled_for` (`FString`): UTC ISO 8601 time at which the reset will be processed

These fields auto-deserialize from the game API leaderboard details response — no new Blueprint or C++ methods are required.