### PR TITLE
feat: Add connection state check method

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerMiscellaneousRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerMiscellaneousRequestHandler.cpp
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2021 LootLocker
 
 #include "GameAPI/LootLockerMiscellaneousRequestHandler.h"
+#include "GameAPI/LootLockerBanRequestHandler.h"
 #include "Utils/LootLockerUtilities.h"
 #include "LootLockerGameEndpoints.h"
 
@@ -25,5 +26,100 @@ FString ULootLockerMiscellaneousRequestHandler::GetGameInfo(const FGameInfoRespo
         EmptyQueryParams,
         FLootLockerPlayerData(),
         OnCompletedRequest
+    );
+}
+
+FString ULootLockerMiscellaneousRequestHandler::CheckConnectionStatus(const FLootLockerPlayerData& PlayerData, const FLootLockerConnectionStateDelegate& OnCompletedRequest)
+{
+    return LLAPI<FLootLockerTimeResponse>::CallAPI(
+        LootLockerEmptyRequest,
+        ULootLockerGameEndpoints::GetServerTimeEndpoint,
+        {},
+        EmptyQueryParams,
+        PlayerData,
+        FTimeResponseDelegate::CreateLambda([PlayerData, OnCompletedRequest](FLootLockerTimeResponse PingResponse)
+        {
+            if (PingResponse.StatusCode == 0)
+            {
+                FLootLockerConnectionStateResponse Response;
+                Response.success = false;
+                Response.StatusCode = 0;
+                Response.State = ELootLockerConnectionState::NoConnection;
+                Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                Response.ErrorData = PingResponse.ErrorData;
+                Response.Context = PingResponse.Context;
+                OnCompletedRequest.ExecuteIfBound(Response);
+                return;
+            }
+
+            if (PingResponse.success)
+            {
+                FLootLockerConnectionStateResponse Response;
+                Response.success = true;
+                Response.StatusCode = PingResponse.StatusCode;
+                Response.State = ELootLockerConnectionState::SignedInAndConnected;
+                Response.ServerTime = PingResponse.date;
+                Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                Response.Context = PingResponse.Context;
+                OnCompletedRequest.ExecuteIfBound(Response);
+                return;
+            }
+
+            int32 StatusCode = PingResponse.StatusCode;
+
+            if (StatusCode >= 500)
+            {
+                FLootLockerConnectionStateResponse Response;
+                Response.success = false;
+                Response.StatusCode = StatusCode;
+                Response.State = ELootLockerConnectionState::ServerError;
+                Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                Response.ErrorData = PingResponse.ErrorData;
+                Response.Context = PingResponse.Context;
+                OnCompletedRequest.ExecuteIfBound(Response);
+                return;
+            }
+
+            // 401 = token expired (or a banned player's auto-refresh synthesized a 401).
+            // 403 = forbidden — could also be a ban.
+            // In both cases, call ban-status to check whether the player is actually banned.
+            if (StatusCode == 401 || StatusCode == 403)
+            {
+                ULootLockerBanRequestHandler::GetPlayerBanStatus(
+                    PlayerData.PlayerUlid,
+                    FLootLockerBanStatusDelegate::CreateLambda([PingResponse, StatusCode, OnCompletedRequest](FLootLockerBanStatusResponse BanResponse)
+                    {
+                        FLootLockerConnectionStateResponse Response;
+                        Response.success = false;
+                        Response.StatusCode = StatusCode;
+                        Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                        Response.ErrorData = PingResponse.ErrorData;
+                        Response.Context = PingResponse.Context;
+
+                        if (BanResponse.success && BanResponse.is_banned)
+                        {
+                            Response.State = ELootLockerConnectionState::Banned;
+                            Response.BanDetails = BanResponse.ban;
+                        }
+                        else
+                        {
+                            Response.State = ELootLockerConnectionState::SessionExpired;
+                        }
+                        OnCompletedRequest.ExecuteIfBound(Response);
+                    })
+                );
+                return;
+            }
+
+            // Any other failure (e.g. 400, 429) — map to ServerError so State is consistent with StatusCode.
+            FLootLockerConnectionStateResponse Response;
+            Response.success = false;
+            Response.StatusCode = StatusCode;
+            Response.State = ELootLockerConnectionState::ServerError;
+            Response.FullTextFromServer = PingResponse.FullTextFromServer;
+            Response.ErrorData = PingResponse.ErrorData;
+            Response.Context = PingResponse.Context;
+            OnCompletedRequest.ExecuteIfBound(Response);
+        })
     );
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -23,7 +23,7 @@ void ULootLockerManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 
 void ULootLockerManager::SetPlayerUlidToActive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::SetPlayerUlidToActive(PlayerUlid);
+    ULootLockerStateData::MakePlayerActive(PlayerUlid);
 }
 
 void ULootLockerManager::SetAllPlayersToInactive()

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -21,6 +21,11 @@ void ULootLockerManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
     return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
