### PR TITLE
feat: Add support for listing catalog items by id

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
@@ -651,10 +651,6 @@ FString ULootLockerCatalogRequestHandler::ListCatalogItemsById(const FLootLocker
 
             for (int j = 0; j < JsonMetadataArray.Num(); j++)
             {
-                if (j >= Entry.Metadata.Num())
-                {
-                    break;
-                }
                 TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j].Get()->AsObject();
                 FString MetadataKey = JsonMetadataObject.Get()->GetStringField(TEXT("key"));
                 for (int k = 0; k < Entry.Metadata.Num(); k++)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2021 LootLocker
 
 #include "GameAPI/LootLockerCatalogRequestHandler.h"
+#include "JsonObjectConverter.h"
 #include "LootLockerGameEndpoints.h"
 #include "Utils/LootLockerUtilities.h"
 
@@ -421,8 +422,6 @@ FLootLockerListCatalogPricesResponse::FLootLockerListCatalogPricesResponse(const
 			Detail.Catalog_listing_id,
 			Detail.Id
 			}, Detail);
-
-
 	}
 }
 
@@ -605,4 +604,72 @@ FString ULootLockerCatalogRequestHandler::ListCatalogItemsV2(const FLootLockerPl
     });
 
     return LLAPI<FInternalLootLockerListCatalogPricesV2Response>::CallAPI(FLootLockerEmptyRequest{}, ULootLockerGameEndpoints::ListCatalogItemsByKey, { CatalogKey }, QueryParams, PlayerData, FInternalLootLockerListCatalogPricesV2ResponseDelegate(), InternalResponseConverter);
