### PR TITLE
feat: Add check for updates functionality

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -18,7 +18,7 @@ TArray<FString> ULootLockerManager::GetActivePlayerUlids()
 
 void ULootLockerManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
+    ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
 void ULootLockerManager::SetPlayerUlidToActive(const FString& PlayerUlid)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -17,7 +17,7 @@ TArray<FString> ULootLockerSDKManager::GetActivePlayerUlids()
 
 void ULootLockerSDKManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
+    ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
 void ULootLockerSDKManager::SetPlayerUlidToActive(const FString& PlayerUlid)

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class LootLockerSDKEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore"
+            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore", "Json", "JsonUtilities"
         });
 
         PublicDependencyModuleNames.AddRange(new string[] {

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class LootLockerSDKEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore", "Json", "JsonUtilities"
+            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore", "Json"
         });
 
         PublicDependencyModuleNames.AddRange(new string[] {

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) LootLocker. All Rights Reserved.
 #include "Modules/ModuleManager.h"
 #include "LootLockerLogViewerWidget.h"
+#include "LootLockerUpdateChecker.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "LevelEditor.h"
 #include "ToolMenus.h"
@@ -51,12 +52,23 @@ public:
                         FGlobalTabmanager::Get()->TryInvokeTab(LootLockerLogViewerTabName);
                     }))
                 );
+                Section.AddMenuEntry(
+                    "LootLockerCheckForUpdates",
+                    FText::FromString("Check for Updates"),
+                    FText::FromString("Check if a newer version of the LootLocker SDK is available."),
+                    FSlateIcon(),
+                    FUIAction(FExecuteAction::CreateStatic(&FLootLockerUpdateChecker::ManualCheck))
+                );
             }
         }));