+void ULootLockerManager::SetPlayerUlidToActive(const FString& PlayerUlid)
+{
+    return ULootLockerStateData::SetPlayerUlidToActive(PlayerUlid);
+}
+
 void ULootLockerManager::SetAllPlayersToInactive()
 {
     ULootLockerStateData::SetAllPlayersToInactive();
@@ -2196,6 +2201,14 @@ FString ULootLockerManager::GetGameInfo(const FGameInfoResponseDelegateBP& OnCom
     {
         OnCompletedRequestBP.ExecuteIfBound(Response);
     }));
+}
+
+FString ULootLockerManager::CheckConnectionStatus(const FString& ForPlayerWithUlid, const FLootLockerConnectionStateResponseBP& OnCompletedRequestBP)
+{
+    return ULootLockerSDKManager::CheckConnectionStatus(FLootLockerConnectionStateDelegate::CreateLambda([OnCompletedRequestBP](FLootLockerConnectionStateResponse Response)
+    {
+        OnCompletedRequestBP.ExecuteIfBound(Response);
+    }), ForPlayerWithUlid);
 }
 
 // Followers (Unified with optional pagination parameters)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -20,6 +20,11 @@ void ULootLockerSDKManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
     return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
+void ULootLockerSDKManager::SetPlayerUlidToActive(const FString& PlayerUlid)
+{
+    return ULootLockerStateData::MakePlayerActive(PlayerUlid);
+}
+
 void ULootLockerSDKManager::SetAllPlayersToInactive()
 {
     ULootLockerStateData::SetAllPlayersToInactive();
@@ -1681,6 +1686,42 @@ FString ULootLockerSDKManager::GetLastActivePlatform(const FString& ForPlayerWit
 FString ULootLockerSDKManager::GetGameInfo(const FGameInfoResponseDelegate& OnComplete)
 {
     return ULootLockerMiscellaneousRequestHandler::GetGameInfo(OnComplete);
+}
+
+FString ULootLockerSDKManager::CheckConnectionStatus(const FLootLockerConnectionStateDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
+    if (Config == nullptr || Config->LootLockerGameKey.IsEmpty())
+    {
+        FLootLockerConnectionStateResponse Error;
+        Error.success = false;
+        Error.StatusCode = 0;
+        Error.State = ELootLockerConnectionState::NotInitialized;
+        OnCompletedRequest.ExecuteIfBound(Error);
+        return "";
+    }
+
+    // Resolve the ULID so we can pass it to SaveStateExistsForPlayer if needed.
+    FString ResolvedUlid = ForPlayerWithUlid.IsEmpty() ? ULootLockerStateData::GetDefaultPlayerUlid() : ForPlayerWithUlid;
+
+    // Only proceed if the player is currently active in the multi-player session.
+    // Using an inactive player's credentials would risk activating them as a side
+    // effect of a successful ping or an automatic token refresh.
+    const TSharedPtr<FLootLockerPlayerData> PlayerData = ULootLockerStateData::GetStateForPlayerOrDefaultIfActive(ResolvedUlid);
+    if (!PlayerData.IsValid() || PlayerData->Token.IsEmpty())
+    {
+        FLootLockerConnectionStateResponse Error;
+        Error.success = false;
+        Error.StatusCode = 0;
+        // Distinguish: saved credentials that are inactive vs. no credentials at all.
+        Error.State = (!ResolvedUlid.IsEmpty() && ULootLockerStateData::SaveStateExistsForPlayer(ResolvedUlid))
+            ? ELootLockerConnectionState::SavedButInactive
+            : ELootLockerConnectionState::NotSignedIn;
+        OnCompletedRequest.ExecuteIfBound(Error);
+        return "";
+    }
+
+    return ULootLockerMiscellaneousRequestHandler::CheckConnectionStatus(*PlayerData, OnCompletedRequest);
 }
 
 // ========================================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -22,7 +22,7 @@ void ULootLockerSDKManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 
 void ULootLockerSDKManager::SetPlayerUlidToActive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::MakePlayerActive(PlayerUlid);
+    ULootLockerStateData::MakePlayerActive(PlayerUlid);
 }
 
 void ULootLockerSDKManager::SetAllPlayersToInactive()
@@ -1697,6 +1697,7 @@ FString ULootLockerSDKManager::CheckConnectionStatus(const FLootLockerConnection
         Error.success = false;
         Error.StatusCode = 0;
         Error.State = ELootLockerConnectionState::NotInitialized;
+        Error.Context.PlayerUlid = ForPlayerWithUlid;
         OnCompletedRequest.ExecuteIfBound(Error);
         return "";
     }
@@ -1713,6 +1714,7 @@ FString ULootLockerSDKManager::CheckConnectionStatus(const FLootLockerConnection
         FLootLockerConnectionStateResponse Error;
         Error.success = false;
         Error.StatusCode = 0;
+        Error.Context.PlayerUlid = ResolvedUlid;
         // Distinguish: saved credentials that are inactive vs. no credentials at all.
         Error.State = (!ResolvedUlid.IsEmpty() && ULootLockerStateData::SaveStateExistsForPlayer(ResolvedUlid))
             ? ELootLockerConnectionState::SavedButInactive

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerMiscellaneousRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerMiscellaneousRequestHandler.h
@@ -71,6 +71,48 @@ struct FLootLockerGameInfoResponse : public FLootLockerResponse
     FLootLockerGameInfo Info;
 };
 
+/// The state of a player's connection and session with the LootLocker backend.
+/// Returned by CheckConnectionStatus.
+UENUM(BlueprintType)
+enum class ELootLockerConnectionState : uint8
+{
+    /// The SDK has not been configured (game API key is not set).
+    NotInitialized      UMETA(DisplayName = "Not Initialized"),
+    /// No session token exists in local state for the specified player.
+    NotSignedIn         UMETA(DisplayName = "Not Signed In"),
+    /// The player has saved credentials on disk but is not currently active in the
+    /// multi-player session. Call SetPlayerUlidToActive (or start a new session) to activate
+    /// them before calling CheckConnectionStatus again.
+    SavedButInactive    UMETA(DisplayName = "Saved But Inactive"),
+    /// The session token is valid and the server is reachable (ping returned 200).
+    SignedInAndConnected UMETA(DisplayName = "Signed In And Connected"),
+    /// A session token exists but the server returned 401 or 403 and the player is not banned.
+    SessionExpired      UMETA(DisplayName = "Session Expired"),
+    /// A session token exists but the player is currently banned.
+    Banned              UMETA(DisplayName = "Banned"),
+    /// The server could not be reached (no network, timeout, or status code 0).
+    NoConnection        UMETA(DisplayName = "No Connection"),
+    /// The server returned a 5xx error or an unexpected non-success status code.
+    ServerError         UMETA(DisplayName = "Server Error"),
+};
+
+/**
+*/
+USTRUCT(BlueprintType)
+struct FLootLockerConnectionStateResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /// The determined connection and session state for the player.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    ELootLockerConnectionState State = ELootLockerConnectionState::NotInitialized;
+    /// Server timestamp returned by the ping. Populated only when State is SignedInAndConnected.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString ServerTime = "";
+    /// Details about the active ban. Populated only when State is Banned.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerBanInfo BanDetails;
+};
+
 //==================================================
 // Delegate Definitions
 //==================================================