+}
+
+FString ULootLockerCatalogRequestHandler::ListCatalogItemsById(const FLootLockerPlayerData& PlayerData, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete)
+{
+    FLootLockerListCatalogItemsByIdRequest Request;
+    Request.Ids = CatalogListingIds;
+
+    if (IncludeMetadata)
+    {
+        Request.Includes.Metadata.All = (MetadataKeys.Num() == 0);
+        Request.Includes.Metadata.Keys = MetadataKeys;
+    }
+
+    if (!IncludeMetadata)
+    {
+        return LLAPI<FLootLockerListCatalogItemsByIdResponse>::CallAPI(Request, ULootLockerGameEndpoints::ListCatalogItemsById, {}, {}, PlayerData, OnComplete);
+    }
+
+    LLAPI<FLootLockerListCatalogItemsByIdResponse>::FResponseInspectorCallback MetadataParser = LLAPI<FLootLockerListCatalogItemsByIdResponse>::FResponseInspectorCallback::CreateLambda([OnComplete](FLootLockerListCatalogItemsByIdResponse& Response)
+    {
+        if (!Response.success || Response.Items.Num() == 0)
+        {
+            OnComplete.ExecuteIfBound(Response);
+            return;
+        }
+        TSharedPtr<FJsonObject> FullJsonObject = LootLockerUtilities::JsonObjectFromFString(Response.FullTextFromServer);
+        if (!FullJsonObject.IsValid())
+        {
+            OnComplete.ExecuteIfBound(Response);
+            return;
+        }
+        TArray<TSharedPtr<FJsonValue>> JsonItems = FullJsonObject.Get()->GetArrayField(TEXT("items"));
+        if (JsonItems.Num() != Response.Items.Num())
+        {
+            OnComplete.ExecuteIfBound(Response);
+            return;
+        }
+
+        for (int i = 0; i < JsonItems.Num(); i++)
+        {
+            TSharedPtr<FJsonObject> JsonItemObject = JsonItems[i].Get()->AsObject();
+            // Parse entry-level metadata
+            TArray<TSharedPtr<FJsonValue>> JsonMetadataArray = JsonItemObject.Get()->GetArrayField(TEXT("metadata"));
+            FLootLockerListCatalogItemsByIdEntry& Entry = Response.Items[i];
+
+            for (int j = 0; j < JsonMetadataArray.Num(); j++)
+            {
+                if (j >= Entry.Metadata.Num())
+                {
+                    break;
+                }
+                TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j].Get()->AsObject();
+                FString MetadataKey = JsonMetadataObject.Get()->GetStringField(TEXT("key"));
+                for (int k = 0; k < Entry.Metadata.Num(); k++)
+                {
+                    if (Entry.Metadata[k].Key.Equals(MetadataKey))
+                    {
+                        Entry.Metadata[k]._INTERNAL_SetJsonRepresentation(*JsonMetadataObject.Get());
+                        break;
+                    }
+                }
+            }
+        }
+
+        OnComplete.ExecuteIfBound(Response);
+    });
+
+    return LLAPI<FLootLockerListCatalogItemsByIdResponse>::CallAPI(Request, ULootLockerGameEndpoints::ListCatalogItemsById, {}, {}, PlayerData, FLootLockerListCatalogItemsByIdResponseDelegate(), MetadataParser);
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -278,6 +278,7 @@ FLootLockerEndPoints ULootLockerGameEndpoints::CreateWallet = InitEndpoint("wall
 FLootLockerEndPoints ULootLockerGameEndpoints::ListCatalogs = InitEndpoint("catalogs", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::DeprecatedListCatalogItemsByKey = InitEndpoint("catalog/key/{0}/prices", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::ListCatalogItemsByKey = InitEndpoint("catalogs/inspired-ibex/v1/catalog/key/{0}/list", ELootLockerHTTPMethod::GET);
+FLootLockerEndPoints ULootLockerGameEndpoints::ListCatalogItemsById = InitEndpoint("catalogs/inspired-ibex/v1/catalog/items", ELootLockerHTTPMethod::POST);
 
 // Entitlements
 FLootLockerEndPoints ULootLockerGameEndpoints::ListEntitlements = InitEndpoint("entitlements", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1902,6 +1902,14 @@ FString ULootLockerManager::ListCatalogItemsV2(const FString& ForPlayerWithUlid,
     }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::ListCatalogItemsById(const FString& ForPlayerWithUlid, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseBP& OnComplete)
+{
+    return ULootLockerSDKManager::ListCatalogItemsById(CatalogListingIds, IncludeMetadata, MetadataKeys, FLootLockerListCatalogItemsByIdResponseDelegate::CreateLambda([OnComplete](const FLootLockerListCatalogItemsByIdResponse& Response)
+    {
+        OnComplete.ExecuteIfBound(Response);
+    }), ForPlayerWithUlid);
+}
+
 TArray<FLootLockerInlinedCatalogEntry> ULootLockerManager::ConvertCatalogToInlineItems(const FLootLockerListCatalogPricesResponse& Catalog)
 {
     return ULootLockerCatalogRequestHandler::ConvertCatalogToInlineItems(Catalog);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1386,6 +1386,25 @@ FString ULootLockerSDKManager::ListCatalogItems(const FString& CatalogKey, int P
     return ULootLockerCatalogRequestHandler::ListCatalogItemsV2(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogKey, PerPage, Page, OnComplete);
 }
 
+FString ULootLockerSDKManager::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete, const FString& ForPlayerWithUlid /* = "" */)
+{
+    if (CatalogListingIds.Num() == 0)
+    {
+        FLootLockerListCatalogItemsByIdResponse ErrorResponse = LootLockerResponseFactory::Error<FLootLockerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", -1, ForPlayerWithUlid);
+        OnComplete.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    if (CatalogListingIds.Num() > 100)
+    {
+        FLootLockerListCatalogItemsByIdResponse ErrorResponse = LootLockerResponseFactory::Error<FLootLockerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", -1, ForPlayerWithUlid);
+        OnComplete.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    return ULootLockerCatalogRequestHandler::ListCatalogItemsById(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogListingIds, IncludeMetadata, MetadataKeys, OnComplete);
+}
+
 // Entitlements
 FString ULootLockerSDKManager::ListEntitlements(const int Count, const FString& After, const FLootLockerListEntitlementsResponseDelegate& OnComplete, const FString& ForPlayerWithUlid /* = "" */)
 {

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "LootLockerPlayerData.h"
 #include "LootLockerResponse.h"
+#include "GameAPI/LootLockerMetadataRequestHandler.h"
 #include "LootLockerCatalogRequestHandler.generated.h"
 
 //==================================================
@@ -610,9 +611,10 @@ struct FLootLockerGroupDetails
     FString Description = "";
     /**
      * The metadata of the Group.
+     * @deprecated This field was never used and will be removed.
      */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    TArray<FLootLockerCatalogGroupMetadata> Metadata;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker", meta = (DeprecatedProperty, DeprecationMessage = "This field was never used and will be removed"))
+    TArray<FLootLockerCatalogGroupMetadata> Metadata; // Deprecation date 2026-06-30
     /**
      * The ID of the reward.
      */
@@ -921,6 +923,233 @@ struct FLootLockerListCatalogPricesV2Response : public FLootLockerResponse
     TArray<FLootLockerInlinedCatalogEntry> GetLootLockerInlinedCatalogEntries() const;
 };
 
+/**
+ * Metadata include configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerMetadataInclude
+{
+    GENERATED_BODY()
+    /**
+    * If true, all metadata entries for the item are returned.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool All = false;
+
+    /**
+    * Specific metadata key names to filter by. Only used when bAll is false.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> Keys;
+};
+
+/**
+ * Optional includes configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerCatalogItemsIncludes
+{
+    GENERATED_BODY()
+    /**
+    * Metadata include configuration. If not set, metadata is not included.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerMetadataInclude Metadata;
+};
+
+/**
+ * Request body for looking up catalog items by their catalog_listing_ids.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdRequest
+{
+    GENERATED_BODY()
+    /**
+    * Array of catalog_listing_id strings to look up (max 100)
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> Ids;
+
+    /**
+    * Optional includes configuration to control what additional data is returned
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCatalogItemsIncludes Includes;
+};
+
+/**
+ * A group association with the entity detail inlined directly.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerInlinedGroupAssociation
+{
+    GENERATED_BODY()
+    /**
+    * The entity kind of this association (asset, currency, progression_points, progression_reset)
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    ELootLockerCatalogEntryEntityKind Kind = ELootLockerCatalogEntryEntityKind::Asset;
+
+    /**
+    * The unique id of the entity
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Id;
+
+    /**
+    * The catalog listing id for this association
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Catalog_listing_id;
+
+    /**
+    * Asset details inlined, populated when kind is asset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerAssetDetails Asset_detail;
+
+    /**
+    * Currency details inlined, populated when kind is currency
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCurrencyDetails Currency_detail;
+
+    /**
+    * Progression point details inlined, populated when kind is progression_points
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionPointDetails Progression_point_detail;
+
+    /**
+    * Progression reset details inlined, populated when kind is progression_reset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionResetDetails Progression_reset_detail;
+};
+
+/**
+ * Group detail used by the ListCatalogItemsById endpoint, where association details are
+ * inlined directly into each association entry by the backend.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerInlinedGroupDetailsWithAssociations
+{
+    GENERATED_BODY()
+    /**
+    * The name of the Group.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Name;
+
+    /**
+    * The description of the Group.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Description;
+
+    /**
+    * The ID of the reward.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Id;
+
+    /**
+    * The catalog listing id for this group detail.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Catalog_listing_id;
+
+    /**
+    * Associations with entity details inlined directly.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerInlinedGroupAssociation> Associations;
+};
+
+/**
+ * A catalog entry with entity details inlined directly. Used by the ListCatalogItemsById endpoint.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdEntry : public FLootLockerCatalogEntry
+{
+    GENERATED_BODY()
+    /**
+    * Asset details inlined, non-null when entity_kind is asset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerAssetDetails Asset_detail;
+
+    /**
+    * Currency details inlined, non-null when entity_kind is currency
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCurrencyDetails Currency_detail;
+
+    /**
+    * Progression point details inlined, non-null when entity_kind is progression_points
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionPointDetails Progression_point_detail;
+
+    /**
+    * Progression reset details inlined, non-null when entity_kind is progression_reset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionResetDetails Progression_reset_detail;
+
+    /**
+    * Group details inlined, non-null when entity_kind is group
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerInlinedGroupDetailsWithAssociations Group_detail;
+
+    /**
+    * Metadata entries. Populated when includes.metadata is set.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerMetadataEntry> Metadata;
+};
+
+/**
+ * Describes why a specific catalog_listing_id could not be resolved.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdError
+{
+    GENERATED_BODY()
+    /**
+    * The catalog_listing_id that failed
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Id;
+
+    /**
+    * The reason (e.g. "not_found")
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Reason;
+};
+
+/**
+ * Response for the ListCatalogItemsById endpoint.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+    * Array of inlined catalog entries matching the successfully resolved IDs
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerListCatalogItemsByIdEntry> Items;
+
+    /**
+    * Errors for IDs that could not be resolved. Omitted when all IDs succeeded.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerListCatalogItemsByIdError> Errors;
+};
+
 //==================================================
 // Delegate Definitions
 //==================================================
@@ -947,7 +1176,10 @@ DECLARE_DELEGATE_OneParam(FInternalLootLockerListCatalogPricesResponseDelegate, 
  * Internal C++ response delegate for listing items and prices in a catalog with details as arrays
  */
 DECLARE_DELEGATE_OneParam(FInternalLootLockerListCatalogPricesV2ResponseDelegate, FInternalLootLockerListCatalogPricesV2Response);
-
+/**
+ * Delegate for ListCatalogItemsById response
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerListCatalogItemsByIdResponseDelegate, FLootLockerListCatalogItemsByIdResponse);
 
 //==================================================
 // API Class Definition
@@ -964,6 +1196,7 @@ public:
     static FString ListCatalogs(const FLootLockerPlayerData& PlayerData, const FLootLockerListCatalogsResponseDelegate& OnComplete);
     static FString ListCatalogItems(const FLootLockerPlayerData& PlayerData, const FString& CatalogKey, int Count, const FString& After, const FLootLockerListCatalogPricesResponseDelegate& OnComplete);
     static FString ListCatalogItemsV2(const FLootLockerPlayerData& PlayerData, const FString& CatalogKey, int PerPage, int Page, const FLootLockerListCatalogPricesV2ResponseDelegate& OnComplete);
+    static FString ListCatalogItemsById(const FLootLockerPlayerData& PlayerData, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete);
     static TArray<FLootLockerInlinedCatalogEntry> ConvertCatalogToInlineItems(const FLootLockerListCatalogPricesResponse& Catalog)
     {
         return Catalog.GetLootLockerInlinedCatalogEntries();

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCharacterRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCharacterRequestHandler.h
@@ -103,6 +103,8 @@ struct FLootLockerListCharacterResponseItem {
 	FString name = "";
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString id = "";
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FString ulid = "";
 };
 
 USTRUCT(BlueprintType)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -313,6 +313,7 @@ public:
     static FLootLockerEndPoints ListCatalogs;
     static FLootLockerEndPoints DeprecatedListCatalogItemsByKey;
     static FLootLockerEndPoints ListCatalogItemsByKey;
+    static FLootLockerEndPoints ListCatalogItemsById;
 
     // Entitlements
     static FLootLockerEndPoints ListEntitlements;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -377,6 +377,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogsResponseBP, FLootLocker
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogPricesResponseBP, FLootLockerListCatalogPricesResponse, Response);
 /** Blueprint response delegate for listing catalog prices responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogPricesV2ResponseBP, FLootLockerListCatalogPricesV2Response, Response);
+/** Blueprint response delegate for listing catalog items by id responses */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogItemsByIdResponseBP, FLootLockerListCatalogItemsByIdResponse, Response);
 /** Blueprint response delegate for internal listing catalog prices responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FInternalLootLockerListCatalogPricesResponseBP, FInternalLootLockerListCatalogPricesResponse, Response);
 /** Blueprint response delegate for internal listing catalog prices responses */
@@ -3491,6 +3493,18 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "PerPage,Page,ForPlayerWithUlid", PerPage = -1, Page = -1, ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsV2(const FString& ForPlayerWithUlid, const FString& CatalogKey, int PerPage, int Page, const FLootLockerListCatalogPricesV2ResponseBP& OnComplete);
+
+    /**
+     List catalog items by their catalog_listing_ids. Returns entries with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. Only applicable if IncludeMetadata is true. If empty, all metadata is returned.
+     @param OnComplete Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys,ForPlayerWithUlid"))
+    static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsById(const FString& ForPlayerWithUlid, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseBP& OnComplete);
 
     /**
      Inline the data items from a catalog response into the catalog items

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -3503,7 +3503,7 @@ public:
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
      @return A unique id for this request
     */
-    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys,ForPlayerWithUlid"))
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys,ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsById(const FString& ForPlayerWithUlid, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseBP& OnComplete);
 
     /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -3165,6 +3165,17 @@ public:
      */
     static FString ListCatalogItems(const FString & CatalogKey, const FLootLockerListCatalogPricesV2ResponseDelegate & OnComplete, const FString& ForPlayerWithUlid = "") { return ListCatalogItems(CatalogKey, -1, 0, OnComplete, ForPlayerWithUlid); }
 
+    /**
+     List catalog items by their catalog_listing_ids. Returns entries with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. Only applicable if IncludeMetadata is true. If empty, all metadata is returned.
+     @param OnComplete Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+     */
+    static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete, const FString& ForPlayerWithUlid = "");
+
     /// @}
 
     //==================================================


### PR DESCRIPTION
## Tracking issue

https://github.com/lootlocker/index/issues/1526 (client side reflection of https://github.com/lootlocker/index/issues/1408)

## Description

The catalog listing endpoint is a paginated view of the entire catalog, and while it is fast I found myself sometimes wanting a convenience method for looking up a single (or a batch of) catalog listing ids with their data inlined in the object and the metadata for the item all in one go.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing notes

Automated test added