+
+        // Delayed update check (fires after StartupDelaySeconds)
+        FLootLockerUpdateChecker::Initialize();
     }
 
     virtual void ShutdownModule() override
     {
+        FLootLockerUpdateChecker::Shutdown();
         FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(LootLockerLogViewerTabName);
     }
 };

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#include "LootLockerUpdateChecker.h"
+#include "SLootLockerUpdateNotification.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+#include "Interfaces/IPluginManager.h"
+#include "Misc/DateTime.h"
+#include "Misc/ConfigCacheIni.h"
+#include "Misc/App.h"
+#include "Containers/Ticker.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "HAL/PlatformProcess.h"
+#include "Logging/LogMacros.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogLootLockerSDKEditor, Log, All);
+
+// --- Static member definitions ---
+FTSTicker::FDelegateHandle FLootLockerUpdateChecker::TickerHandle;
+double FLootLockerUpdateChecker::ElapsedStartupSeconds = 0.0;
+const TCHAR* FLootLockerUpdateChecker::ConfigSection = TEXT("/Script/LootLockerSDKEditor.UpdateChecker");
+const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
+    TEXT("https://api.github.com/repos/lootlocker/unreal-sdk/releases/latest");
+
+// ---------------------------------------------------------------------------
+
+void FLootLockerUpdateChecker::Initialize()
+{
+    ElapsedStartupSeconds = 0.0;
+    TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
+        FTickerDelegate::CreateStatic(&FLootLockerUpdateChecker::OnStartupTick),
+        0.0f  // tick every frame; we measure elapsed time ourselves
+    );
+}
+
+void FLootLockerUpdateChecker::Shutdown()
+{
+    if (TickerHandle.IsValid())
+    {
+        FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+        TickerHandle.Reset();
+    }
+}
+
+void FLootLockerUpdateChecker::ManualCheck()
+{
+    CheckForUpdate(/*bManual=*/true);
+}
+
+bool FLootLockerUpdateChecker::OnStartupTick(float DeltaTime)
+{
+    ElapsedStartupSeconds += DeltaTime;
+    if (ElapsedStartupSeconds >= StartupDelaySeconds)
+    {
+        // Remove ticker — we only need one startup check
+        TickerHandle.Reset();
+        CheckForUpdate(/*bManual=*/false);
+        return false;  // unregister
+    }
+    return true;  // keep ticking
+}
+
+void FLootLockerUpdateChecker::CheckForUpdate(bool bManual)
+{
+    if (!bManual && !ShouldCheck())
+    {
+        return;
+    }
+    FetchLatestRelease(bManual);
+}
+
+bool FLootLockerUpdateChecker::ShouldCheck()
+{
+    if (GetNeverNotify())
+    {
+        return false;
+    }
+
+    const FDateTime RemindAfter = GetRemindAfterTime();
+    if (FDateTime::UtcNow() < RemindAfter)
+    {
+        return false;
+    }
+
+    const FDateTime LastChecked = GetLastCheckedTime();
+    const FTimespan TimeSinceLastCheck = FDateTime::UtcNow() - LastChecked;
+    if (TimeSinceLastCheck.GetTotalHours() < CheckIntervalHours)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool FLootLockerUpdateChecker::ShouldNotify(const FString& LatestVersion)
+{
+    return GetSkippedVersion() != LatestVersion;
+}
+
+void FLootLockerUpdateChecker::FetchLatestRelease(bool bManual)
+{
+    TSharedRef<IHttpRequest> Request = FHttpModule::Get().CreateRequest();
+    Request->SetURL(GitHubReleasesUrl);
+    Request->SetVerb(TEXT("GET"));
+    Request->SetHeader(TEXT("Accept"), TEXT("application/vnd.github.v3+json"));
+    Request->SetHeader(TEXT("User-Agent"), TEXT("LootLockerSDK-UnrealEditor"));
+
+    // Capture bManual by value in the lambda binding
+    Request->OnProcessRequestComplete().BindLambda(
+        [bManual](FHttpRequestPtr Req, FHttpResponsePtr Resp, bool bWasSuccessful)
+        {
+            FLootLockerUpdateChecker::OnResponseReceived(Req, Resp, bWasSuccessful, bManual);
+        }
+    );
+
+    Request->ProcessRequest();
+}
+
+void FLootLockerUpdateChecker::OnResponseReceived(
+    FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual)
+{
+    if (!bWasSuccessful || !Response.IsValid() || Response->GetResponseCode() != 200)
+    {
+        if (bManual)
+        {
+            UE_LOG(LogLootLockerSDKEditor, Warning,
+                TEXT("LootLocker update check failed (HTTP %d)."),
+                Response.IsValid() ? Response->GetResponseCode() : 0);
+
+            FNotificationInfo Info(FText::FromString(TEXT("LootLocker: Could not reach GitHub to check for updates.")));
+            Info.ExpireDuration = 5.0f;
+            Info.bFireAndForget = true;
+            FSlateNotificationManager::Get().AddNotification(Info);
+        }
+        return;
+    }
+
+    TSharedPtr<FJsonObject> JsonObject;
+    const TSharedRef<TJsonReader<>> Reader =
+        TJsonReaderFactory<>::Create(Response->GetContentAsString());
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        UE_LOG(LogLootLockerSDKEditor, Warning, TEXT("LootLocker update check: failed to parse GitHub response."));
+        return;
+    }
+
+    FString TagName = JsonObject->GetStringField(TEXT("tag_name"));  // e.g. "v10.5.0"
+    const FString HtmlUrl = JsonObject->GetStringField(TEXT("html_url"));
+
+    // Strip leading 'v' or 'V'
+    if (TagName.StartsWith(TEXT("v")) || TagName.StartsWith(TEXT("V")))
+    {
+        TagName.RightChopInline(1);
+    }
+
+    // Strip any pre-release suffix (e.g. "10.5.0-beta.1" → "10.5.0")
+    int32 DashIndex;
+    if (TagName.FindChar(TEXT('-'), DashIndex))
+    {
+        TagName = TagName.Left(DashIndex);
+    }
+    int32 PlusIndex;
+    if (TagName.FindChar(TEXT('+'), PlusIndex))
+    {
+        TagName = TagName.Left(PlusIndex);
+    }
+
+    SaveLastCheckedTime(FDateTime::UtcNow());
+
+    if (IsVersionNewer(TagName, GetCurrentVersion()))
+    {
+        if (bManual || ShouldNotify(TagName))
+        {
+            ShowUpdateNotification(TagName, HtmlUrl, bManual);
+        }
+    }
+    else if (bManual)
+    {
+        ShowUpToDateNotification();
+    }
+}
+
+void FLootLockerUpdateChecker::ShowUpdateNotification(
+    const FString& LatestVersion, const FString& ReleaseUrl, bool bManual)
+{
+    if (!FSlateApplication::IsInitialized())
+    {
+        return;
+    }
+
+    const TSharedRef<SWindow> Window = SNew(SWindow)
+        .Title(FText::FromString(TEXT("LootLocker SDK Update Available")))
+        .ClientSize(FVector2D(560.0f, 210.0f))
+        .SupportsMinimize(false)
+        .SupportsMaximize(false)
+        .IsTopmostWindow(false)
+        .SizingRule(ESizingRule::FixedSize);
+
+    Window->SetContent(
+        SNew(SLootLockerUpdateNotification)
+            .CurrentVersion(GetCurrentVersion())
+            .LatestVersion(LatestVersion)
+            .ReleaseUrl(ReleaseUrl)
+            .ParentWindow(Window)
+    );
+
+    FSlateApplication::Get().AddWindow(Window);
+}
+
+void FLootLockerUpdateChecker::ShowUpToDateNotification()
+{
+    FNotificationInfo Info(FText::FromString(TEXT("LootLocker SDK is up to date!")));
+    Info.ExpireDuration = 5.0f;
+    Info.bFireAndForget = true;
+    FSlateNotificationManager::Get().AddNotification(Info);
+}
+
+bool FLootLockerUpdateChecker::IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion)
+{
+    TArray<FString> RemoteParts, LocalParts;
+    RemoteVersion.ParseIntoArray(RemoteParts, TEXT("."));
+    LocalVersion.ParseIntoArray(LocalParts, TEXT("."));
+
+    const int32 MaxParts = FMath::Max(RemoteParts.Num(), LocalParts.Num());
+    for (int32 i = 0; i < MaxParts; ++i)
+    {
+        const int32 Remote = (i < RemoteParts.Num()) ? FCString::Atoi(*RemoteParts[i]) : 0;
+        const int32 Local  = (i < LocalParts.Num())  ? FCString::Atoi(*LocalParts[i])  : 0;
+        if (Remote > Local) return true;
+        if (Remote < Local) return false;
+    }
+    return false;  // equal
+}
+
+bool FLootLockerUpdateChecker::IsFabManaged()
+{
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
+    if (!Plugin.IsValid())
+    {
+        return false;
+    }
+    return Plugin->GetBaseDir().Contains(TEXT("Marketplace"));
+}
+
+FString FLootLockerUpdateChecker::GetCurrentVersion()
+{
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
+    if (Plugin.IsValid())
+    {
+        return Plugin->GetDescriptor().VersionName;
+    }
+    return TEXT("0.0.0");
+}
+
+// --- Config helpers ---
+
+bool FLootLockerUpdateChecker::GetNeverNotify()
+{
+    bool bValue = false;
+    GConfig->GetBool(ConfigSection, TEXT("NeverNotify"), bValue, GEditorPerProjectIni);
+    return bValue;
+}
+
+void FLootLockerUpdateChecker::SetNeverNotify(bool bValue)
+{
+    GConfig->SetBool(ConfigSection, TEXT("NeverNotify"), bValue, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FString FLootLockerUpdateChecker::GetSkippedVersion()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("SkippedVersion"), Value, GEditorPerProjectIni);
+    return Value;
+}
+
+void FLootLockerUpdateChecker::SetSkippedVersion(const FString& Version)
+{
+    GConfig->SetString(ConfigSection, TEXT("SkippedVersion"), *Version, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FDateTime FLootLockerUpdateChecker::GetRemindAfterTime()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("RemindAfterUtc"), Value, GEditorPerProjectIni);
+    FDateTime Result;
+    if (FDateTime::ParseIso8601(*Value, Result))
+    {
+        return Result;
+    }
+    return FDateTime::MinValue();
+}
+
+void FLootLockerUpdateChecker::SetRemindAfterTime(const FDateTime& Time)
+{
+    GConfig->SetString(ConfigSection, TEXT("RemindAfterUtc"), *Time.ToIso8601(), GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FDateTime FLootLockerUpdateChecker::GetLastCheckedTime()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("LastCheckedUtc"), Value, GEditorPerProjectIni);
+    FDateTime Result;
+    if (FDateTime::ParseIso8601(*Value, Result))
+    {
+        return Result;
+    }
+    return FDateTime::MinValue();
+}
+
+void FLootLockerUpdateChecker::SaveLastCheckedTime(const FDateTime& Time)
+{
+    GConfig->SetString(ConfigSection, TEXT("LastCheckedUtc"), *Time.ToIso8601(), GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -22,7 +22,6 @@ DEFINE_LOG_CATEGORY_STATIC(LogLootLockerSDKEditor, Log, All);
 
 // --- Static member definitions ---
 FTSTicker::FDelegateHandle FLootLockerUpdateChecker::TickerHandle;
-double FLootLockerUpdateChecker::ElapsedStartupSeconds = 0.0;
 const TCHAR* FLootLockerUpdateChecker::ConfigSection = TEXT("/Script/LootLockerSDKEditor.UpdateChecker");
 const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
     TEXT("https://api.github.com/repos/lootlocker/unreal-sdk/releases/latest");
@@ -31,10 +30,10 @@ const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
 
 void FLootLockerUpdateChecker::Initialize()
 {
-    ElapsedStartupSeconds = 0.0;
+    // Fire once after StartupDelaySeconds — return false in the callback to auto-unregister.
     TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
         FTickerDelegate::CreateStatic(&FLootLockerUpdateChecker::OnStartupTick),
-        0.0f  // tick every frame; we measure elapsed time ourselves
+        StartupDelaySeconds
     );
 }
 
@@ -54,15 +53,8 @@ void FLootLockerUpdateChecker::ManualCheck()
 
 bool FLootLockerUpdateChecker::OnStartupTick(float DeltaTime)
 {
-    ElapsedStartupSeconds += DeltaTime;
-    if (ElapsedStartupSeconds >= StartupDelaySeconds)
-    {
-        // Remove ticker — we only need one startup check
-        TickerHandle.Reset();
-        CheckForUpdate(/*bManual=*/false);
-        return false;  // unregister
-    }
-    return true;  // keep ticking
+    CheckForUpdate(/*bManual=*/false);
+    return false;  // one-shot — unregister immediately
 }
 
 void FLootLockerUpdateChecker::CheckForUpdate(bool bManual)
@@ -150,8 +142,15 @@ void FLootLockerUpdateChecker::OnResponseReceived(
         return;
     }
 
-    FString TagName = JsonObject->GetStringField(TEXT("tag_name"));  // e.g. "v10.5.0"
-    const FString HtmlUrl = JsonObject->GetStringField(TEXT("html_url"));
+    FString TagName;
+    FString HtmlUrl;
+    if (!JsonObject->TryGetStringField(TEXT("tag_name"), TagName) ||
+        !JsonObject->TryGetStringField(TEXT("html_url"), HtmlUrl))
+    {
+        UE_LOG(LogLootLockerSDKEditor, Warning,
+            TEXT("LootLocker update check: GitHub response is missing expected fields."));
+        return;
+    }
 
     // Strip leading 'v' or 'V'
     if (TagName.StartsWith(TEXT("v")) || TagName.StartsWith(TEXT("V")))
@@ -177,7 +176,7 @@ void FLootLockerUpdateChecker::OnResponseReceived(
     {
         if (bManual || ShouldNotify(TagName))
         {
-            ShowUpdateNotification(TagName, HtmlUrl, bManual);
+            ShowUpdateNotification(TagName, HtmlUrl);
         }
     }
     else if (bManual)
@@ -187,7 +186,7 @@ void FLootLockerUpdateChecker::OnResponseReceived(
 }
 
 void FLootLockerUpdateChecker::ShowUpdateNotification(
-    const FString& LatestVersion, const FString& ReleaseUrl, bool bManual)
+    const FString& LatestVersion, const FString& ReleaseUrl)
 {
     if (!FSlateApplication::IsInitialized())
     {
@@ -236,16 +235,6 @@ bool FLootLockerUpdateChecker::IsVersionNewer(const FString& RemoteVersion, cons
         if (Remote < Local) return false;
     }
     return false;  // equal
-}
-
-bool FLootLockerUpdateChecker::IsFabManaged()
-{
-    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
-    if (!Plugin.IsValid())
-    {
-        return false;
-    }
-    return Plugin->GetBaseDir().Contains(TEXT("Marketplace"));
 }
 
 FString FLootLockerUpdateChecker::GetCurrentVersion()

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
@@ -1,0 +1,78 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Containers/Ticker.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+/**
+ * Editor-only utility that checks GitHub Releases for a newer LootLocker SDK version
+ * and shows a non-blocking notification window when one is available.
+ *
+ * Call Initialize() from StartupModule() and Shutdown() from ShutdownModule().
+ * The automatic check fires once after a 180-second startup delay, then at most once
+ * every 24 hours. Silence and skip preferences are persisted via GConfig.
+ */
+class FLootLockerUpdateChecker
+{
+public:
+    /** Called from StartupModule — registers the delayed startup ticker. */
+    static void Initialize();
+
+    /** Called from ShutdownModule — removes the ticker handle. */
+    static void Shutdown();
+
+    /** Manual check triggered from the Tools menu. Bypasses throttle and silence settings. */
+    static void ManualCheck();
+
+    // Called by SLootLockerUpdateNotification button handlers
+    static void SetNeverNotify(bool bValue);
+    static void SetSkippedVersion(const FString& Version);
+    static void SetRemindAfterTime(const FDateTime& Time);
+
+private:
+    static bool OnStartupTick(float DeltaTime);
+
+    static void CheckForUpdate(bool bManual);
+
+    /** Returns true if the automatic check should proceed (throttle + silence guards). */
+    static bool ShouldCheck();
+
+    /** Returns true if the notification window should be shown for LatestVersion. */
+    static bool ShouldNotify(const FString& LatestVersion);
+
+    static void FetchLatestRelease(bool bManual);
+
+    static void OnResponseReceived(
+        FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual);
+
+    static void ShowUpdateNotification(
+        const FString& LatestVersion, const FString& ReleaseUrl, bool bManual);
+
+    static void ShowUpToDateNotification();
+
+    /** Numeric semver comparison — returns true if RemoteVersion is strictly newer than LocalVersion. */
+    static bool IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion);
+
+    /** Returns true if the plugin appears to be installed via Fab (engine Marketplace directory). */
+    static bool IsFabManaged();
+
+    /** Reads the current SDK version from the plugin descriptor. */
+    static FString GetCurrentVersion();
+
+    // --- Config helpers (GEditorPerProjectIni) ---
+    static bool GetNeverNotify();
+    static FString GetSkippedVersion();
+    static FDateTime GetRemindAfterTime();
+    static FDateTime GetLastCheckedTime();
+    static void SaveLastCheckedTime(const FDateTime& Time);
+
+    static FTSTicker::FDelegateHandle TickerHandle;
+    static double ElapsedStartupSeconds;
+
+    static constexpr double StartupDelaySeconds = 15.0;
+    static constexpr double CheckIntervalHours = 24.0;
+    static const TCHAR* ConfigSection;
+    static const TCHAR* GitHubReleasesUrl;
+};

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
@@ -48,15 +48,12 @@ private:
         FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual);
 
     static void ShowUpdateNotification(
-        const FString& LatestVersion, const FString& ReleaseUrl, bool bManual);
+        const FString& LatestVersion, const FString& ReleaseUrl);
 
     static void ShowUpToDateNotification();
 
     /** Numeric semver comparison — returns true if RemoteVersion is strictly newer than LocalVersion. */
     static bool IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion);