@@ -84,6 +126,10 @@ DECLARE_DELEGATE_OneParam(FTimeResponseDelegate, FLootLockerTimeResponse);
  * C++ response delegate for fetching game info
  */
 DECLARE_DELEGATE_OneParam(FGameInfoResponseDelegate, FLootLockerGameInfoResponse);
+/**
+ * C++ response delegate for CheckConnectionStatus
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerConnectionStateDelegate, FLootLockerConnectionStateResponse);
 
 //==================================================
 // API Class Definition
@@ -99,4 +145,5 @@ public:
 	static FString GetServerTime(const FLootLockerPlayerData& PlayerData, const FTimeResponseDelegate& OnCompletedRequest);
 	static FString GetLastActivePlatform(const FLootLockerPlayerData& PlayerData);
     static FString GetGameInfo(const FGameInfoResponseDelegate& OnCompletedRequest);
+    static FString CheckConnectionStatus(const FLootLockerPlayerData& PlayerData, const FLootLockerConnectionStateDelegate& OnCompletedRequest);
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -4102,7 +4102,7 @@ public:
      - NotInitialized      — the SDK has not been configured (game API key is not set).
      - NotSignedIn         — no saved credentials exist for the specified player.
      - SavedButInactive    — the player has saved credentials but is not currently active in the
-                             multi-player session. Call MakePlayerActive or start a new session first.
+                             multi-player session. Call SetPlayerUlidToActive or start a new session first.
      - NoConnection        — the server could not be reached (no network, timeout, or status 0).
      - SignedInAndConnected — the session is valid and the server is reachable.
      - SessionExpired      — a session exists but the token is no longer valid (401 or non-ban 403).

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -445,6 +445,10 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FTimeResponseDelegateBP, FLootLockerTimeRespon
  Blueprint response delegate for fetching game info
 */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FGameInfoResponseDelegateBP, FLootLockerGameInfoResponse, Response);
+/**
+ Blueprint response delegate for CheckConnectionStatus
+*/
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerConnectionStateResponseBP, FLootLockerConnectionStateResponse, Response);
 
 //==================================================
 // Presence Delegates
@@ -477,6 +481,14 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Player State")
     static void SetPlayerUlidToInactive(const FString& PlayerUlid);
+
+    /**
+     Mark a player's state as active
+
+    @param PlayerUlid ULID of the player to set active
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Player State")
+    static void SetPlayerUlidToActive(const FString& PlayerUlid);
 
     /**
      Mark all currently active players as inactive
@@ -4081,6 +4093,32 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Miscellaneous")
     static UPARAM(DisplayName = "RequestId") FString GetGameInfo(const FGameInfoResponseDelegateBP& OnCompletedRequestBP);
+
+    /**
+     Check the current connection and session state for a player.
+
+     Performs fast local checks first, then a lightweight ping to the LootLocker servers.
+     Returns one of the following states:
+     - NotInitialized      — the SDK has not been configured (game API key is not set).
+     - NotSignedIn         — no saved credentials exist for the specified player.
+     - SavedButInactive    — the player has saved credentials but is not currently active in the
+                             multi-player session. Call MakePlayerActive or start a new session first.
+     - NoConnection        — the server could not be reached (no network, timeout, or status 0).
+     - SignedInAndConnected — the session is valid and the server is reachable.
+     - SessionExpired      — a session exists but the token is no longer valid (401 or non-ban 403).
+     - Banned              — the player is currently banned; BanDetails is populated.
+     - ServerError         — the server returned a 5xx or other unexpected error.
+
+     Note: if automatic token refresh is enabled in the SDK config (AllowTokenRefresh), the underlying
+     HTTP client may attempt a refresh when the ping returns 401 or 403. This method reports the
+     resulting state after any such automatic behavior — it does not explicitly request a refresh.
+
+    @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied the default player is used
+    @param OnCompletedRequestBP Delegate for handling the response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Miscellaneous", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString CheckConnectionStatus(const FString& ForPlayerWithUlid, const FLootLockerConnectionStateResponseBP& OnCompletedRequestBP);
 
     //==================================================
     // Presence

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -66,6 +66,13 @@ public:
     static void SetPlayerUlidToInactive(const FString& PlayerUlid);
 
     /**
+    Mark a player's state as active
+
+     @param PlayerUlid ULID of the player to set active
+     */
+    static void SetPlayerUlidToActive(const FString& PlayerUlid);
+
+    /**
      Mark all currently active players as inactive
      */
     static void SetAllPlayersToInactive();