-
-    /** Returns true if the plugin appears to be installed via Fab (engine Marketplace directory). */
-    static bool IsFabManaged();
 
     /** Reads the current SDK version from the plugin descriptor. */
     static FString GetCurrentVersion();
@@ -69,9 +66,8 @@ private:
     static void SaveLastCheckedTime(const FDateTime& Time);
 
     static FTSTicker::FDelegateHandle TickerHandle;
-    static double ElapsedStartupSeconds;
 
-    static constexpr double StartupDelaySeconds = 15.0;
+    static constexpr float StartupDelaySeconds = 180.0f;
     static constexpr double CheckIntervalHours = 24.0;
     static const TCHAR* ConfigSection;
     static const TCHAR* GitHubReleasesUrl;

--- a/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#include "SLootLockerUpdateNotification.h"
+#include "LootLockerUpdateChecker.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SSpacer.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/SBoxPanel.h"
+#include "HAL/PlatformProcess.h"
+#include "Framework/Application/SlateApplication.h"
+
+void SLootLockerUpdateNotification::Construct(const FArguments& InArgs)
+{
+    CurrentVersion = InArgs._CurrentVersion;
+    LatestVersion  = InArgs._LatestVersion;
+    ReleaseUrl     = InArgs._ReleaseUrl;
+    ParentWindow   = InArgs._ParentWindow;
+
+    ChildSlot
+    [
+        SNew(SBorder)
+        .Padding(FMargin(16.0f))
+        [
+            SNew(SVerticalBox)
+
+            // Header
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("A new version of the LootLocker SDK is available.")))
+                .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
+            ]
+
+            // Version info
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 4.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Installed:  ")))
+                ]
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("v%s"), *CurrentVersion)))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.6f, 0.6f)))
+                ]
+            ]
+
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 12.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Available:  ")))
+                ]
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("v%s"), *LatestVersion)))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.8f, 0.2f)))
+                ]
+            ]
+
+            // "See what's new" link button
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 16.0f)
+            [
+                SNew(SButton)
+                .ButtonStyle(FCoreStyle::Get(), "NoBorder")
+                .OnClicked(this, &SLootLockerUpdateNotification::OnSeeWhatsNewClicked)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(TEXT("See what's new \u2197")))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
+                ]
+            ]
+
+            // Action buttons — fill available width evenly
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            [
+                SNew(SHorizontalBox)
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Update Now")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnUpdateNowClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Skip This Version")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnSkipVersionClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Remind in 7 Days")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnRemindLaterClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Never Notify Me")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnNeverNotifyClicked)
+                ]
+            ]
+        ]
+    ];
+}
+
+FReply SLootLockerUpdateNotification::OnSeeWhatsNewClicked()
+{
+    if (!ReleaseUrl.IsEmpty())
+    {
+        // Validate URL is from github.com before launching
+        if (ReleaseUrl.StartsWith(TEXT("https://github.com/")))
+        {
+            FPlatformProcess::LaunchURL(*ReleaseUrl, nullptr, nullptr);
+        }
+    }
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnUpdateNowClicked()
+{
+    if (!ReleaseUrl.IsEmpty())
+    {
+        if (ReleaseUrl.StartsWith(TEXT("https://github.com/")))
+        {
+            FPlatformProcess::LaunchURL(*ReleaseUrl, nullptr, nullptr);
+        }
+    }
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnSkipVersionClicked()
+{
+    FLootLockerUpdateChecker::SetSkippedVersion(LatestVersion);
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnRemindLaterClicked()
+{
+    FLootLockerUpdateChecker::SetRemindAfterTime(FDateTime::UtcNow() + FTimespan::FromDays(7.0));
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnNeverNotifyClicked()
+{
+    FLootLockerUpdateChecker::SetNeverNotify(true);
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+void SLootLockerUpdateNotification::CloseParentWindow()
+{
+    if (const TSharedPtr<SWindow> Window = ParentWindow.Pin())
+    {
+        Window->RequestDestroyWindow();
+    }
+}

--- a/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.h
@@ -1,0 +1,36 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#pragma once
+
+#include "Widgets/SCompoundWidget.h"
+#include "Templates/SharedPointer.h"
+
+/**
+ * Non-modal Slate window content shown when a newer LootLocker SDK version is available.
+ * Hosted inside an SWindow created by FLootLockerUpdateChecker::ShowUpdateNotification().
+ */
+class SLootLockerUpdateNotification : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SLootLockerUpdateNotification) {}
+        SLATE_ARGUMENT(FString, CurrentVersion)
+        SLATE_ARGUMENT(FString, LatestVersion)
+        SLATE_ARGUMENT(FString, ReleaseUrl)
+        SLATE_ARGUMENT(TSharedPtr<SWindow>, ParentWindow)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+private:
+    FReply OnSeeWhatsNewClicked();
+    FReply OnUpdateNowClicked();
+    FReply OnSkipVersionClicked();
+    FReply OnRemindLaterClicked();
+    FReply OnNeverNotifyClicked();
+
+    void CloseParentWindow();
+
+    FString CurrentVersion;
+    FString LatestVersion;
+    FString ReleaseUrl;
+    TWeakPtr<SWindow> ParentWindow;
+};


### PR DESCRIPTION
## Summary

Adds an automatic SDK update checker to the `LootLockerSDKEditor` module. On editor startup (after a 180-second delay), the checker queries the GitHub Releases API for a newer version of the SDK and shows a non-blocking notification window if one is available. A manual trigger is also available via **Tools → LootLocker Tools → Check for Updates**.

Closes #1603

---

## Changes

### New — `LootLockerSDKEditor` module

- **`LootLockerUpdateChecker`** — static utility class that handles:
  - Delayed startup check via `FTSTicker` (180s after module startup)
  - HTTP fetch to `https://api.github.com/repos/lootlocker/unreal-sdk/releases/latest`
  - Numeric semver comparison (strips `v`/pre-release suffixes)
  - Throttle (max once per 24h) and silence (never notify / skip version / remind later) logic persisted to `GEditorPerProjectIni`
  - Headless/unattended mode is already guarded at the module level — the checker never initialises in commandlet builds
- **`SLootLockerUpdateNotification`** — non-modal `SWindow` Slate widget with four action buttons:
  - **Update Now** — opens the GitHub release page in the browser
  - **Skip This Version** — suppresses notifications for the specific latest version
  - **Remind in 7 Days** — sets a 7-day cooldown
  - **Never Notify Me** — disables all future automatic notifications

### Modified

- **`LootLockerSDKEditor.cpp`** — calls `FLootLockerUpdateChecker::Initialize()` / `Shutdown()` and registers the "Check for Updates" menu entry under *Tools → LootLocker Tools*
- **`LootLockerSDKEditor.Build.cs`** — adds `Json` and `JsonUtilities` to `PrivateDependencyModuleNames`

---

## Testing

Tested manually with `StartupDelaySeconds` temporarily reduced to 15s:
- Notification window appears when a newer version is available
- All four buttons persist the correct config values and close the window
- Manual menu trigger works and shows "up to date" toast when already current
- Window buttons are evenly distributed and fully visible at all window sizes