@@ -3740,6 +3747,31 @@ public:
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     static FString GetGameInfo(const FGameInfoResponseDelegate& OnComplete);
+
+    /**
+     Check the current connection and session state for a player.
+
+     Performs fast local checks first, then a lightweight ping to the LootLocker servers.
+     Returns one of the following states:
+     - NotInitialized   — the SDK has not been configured (game API key is not set).
+     - NotSignedIn      — no saved credentials exist for the specified player.
+     - SavedButInactive — the player has saved credentials but is not currently active in the
+                          multi-player session. Call SetPlayerUlidToActive or start a new session first.
+     - NoConnection     — the server could not be reached (no network, timeout, or status 0).
+     - SignedInAndConnected — the session is valid and the server is reachable.
+     - SessionExpired   — a session exists but the token is no longer valid (401 or non-ban 403).
+     - Banned           — the player is currently banned; BanDetails is populated.
+     - ServerError      — the server returned a 5xx or other unexpected error.
+
+     Note: if automatic token refresh is enabled in the SDK config (AllowTokenRefresh), the underlying
+     HTTP client may attempt a refresh when the ping returns 401 or 403. This method reports the
+     resulting state after any such automatic behavior — it does not explicitly request a refresh.
+
+     @param OnCompletedRequest Delegate called when the check is complete
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString CheckConnectionStatus(const FLootLockerConnectionStateDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
     /// @}
 


### PR DESCRIPTION
## Summary

Adds a `CheckConnectionStatus` method to the Unreal SDK, mirroring the equivalent feature already shipped in the Unity SDK (see unity-sdk PR #473). It gives callers a single call to determine whether a player is initialized, signed in, reachable, banned, or in any other relevant state — without requiring the caller to stitch together multiple SDK queries.

## Changes

### New API

`ULootLockerSDKManager::CheckConnectionStatus` / `ULootLockerManager::CheckConnectionStatus` (Blueprint)

Returns an `ELootLockerConnectionState` and, where applicable, additional detail (`ServerTime`, `BanDetails`).

### New enum — `ELootLockerConnectionState`

| State | When set |
|---|---|
| `NotInitialized` | No game API key configured |
| `NotSignedIn` | No saved credentials for this player |
| `SavedButInactive` | Credentials exist on disk but the player is not active in the multi-player session |
| `SignedInAndConnected` | Ping succeeded; `ServerTime` is populated |
| `SessionExpired` | Server returned 401 / non-ban 403 |
| `Banned` | Player is banned; `BanDetails` is populated |
| `NoConnection` | Network unreachable or status 0 |
| `ServerError` | 5xx or unexpected status code |

### New response struct — `FLootLockerConnectionStateResponse`

Extends `FLootLockerResponse` with:
- `State` — the determined `ELootLockerConnectionState`
- `ServerTime` — server timestamp (populated on `SignedInAndConnected`)
- `BanDetails` — ban info (populated on `Banned`)

### Implementation details

- **Local-only fast path** — `NotInitialized`, `NotSignedIn`, and `SavedButInactive` are resolved entirely from local state with no network call.
- **`SavedButInactive` guard** — prevents accidental player activation via token-refresh when `AllowTokenRefresh` is enabled; callers must explicitly activate the player before a network check is attempted.
- **Network path** — delegates to a lightweight `GetServerTime` ping; 401/403 results trigger a `GetPlayerBanStatus` lookup to distinguish `Banned` from `SessionExpired`.

## Files changed

| File | Change |
|---|---|
| `Public/GameAPI/LootLockerMiscellaneousRequestHandler.h` | `ELootLockerConnectionState`, `FLootLockerConnectionStateResponse`, `FLootLockerConnectionStateDelegate`, `CheckConnectionStatus` declaration |
| `Private/GameAPI/LootLockerMiscellaneousRequestHandler.cpp` | `CheckConnectionStatus` implementation |
| `Public/LootLockerSDKManager.h` | C++ facade declaration |
| `Private/LootLockerSDKManager.cpp` | C++ facade implementation (preflight + dispatch) |
| `Public/LootLockerManager.h` | Blueprint UFUNCTION declaration |
| `Private/LootLockerManager.cpp` | Blueprint UFUNCTION implementation |

## Related

Closes / relates to #1574