### PR TITLE
Release Candidate v10.5.0

### DIFF
--- a/.github/instructions/release-notes.md
+++ b/.github/instructions/release-notes.md
@@ -1,0 +1,87 @@
+# Release Notes Template
+
+Use this template when drafting a GitHub release for the Unreal Game SDK.
+
+## Title Format
+
+```
+LootLocker_UnrealSDK_V{MAJOR}.{MINOR}.{PATCH}
+```
+
+Examples: `LootLocker_UnrealSDK_V10.4.0`, `LootLocker_UnrealSDK_V10.3.2`
+
+---
+
+## Body Template — Major/Minor Release
+
+```markdown
+### Features
+
+• 🚀 **Feature Title** — Description of the feature. Keep it user-facing and
+actionable. Mention what problem it solves or what new capability it unlocks.
+• 🔗 **Another Feature** — Another description. Use emojis to visually group
+related features (e.g. 💳 for payments, 📱 for platform-specific, 🎮 for auth).
+• 📚 **Documentation / Tooling** — If applicable.
+• Minor additions without their own emoji header.
+
+### Fixes
+
+• Fixed an issue where X would happen when Y.
+• Fixed a crash when Z was null.
+• Fixed compilation errors on platform/engine version.
+• Fixed `UProperty` name mismatches between C++ and Blueprint surfaces.
+
+### Breaking Changes
+
+• Removed `DeprecatedClass` / `DeprecatedMethod` — use `NewClass` / `NewMethod` instead.
+• `EOldEnum` replaced by `ENewEnum` — update your switch statements.
+
+### Deprecations
+
+• `OldMethod` is now deprecated and will be removed in v{NEXT_MAJOR}. Migrate to `NewMethod`.
+
+### Refactoring
+
+• Summary of internal changes that users should be aware of but don't change
+the public API surface (e.g. HTTP client rewrite, delegate restructuring).
+
+Full Changelog: [v{PREV_VERSION}...v{NEW_VERSION}](https://github.com/lootlocker/unreal-sdk/compare/v{PREV_VERSION}...v{NEW_VERSION})
+```
+
+---
+
+## Body Template — Patch Release
+
+```markdown
+### Fix
+
+• Fixed a crash when X is null.
+• Fixed missing `UPROPERTY` / `UFUNCTION` specifiers.
+• Fixed packaging/building error on engine version Y.
+
+Full Changelog: [v{PREV_VERSION}...v{NEW_VERSION}](https://github.com/lootlocker/unreal-sdk/compare/v{PREV_VERSION}...v{NEW_VERSION})
+```
+
+---
+
+## Writing Guidelines
+
+- **Audience:** Game developers using LootLocker in Unreal Engine. Keep
+  descriptions user-facing — describe what _they_ can do or what was fixed
+  for _them_. Use Unreal terms: Blueprint, UCLASS, UFUNCTION, UPROPERTY,
+  UObject, Actor, etc.
+- **Links:** Use full URLs for cross-references (blog posts, docs, compare links).
+- **Emojis:** Use to visually group features. Common ones:
+  - 🚀 Major new capability
+  - 💳 Payments / purchases
+  - 🎮 Authentication / platforms
+  - 📱 Platform-specific (mobile, console)
+  - 📚 Documentation / reference docs
+  - 🧪 Testing / CI
+  - ⚡ Performance / real-time (Presence, WebSockets)
+  - 🔍 Filtering / search
+  - 🔗 Linking / connected accounts / remote sessions
+  - 🛒 Store / catalog
+  - 📣 Broadcasts / notifications
+- **Sections:** Only include sections that have content. Don't add empty headings.
+- **Compare link:** Always include the `Full Changelog` link at the bottom.

--- a/.github/scripts/run-tests.ps1
+++ b/.github/scripts/run-tests.ps1
@@ -19,16 +19,28 @@
     starts with "LootLocker.", so the default "LootLocker" runs all of them.
     Use a more specific substring to run a subset — e.g. "LootLocker.Balances".
 
+.PARAMETER NoBuild
+    Skip the BuildPlugin step and reuse the previously built binaries. Useful
+    for iterating on tests without waiting for a full rebuild. Ignored (build
+    always runs) when -Clean is also specified.
+
 .PARAMETER Clean
     Delete the previous build output before building. Omit for a faster
-    incremental build (UAT reuses cached artifacts).
+    incremental build (UAT reuses cached artifacts). Overrides -NoBuild.
+
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for UnrealEditor-Cmd.exe to exit after tests finish.
+    If exceeded the process is killed and the run is reported as failed.
+    Defaults to 600 (10 minutes).
 
 .NOTES
     Exit codes: 0 = all tests passed, 1 = one or more tests failed or setup error.
 #>
 param(
     [string]$TestFilter = "LootLocker",
-    [switch]$Clean
+    [switch]$NoBuild,
+    [switch]$Clean,
+    [int]$TimeoutSeconds = 600
 )
 
 $ErrorActionPreference = 'Stop'
@@ -89,27 +101,15 @@ if (-not $PluginFile) {
     exit 1
 }
 
+$ShouldBuild = $Clean -or (-not $NoBuild)
+
 # ---------------------------------------------------------------------------
-# 2. Temporarily disable UBA (same reason as in verify-compilation.ps1)
+# 2. Temporarily disable UBA + 3. Build the plugin
 # ---------------------------------------------------------------------------
 $UbtConfigDir    = Join-Path $env:APPDATA "Unreal Engine\UnrealBuildTool"
 $UbtConfigFile   = Join-Path $UbtConfigDir "BuildConfiguration.xml"
 $UbtConfigBackup = $UbtConfigFile + ".run-tests-backup"
 $WroteUbtConfig  = $false
-
-if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
-if (Test-Path $UbtConfigFile) { Copy-Item $UbtConfigFile $UbtConfigBackup -Force }
-
-$noUbaXml = @'
-<?xml version="1.0" encoding="utf-8" ?>
-<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
-  <BuildConfiguration>
-    <bAllowUBAExecutor>false</bAllowUBAExecutor>
-  </BuildConfiguration>
-</Configuration>
-'@
-[IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
-$WroteUbtConfig = $true
 
 function Restore-UbtConfig {
     if ($script:WroteUbtConfig) {
@@ -122,72 +122,93 @@ function Restore-UbtConfig {
     }
 }
 
-Write-Step "Note: Disabled UBA local executor (restored after tests)."
-Write-Step ""
+if ($ShouldBuild) {
+    # Temporarily disable UBA (same reason as in verify-compilation.ps1)
+    if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
+    if (Test-Path $UbtConfigFile) { Copy-Item $UbtConfigFile $UbtConfigBackup -Force }
 
-# ---------------------------------------------------------------------------
-# 3. Build the plugin (ensures the latest test code is compiled into binaries)
-# ---------------------------------------------------------------------------
-Write-Step "Step 1/3 - Building plugin via RunUAT BuildPlugin ..."
-Write-Step "Plugin  : $($PluginFile.FullName)"
-Write-Step "Engine  : $UnrealRoot"
-Write-Step "Output  : $BuildOutput"
-Write-Step ""
+    $noUbaXml = @'
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+  </BuildConfiguration>
+</Configuration>
+'@
+    [IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
+    $WroteUbtConfig = $true
+    Write-Step "Note: Disabled UBA local executor (restored after tests)."
+    Write-Step ""
 
-$BuildLogDir = Split-Path $BuildLog
-if (-not (Test-Path $BuildLogDir)) { New-Item -ItemType Directory -Path $BuildLogDir -Force | Out-Null }
-if (Test-Path $BuildLog) { Remove-Item $BuildLog -Force }
+    # Build the plugin (ensures the latest test code is compiled into binaries)
+    Write-Step "Step 1/3 - Building plugin via RunUAT BuildPlugin ..."
+    Write-Step "Plugin  : $($PluginFile.FullName)"
+    Write-Step "Engine  : $UnrealRoot"
+    Write-Step "Output  : $BuildOutput"
+    Write-Step ""
 
-if ($Clean) {
-    if (Test-Path $BuildOutput) {
-        Write-Step "Cleaning previous build output..."
-        & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+    $BuildLogDir = Split-Path $BuildLog
+    if (-not (Test-Path $BuildLogDir)) { New-Item -ItemType Directory -Path $BuildLogDir -Force | Out-Null }
+    if (Test-Path $BuildLog) { Remove-Item $BuildLog -Force }
+
+    if ($Clean) {
         if (Test-Path $BuildOutput) {
-            Write-Warn "Warning: Could not fully remove previous build output - UAT will attempt to overwrite."
+            Write-Step "Cleaning previous build output..."
+            & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+            if (Test-Path $BuildOutput) {
+                Write-Warn "Warning: Could not fully remove previous build output - UAT will attempt to overwrite."
+            }
         }
+    } elseif (Test-Path $BuildOutput) {
+        Write-Step "Reusing existing build output (pass -Clean to force a full rebuild)."
     }
-} elseif (Test-Path $BuildOutput) {
-    Write-Step "Reusing existing build output (pass -Clean to force a full rebuild)."
-}
 
-$prevEAP = $ErrorActionPreference
-$ErrorActionPreference = 'Continue'
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
 
-$buildLines  = [System.Collections.Generic.List[string]]::new()
-$buildStream = [System.IO.StreamWriter]::new($BuildLog, $false, [System.Text.Encoding]::UTF8)
+    $buildLines  = [System.Collections.Generic.List[string]]::new()
+    $buildStream = [System.IO.StreamWriter]::new($BuildLog, $false, [System.Text.Encoding]::UTF8)
 
-$uatArgs = @(
-    "BuildPlugin"
-    "-Plugin=`"$($PluginFile.FullName)`""
-    "-Package=`"$BuildOutput`""
-    "-Rocket"
-    "-TargetPlatforms=Win64"
-    "-VS2022"
-)
+    $uatArgs = @(
+        "BuildPlugin"
+        "-Plugin=`"$($PluginFile.FullName)`""
+        "-Package=`"$BuildOutput`""
+        "-Rocket"
+        "-TargetPlatforms=Win64"
+        "-VS2022"
+    )
 
-try {
-    & $RunUAT @uatArgs 2>&1 | ForEach-Object {
-        $line = "$_"
-        $buildLines.Add($line)
-        $buildStream.WriteLine($line)
-        $buildStream.Flush()
-        Write-Host $line
+    try {
+        & $RunUAT @uatArgs 2>&1 | ForEach-Object {
+            $line = "$_"
+            $buildLines.Add($line)
+            $buildStream.WriteLine($line)
+            $buildStream.Flush()
+            Write-Host $line
+        }
+    } finally {
+        $buildStream.Close()
     }
-} finally {
-    $buildStream.Close()
-}
-$buildExit = $LASTEXITCODE
-$ErrorActionPreference = $prevEAP
+    $buildExit = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
 
-if ($buildExit -ne 0) {
-    Restore-UbtConfig
-    Write-Fail "BUILD FAILED - cannot run tests without compiled binaries."
-    Write-Step "Full build log: $BuildLog"
-    exit 1
+    if ($buildExit -ne 0) {
+        Restore-UbtConfig
+        Write-Fail "BUILD FAILED - cannot run tests without compiled binaries."
+        Write-Step "Full build log: $BuildLog"
+        exit 1
+    }
+    Write-Step ""
+    Write-Ok "Plugin built successfully."
+    Write-Step ""
+} else {
+    if (-not (Test-Path $BuildOutput)) {
+        Write-Fail "ERROR: No previous build found at $BuildOutput - run without -NoBuild first."
+        exit 1
+    }
+    Write-Warn "Skipping build (-NoBuild). Reusing existing binaries in: $BuildOutput"
+    Write-Step ""
 }
-Write-Step ""
-Write-Ok "Plugin built successfully."
-Write-Step ""
 
 # ---------------------------------------------------------------------------
 # 4. Set up VerificationProject pointing at the compiled plugin output
@@ -248,7 +269,10 @@ $TestLogDir = Split-Path $TestLog
 if (-not (Test-Path $TestLogDir)) { New-Item -ItemType Directory -Path $TestLogDir -Force | Out-Null }
 if (Test-Path $TestLog) { Remove-Item $TestLog -Force }
 
-$execCmd    = "automation RunTests $TestFilter;quit"
+# UE's -ExecCmds treats ',' as a command separator, so translate to '+' which
+# is the automation system's own OR-filter separator.
+$automationFilter = $TestFilter -replace ',', '+'
+$execCmd    = "automation RunTests $automationFilter;quit"
 $editorArgs = @(
     "`"$ProjectFile`""
     "-unattended"
@@ -256,29 +280,90 @@ $editorArgs = @(
     "-nosound"
     "-NoSplash"
     "-NoPause"
+    "-NoTargetPlatforms"
     "-stdout"
     "-FullStdOutLogOutput"
     "-SkipBadPlugins"
+    "-LogCmds=`"LogTemp Verbose`""
     "-ExecCmds=`"$execCmd`""
 )
 
+$prevEAP = $ErrorActionPreference
 $ErrorActionPreference = 'Continue'
 $outputLines = [System.Collections.Generic.List[string]]::new()
 $testStream  = [System.IO.StreamWriter]::new($TestLog, $false, [System.Text.Encoding]::UTF8)
+$timedOut    = $false
+
+# Run the editor inside a separate runspace so the main thread can enforce a
+# hard timeout. We keep PowerShell's native & call operator (not
+# ProcessStartInfo redirection) so UE's -stdout/-FullStdOutLogOutput flags
+# work correctly — UE suppresses output when stdout is redirected at the OS level.
+$outputQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+$ueRunspace  = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace()
+$ueRunspace.Open()
+$ueRunspace.SessionStateProxy.SetVariable('EditorCmd',   $EditorCmd)
+$ueRunspace.SessionStateProxy.SetVariable('editorArgs',  $editorArgs)
+$ueRunspace.SessionStateProxy.SetVariable('outputQueue', $outputQueue)
+
+$uePowerShell = [System.Management.Automation.PowerShell]::Create()
+$uePowerShell.Runspace = $ueRunspace
+[void]$uePowerShell.AddScript({
+    & $EditorCmd @editorArgs 2>&1 | ForEach-Object { $outputQueue.Enqueue("$_") }
+})
+
+# Snapshot existing UE pids so we can kill only our new instance on timeout.
+$priorUEPids = @(Get-Process -Name "UnrealEditor-Cmd" -ErrorAction SilentlyContinue |
+                 Select-Object -ExpandProperty Id)
+$ueProc   = $null
+$ueHandle = $uePowerShell.BeginInvoke()
 
 try {
-    & $EditorCmd @editorArgs 2>&1 | ForEach-Object {
-        $line = "$_"
-        $outputLines.Add($line)
-        $testStream.WriteLine($line)
+    # Wait up to 30 s for our editor process to appear so we have its PID for a targeted kill.
+    $spawnDeadline = [DateTime]::Now.AddSeconds(30)
+    while ($null -eq $ueProc -and [DateTime]::Now -lt $spawnDeadline -and -not $ueHandle.IsCompleted) {
+        $ueProc = Get-Process -Name "UnrealEditor-Cmd" -ErrorAction SilentlyContinue |
+                  Where-Object { $priorUEPids -notcontains $_.Id } |
+                  Select-Object -First 1
+        if ($null -eq $ueProc) { Start-Sleep -Milliseconds 500 }
+    }
+
+    $deadline = [DateTime]::Now.AddSeconds($TimeoutSeconds)
+    while (-not $ueHandle.IsCompleted) {
+        $item = $null
+        while ($outputQueue.TryDequeue([ref]$item)) {
+            $outputLines.Add($item)
+            $testStream.WriteLine($item)
+            $testStream.Flush()
+            Write-Host $item
+            $item = $null
+        }
+        if ([DateTime]::Now -gt $deadline) {
+            $timedOut = $true
+            Write-Warn ""
+            Write-Warn "TIMEOUT: killing UnrealEditor-Cmd.exe (no exit within $TimeoutSeconds s)"
+            if ($null -ne $ueProc -and -not $ueProc.HasExited) { $ueProc.Kill() }
+            $uePowerShell.Stop()
+            break
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    if (-not $timedOut) { try { [void]$uePowerShell.EndInvoke($ueHandle) } catch {} }
+    # Drain any output still queued after the runspace finished.
+    $item = $null
+    while ($outputQueue.TryDequeue([ref]$item)) {
+        $outputLines.Add($item)
+        $testStream.WriteLine($item)
         $testStream.Flush()
-        Write-Host $line
+        Write-Host $item
+        $item = $null
     }
 } finally {
     $testStream.Close()
+    $uePowerShell.Dispose()
+    $ueRunspace.Close()
+    $ueRunspace.Dispose()
     Restore-UbtConfig
 }
-$editorExit = $LASTEXITCODE
 $ErrorActionPreference = $prevEAP
 
 # ---------------------------------------------------------------------------
@@ -291,6 +376,12 @@ $ErrorActionPreference = $prevEAP
 Write-Step ""
 Write-Step "--- Test results ---"
 Write-Step ""
+
+if ($timedOut) {
+    Write-Fail "TIMED OUT - UnrealEditor-Cmd.exe did not exit within $TimeoutSeconds seconds"
+    Write-Step "Full log: $TestLog"
+    exit 1
+}
 
 $passedLines = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Passed|Success)\}?"
 $failedLines  = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Failed|Fail)\}?"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,159 @@
+name: Create Release
+run-name: "Create Release from ${{ github.ref_name }}"
+
+on:
+  workflow_run:
+    workflows: ["Smoke Test"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to pull release notes from (e.g. 123)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Find merged PR that triggered this push (or use dispatch input)
+        id: find-pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            echo "Manual dispatch - fetching PR #${PR_NUMBER}"
+          else
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            echo "Looking up PR for commit ${HEAD_SHA}"
+            PR_NUMBER=$(gh pr list \
+              --search "${HEAD_SHA}" \
+              --state merged \
+              --json number \
+              --limit 1 \
+              --jq '.[0].number')
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No PR found. Not a release-eligible push."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json number,body,labels,title,state --jq '.')
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          HAS_RC_LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | index("release candidate") != null')
+
+          echo "Found PR #${PR_NUMBER}: ${PR_TITLE}"
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_RC_LABEL" != "true" ]; then
+            echo "::notice::PR #${PR_NUMBER} does not have 'release candidate' label. Skipping release."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$PR_JSON" | jq -r '.body' > /tmp/pr-body.md
+          echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate release notes (PR body is non-empty)
+        id: validate
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          if [ ! -s /tmp/pr-body.md ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            exit 1
+          fi
+          echo "Release notes found ($(wc -c < /tmp/pr-body.md) bytes)."
+
+      - name: Read version from .uplugin
+        id: version
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          TAG="v${VERSION}"
+          echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION} -> Tag: ${TAG}"
+
+      - name: Check tag does not already exist
+        id: check-tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists. Version must be bumped."
+            exit 1
+          fi
+          echo "Tag ${TAG} is available."
+
+      - name: Validate version bump against latest tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          compare_versions() { echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'; }
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version $NEW_VERSION is not greater than latest release $LATEST_VERSION."
+            exit 1
+          fi
+          echo "Version bump validated: ${LATEST_VERSION} -> ${NEW_VERSION}"
+
+      - name: Create git tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed tag ${TAG}"
+
+      - name: Create GitHub Release
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          TITLE="LootLocker_UnrealSDK_V${VERSION}"
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes-file /tmp/pr-body.md \
+            --target main
+          echo "Created release ${TAG}"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Post release notification on PR
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          PR_NUMBER="${{ steps.find-pr.outputs.PR_NUMBER }}"
+          REPO="${{ github.repository }}"
+          printf -v BODY '**Release [%s](https://github.com/%s/releases/tag/%s) created.**\n\nWorkflows now running:\n- [Package SDK](https://github.com/%s/actions/workflows/unreal-sdk-packager.yml) - builds and attaches packages\n- [Generate Docs](https://github.com/%s/actions/workflows/generate-docs.yml) - deploys reference docs' \
+            "$TAG" "$REPO" "$TAG" "$REPO" "$REPO"
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -4,7 +4,7 @@ run-name: "Enforce release candidate PR requirements"
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize, labeled, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -1,0 +1,130 @@
+name: Enforce Release PR
+run-name: "Enforce release candidate PR requirements"
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  enforce:
+    name: Validate release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: contains(github.event.pull_request.labels.*.name, 'release candidate')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate PR body structure
+        id: check-body
+        run: |
+          BODY=$(jq -r '.pull_request.body // ""' < "$GITHUB_EVENT_PATH")
+          if [ -z "$(echo "$BODY" | tr -d '[:space:]')" ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            echo "BODY_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "BODY_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$BODY" | grep -q '^### '; then
+            echo "HAS_SECTIONS=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::PR body must have at least one section header (### Features, ### Fixes, etc.)."
+            echo "HAS_SECTIONS=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$BODY" | grep -qi 'Full Changelog:'; then
+            echo "HAS_CHANGELOG_LINK=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PR body is missing a Full Changelog: compare link."
+            echo "HAS_CHANGELOG_LINK=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read version from .uplugin
+        id: version
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version in branch: ${VERSION}"
+
+      - name: Get latest release tag
+        id: latest-tag
+        run: |
+          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "v0.0.0"')
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Latest release tag: ${LATEST_TAG}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate version bump
+        id: check-version
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          LATEST_TAG="${{ steps.latest-tag.outputs.TAG }}"
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          compare_versions() { echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'; }
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version ${NEW_VERSION} is not greater than latest release ${LATEST_VERSION}."
+            echo "VERSION_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version bump OK: ${LATEST_VERSION} -> ${NEW_VERSION}"
+            echo "VERSION_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report and post status comment
+        if: always()
+        run: |
+          VERSION_OK="${{ steps.check-version.outputs.VERSION_OK }}"
+          BODY_OK="${{ steps.check-body.outputs.BODY_OK }}"
+          HAS_SECTIONS="${{ steps.check-body.outputs.HAS_SECTIONS }}"
+          HAS_CHANGELOG_LINK="${{ steps.check-body.outputs.HAS_CHANGELOG_LINK }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          issues=""
+          if [ "$VERSION_OK" != "true" ]; then
+            issues="${issues}\\n- Version not bumped. Latest release is ${{ steps.latest-tag.outputs.TAG }} but this PR has v${VERSION}."
+          fi
+          if [ "$BODY_OK" != "true" ]; then
+            issues="${issues}\\n- PR body is empty. Add release notes to the PR description."
+          fi
+          if [ "$HAS_SECTIONS" != "true" ]; then
+            issues="${issues}\\n- No section headers found. Add at least one ### section."
+          fi
+          warnings=""
+          if [ "$HAS_CHANGELOG_LINK" != "true" ]; then
+            warnings="${warnings}\\n- Missing Full Changelog link - consider adding one."
+          fi
+
+          if [ -n "$issues" ]; then
+            printf "### Release PR Validation Failed\n${issues}${warnings}\n" > /tmp/status.md
+          else
+            printf "### Release PR Validation Passed\n\n- Version: **v${VERSION}** (bumped from ${{ steps.latest-tag.outputs.TAG }})\n- Release notes: present (section headers found)" > /tmp/status.md
+            if [ "$HAS_CHANGELOG_LINK" = "true" ]; then printf ", changelog link present" >> /tmp/status.md; fi
+            printf "\n" >> /tmp/status.md
+          fi
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("### Release PR Validation")) | .id' | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              --field body="$(cat /tmp/status.md)"
+          else
+            gh pr comment "$PR_NUMBER" --body "$(cat /tmp/status.md)"
+          fi
+          if [ -n "$issues" ]; then exit 1; fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -54,6 +54,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download docs artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -2,12 +2,6 @@ name: Generate Docs
 run-name: "Generate Docs on ${{ github.ref_name }}"
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
   release:
     types: [published]
   workflow_dispatch: {}

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -41,16 +41,20 @@ jobs:
         id: current
         run: |
           VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Current version: ${VERSION}"
 
       - name: Get previous release tag and commit log
         id: prev-tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Previous tag: ${LATEST_TAG:-none}"
-          if [ -n "$LATEST_TAG" ]; then
+          echo "Previous tag: ${LATEST_TAG}"
+          if [ "$LATEST_TAG" != "v0.0.0" ]; then
             REV_RANGE="${LATEST_TAG}..HEAD"
           else
             REV_RANGE="HEAD"
@@ -77,23 +81,24 @@ jobs:
           if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
             echo "Auto-detecting version from OpenRouter..."
             if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
-              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
-              exit 1
+              echo "::warning::OPENROUTER_API_KEY not set. Falling back to patch bump."
+              BUMP="patch"
+            else
+              COMMITS=$(head -100 /tmp/commits.log)
+              printf 'The current version is v%s. Based on these commit messages since the last release, determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 10.5.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+              RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+                -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+                -H "Content-Type: application/json" \
+                -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+              NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+              if [ -z "$NEW" ]; then
+                echo "::warning::AI returned no parseable version. Falling back to patch bump."
+                BUMP="patch"
+              else
+                echo "AI suggested version: ${NEW}"
+                ALREADY_CALCULATED=true
+              fi
             fi
-            COMMITS=$(head -100 /tmp/commits.log)
-            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 10.5.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
-            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
-              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
-            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-            if [ -z "$NEW" ]; then
-              echo "::warning::AI returned no parseable version, falling back to patch bump."
-              PATCH=$(echo "$CURRENT" | cut -d. -f3)
-              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
-            fi
-            echo "AI suggested version: ${NEW}"
-            ALREADY_CALCULATED=true
           fi
 
           if [ "$ALREADY_CALCULATED" = "false" ]; then

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,179 @@
+name: Open Release PR
+run-name: "Open release candidate PR for ${{ inputs.bump }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Type of version bump
+        required: true
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+        default: auto
+      custom_version:
+        description: Custom version override (e.g. 10.5.0). Leave empty to use semver bump.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-pr:
+    name: Create release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Read current version
+        id: current
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version: ${VERSION}"
+
+      - name: Get previous release tag and commit log
+        id: prev-tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${LATEST_TAG:-none}"
+          if [ -n "$LATEST_TAG" ]; then
+            REV_RANGE="${LATEST_TAG}..HEAD"
+          else
+            REV_RANGE="HEAD"
+          fi
+          git log "$REV_RANGE" --format="%s" > /tmp/commits.log
+          COMMIT_COUNT=$(wc -l < /tmp/commits.log)
+          echo "Commits: ${COMMIT_COUNT}"
+          echo "COMMIT_COUNT=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate new version
+        id: new-version
+        run: |
+          CURRENT="${{ steps.current.outputs.VERSION }}"
+          CUSTOM="${{ inputs.custom_version }}"
+          BUMP="${{ inputs.bump }}"
+          ALREADY_CALCULATED=false
+
+          if [ -n "$CUSTOM" ]; then
+            NEW="$CUSTOM"
+            echo "Using custom version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
+            echo "Auto-detecting version from OpenRouter..."
+            if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
+              exit 1
+            fi
+            COMMITS=$(head -100 /tmp/commits.log)
+            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 10.5.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [ -z "$NEW" ]; then
+              echo "::warning::AI returned no parseable version, falling back to patch bump."
+              PATCH=$(echo "$CURRENT" | cut -d. -f3)
+              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
+            fi
+            echo "AI suggested version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$ALREADY_CALCULATED" = "false" ]; then
+            BUMP="${{ inputs.bump }}"
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+            NEW="${MAJOR}.${MINOR}.${PATCH}"
+            echo "Bumped ${CURRENT} -> ${NEW} (${BUMP})"
+          fi
+
+          echo "TAG=v${NEW}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in .uplugin
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          sed -i -r 's/^(\s+"VersionName":\s*)"[0-9]+\.[0-9]+\.[0-9]+"/\1"'"${NEW_VERSION}"'"/' LootLockerSDK/LootLockerSDK.uplugin
+          echo "Updated .uplugin version to ${NEW_VERSION}"
+
+      - name: Create branch and commit
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          BRANCH="release/v${NEW_VERSION}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          git add LootLockerSDK/LootLockerSDK.uplugin
+          git commit -m "Bump version to ${NEW_VERSION}"
+          git push origin "$BRANCH"
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
+
+      - name: Generate release notes
+        run: |
+          PREV="${{ steps.prev-tag.outputs.TAG }}"
+          NEW_TAG="${{ steps.new-version.outputs.TAG }}"
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          COMMITS=$(cat /tmp/commits.log)
+          echo "::group::Commits since ${PREV:-beginning}"
+          echo "$COMMITS"
+          echo "::endgroup::"
+
+          if [ -n "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+            echo "Generating release notes via OpenRouter..."
+            printf 'You are writing release notes for LootLocker Unreal SDK version %s.\n\nBelow are the commit messages since the last release. Write concise, user-facing release notes following this template exactly. Only include sections that have content. Keep the audience in mind: Unreal Engine game developers using LootLocker.\n\nTemplate:\n### Features\n- Feature Title - Description of what the developer can now do.\n\n### Fixes\n- Fixed an issue where X would happen when Y.\n\n### Breaking Changes\n- Removed / changed API - explain migration.\n\n### Refactoring\n- Internal changes users should know about.\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unreal-sdk/compare/%s...%s)\n\nCommit messages:\n%s\n' "$NEW_VERSION" "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" "$COMMITS" > /tmp/ai-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/ai-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"medium"},max_tokens:8000,temperature:0.3}')")
+            NOTES=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""')
+            if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then
+              echo "$NOTES" > /tmp/release-notes.md
+              echo "AI-generated release notes."
+            else
+              echo "::warning::OpenRouter returned empty response, falling back to template."
+              NOTES=""
+            fi
+          fi
+
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Using static template."
+            printf '### Features\n\n- Feature Title - Description.\n\n### Fixes\n\n- Fixed ...\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unreal-sdk/compare/%s...%s)\n' "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" > /tmp/release-notes.md
+          fi
+          echo "Release notes generated."
+
+      - name: Create PR
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          TITLE="Release v${NEW_VERSION}"
+          gh pr create \
+            --title "$TITLE" \
+            --body "$(cat /tmp/release-notes.md)" \
+            --base main \
+            --head "$BRANCH" \
+            --label "release candidate" \
+            --reviewer "kirre-bylund"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/unreal-sdk-packager.yml
+++ b/.github/workflows/unreal-sdk-packager.yml
@@ -1,12 +1,6 @@
 name: Unreal SDK Packager
 run-name: sdk-packager
 on:
-  push:
-      branches:
-        - main
-        - ci/*
-      tags:
-        - v**
   release:
     types: [published]
   workflow_dispatch: {}
@@ -37,16 +31,6 @@ jobs:
           SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
           echo "SDK_PATH=${SDK_PATH}" >> $GITHUB_ENV
           echo "SDK_NAME=${SDK_NAME}" >> $GITHUB_ENV
-          sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
-          CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
-          echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
-          rm -rf "$CURRENT_PACKAGE_DIR"
-          mkdir -p "$CURRENT_PACKAGE_DIR"
-          PACKAGE_NAME="${SDK_NAME}v${SDK_VERSION}_for_Unreal_Engine_${{ matrix.UE_VERSION }}"
-          echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_ENV
-          cp -r "$SDK_PATH/$SDK_NAME" "$CURRENT_PACKAGE_DIR/$SDK_NAME"
-          echo "  Package $PACKAGE_NAME produced to path $CURRENT_PACKAGE_DIR"
-          SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
           sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
           CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
           echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV

--- a/.github/workflows/unreal-sdk-packager.yml
+++ b/.github/workflows/unreal-sdk-packager.yml
@@ -2,12 +2,17 @@ name: Unreal SDK Packager
 run-name: sdk-packager
 on:
   push:
-      branches: # Made towards the following
+      branches:
         - main
         - ci/*
       tags:
         - v**
+  release:
+    types: [published]
   workflow_dispatch: {}
+
+permissions:
+  contents: write
 
 jobs: 
   package-sdk:
@@ -30,6 +35,18 @@ jobs:
           SDK_PATH="$(pwd)"
           SDK_NAME=`find "$SDK_PATH" -type f -name "*.uplugin" | sed -n -r "s/.*\/([-A-Za-z0-9_]+)\.uplugin/\1/p"`
           SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
+          echo "SDK_PATH=${SDK_PATH}" >> $GITHUB_ENV
+          echo "SDK_NAME=${SDK_NAME}" >> $GITHUB_ENV
+          sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
+          CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
+          echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
+          rm -rf "$CURRENT_PACKAGE_DIR"
+          mkdir -p "$CURRENT_PACKAGE_DIR"
+          PACKAGE_NAME="${SDK_NAME}v${SDK_VERSION}_for_Unreal_Engine_${{ matrix.UE_VERSION }}"
+          echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_ENV
+          cp -r "$SDK_PATH/$SDK_NAME" "$CURRENT_PACKAGE_DIR/$SDK_NAME"
+          echo "  Package $PACKAGE_NAME produced to path $CURRENT_PACKAGE_DIR"
+          SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
           sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
           CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
           echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
@@ -45,6 +62,15 @@ jobs:
         with:
           name: ${{ ENV.PACKAGE_NAME }}
           path: ${{ ENV.PACKAGE_DIR }}
+
+      - name: Attach package to release
+        if: github.event_name == 'release'
+        run: |
+          cd "$SDK_PATH"
+          zip -r "/tmp/$PACKAGE_NAME.zip" "$SDK_NAME"
+          gh release upload --clobber "${{ github.ref_name }}" "/tmp/$PACKAGE_NAME.zip"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}
         
       - name: Package SDKs with Outdated Engine Version Warning
         if: ${{ contains(fromJSON(VARS.OUTDATED_ENGINE_VERSIONS), matrix.UE_VERSION) }}
@@ -68,3 +94,12 @@ jobs:
         with:
           name: ${{ ENV.PACKAGE_NAME }}
           path: ${{ ENV.PACKAGE_DIR }}
+
+      - name: Attach outdated package to release
+        if: ${{ github.event_name == 'release' && contains(fromJSON(VARS.OUTDATED_ENGINE_VERSIONS), matrix.UE_VERSION) }}
+        run: |
+          cd "$SDK_PATH"
+          zip -r "/tmp/$PACKAGE_NAME.zip" "$SDK_NAME"
+          gh release upload --clobber "${{ github.ref_name }}" "/tmp/$PACKAGE_NAME.zip"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ docs/xml/
 # outdated before next use. Regenerate from the script invocations in the
 # .github/instructions/documentation.md workflow notes if needed.
 .doxygen/scripts/
+
+# Ignore config files
+LootLockerSDK/Config/*.bytes

--- a/LootLockerSDK/LootLockerSDK.uplugin
+++ b/LootLockerSDK/LootLockerSDK.uplugin
@@ -1,7 +1,7 @@
 {
     "FileVersion": 3,
     "FriendlyName": "LootLockerSDK",
-    "Version": 24,
+    "Version": 25,
     "VersionName": "10.5.0",
     "CreatedBy": "LootLocker",
     "CreatedByURL": "https://www.lootlocker.com/",

--- a/LootLockerSDK/LootLockerSDK.uplugin
+++ b/LootLockerSDK/LootLockerSDK.uplugin
@@ -2,7 +2,7 @@
     "FileVersion": 3,
     "FriendlyName": "LootLockerSDK",
     "Version": 24,
-    "VersionName": "10.4.0",
+    "VersionName": "10.5.0",
     "CreatedBy": "LootLocker",
     "CreatedByURL": "https://www.lootlocker.com/",
     "DocsURL": "https://docs.lootlocker.com/",

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBanRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerBanRequestHandler.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 LootLocker
+
+#include "GameAPI/LootLockerBanRequestHandler.h"
+#include "LootLockerConfig.h"
+#include "LootLockerGameEndpoints.h"
+#include "Utils/LootLockerUtilities.h"
+
+FString ULootLockerBanRequestHandler::GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest)
+{
+    const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
+    FLootLockerBanStatusRequest Request;
+    Request.game_api_key = Config->LootLockerGameKey;
+    Request.player_id = PlayerUlid;
+    return LLAPI<FLootLockerBanStatusResponse>::CallAPI(Request, ULootLockerGameEndpoints::GetPlayerBanStatusEndpoint, {}, {}, FLootLockerPlayerData(), OnCompletedRequest);
+}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
@@ -651,10 +651,6 @@ FString ULootLockerCatalogRequestHandler::ListCatalogItemsById(const FLootLocker
 
             for (int j = 0; j < JsonMetadataArray.Num(); j++)
             {
-                if (j >= Entry.Metadata.Num())
-                {
-                    break;
-                }
                 TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j].Get()->AsObject();
                 FString MetadataKey = JsonMetadataObject.Get()->GetStringField(TEXT("key"));
                 for (int k = 0; k < Entry.Metadata.Num(); k++)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerCatalogRequestHandler.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2021 LootLocker
 
 #include "GameAPI/LootLockerCatalogRequestHandler.h"
+#include "JsonObjectConverter.h"
 #include "LootLockerGameEndpoints.h"
 #include "Utils/LootLockerUtilities.h"
 
@@ -421,8 +422,6 @@ FLootLockerListCatalogPricesResponse::FLootLockerListCatalogPricesResponse(const
 			Detail.Catalog_listing_id,
 			Detail.Id
 			}, Detail);
-
-
 	}
 }
 
@@ -605,4 +604,72 @@ FString ULootLockerCatalogRequestHandler::ListCatalogItemsV2(const FLootLockerPl
     });
 
     return LLAPI<FInternalLootLockerListCatalogPricesV2Response>::CallAPI(FLootLockerEmptyRequest{}, ULootLockerGameEndpoints::ListCatalogItemsByKey, { CatalogKey }, QueryParams, PlayerData, FInternalLootLockerListCatalogPricesV2ResponseDelegate(), InternalResponseConverter);
+}
+
+FString ULootLockerCatalogRequestHandler::ListCatalogItemsById(const FLootLockerPlayerData& PlayerData, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete)
+{
+    FLootLockerListCatalogItemsByIdRequest Request;
+    Request.Ids = CatalogListingIds;
+
+    if (IncludeMetadata)
+    {
+        Request.Includes.Metadata.All = (MetadataKeys.Num() == 0);
+        Request.Includes.Metadata.Keys = MetadataKeys;
+    }
+
+    if (!IncludeMetadata)
+    {
+        return LLAPI<FLootLockerListCatalogItemsByIdResponse>::CallAPI(Request, ULootLockerGameEndpoints::ListCatalogItemsById, {}, {}, PlayerData, OnComplete);
+    }
+
+    LLAPI<FLootLockerListCatalogItemsByIdResponse>::FResponseInspectorCallback MetadataParser = LLAPI<FLootLockerListCatalogItemsByIdResponse>::FResponseInspectorCallback::CreateLambda([OnComplete](FLootLockerListCatalogItemsByIdResponse& Response)
+    {
+        if (!Response.success || Response.Items.Num() == 0)
+        {
+            OnComplete.ExecuteIfBound(Response);
+            return;
+        }
+        TSharedPtr<FJsonObject> FullJsonObject = LootLockerUtilities::JsonObjectFromFString(Response.FullTextFromServer);
+        if (!FullJsonObject.IsValid())
+        {
+            OnComplete.ExecuteIfBound(Response);
+            return;
+        }
+        TArray<TSharedPtr<FJsonValue>> JsonItems = FullJsonObject.Get()->GetArrayField(TEXT("items"));
+        if (JsonItems.Num() != Response.Items.Num())
+        {
+            OnComplete.ExecuteIfBound(Response);
+            return;
+        }
+
+        for (int i = 0; i < JsonItems.Num(); i++)
+        {
+            TSharedPtr<FJsonObject> JsonItemObject = JsonItems[i].Get()->AsObject();
+            // Parse entry-level metadata
+            TArray<TSharedPtr<FJsonValue>> JsonMetadataArray = JsonItemObject.Get()->GetArrayField(TEXT("metadata"));
+            FLootLockerListCatalogItemsByIdEntry& Entry = Response.Items[i];
+
+            for (int j = 0; j < JsonMetadataArray.Num(); j++)
+            {
+                if (j >= Entry.Metadata.Num())
+                {
+                    break;
+                }
+                TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j].Get()->AsObject();
+                FString MetadataKey = JsonMetadataObject.Get()->GetStringField(TEXT("key"));
+                for (int k = 0; k < Entry.Metadata.Num(); k++)
+                {
+                    if (Entry.Metadata[k].Key.Equals(MetadataKey))
+                    {
+                        Entry.Metadata[k]._INTERNAL_SetJsonRepresentation(*JsonMetadataObject.Get());
+                        break;
+                    }
+                }
+            }
+        }
+
+        OnComplete.ExecuteIfBound(Response);
+    });
+
+    return LLAPI<FLootLockerListCatalogItemsByIdResponse>::CallAPI(Request, ULootLockerGameEndpoints::ListCatalogItemsById, {}, {}, PlayerData, FLootLockerListCatalogItemsByIdResponseDelegate(), MetadataParser);
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerMiscellaneousRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerMiscellaneousRequestHandler.cpp
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2021 LootLocker
 
 #include "GameAPI/LootLockerMiscellaneousRequestHandler.h"
+#include "GameAPI/LootLockerBanRequestHandler.h"
 #include "Utils/LootLockerUtilities.h"
 #include "LootLockerGameEndpoints.h"
 
@@ -25,5 +26,100 @@ FString ULootLockerMiscellaneousRequestHandler::GetGameInfo(const FGameInfoRespo
         EmptyQueryParams,
         FLootLockerPlayerData(),
         OnCompletedRequest
+    );
+}
+
+FString ULootLockerMiscellaneousRequestHandler::CheckConnectionStatus(const FLootLockerPlayerData& PlayerData, const FLootLockerConnectionStateDelegate& OnCompletedRequest)
+{
+    return LLAPI<FLootLockerTimeResponse>::CallAPI(
+        LootLockerEmptyRequest,
+        ULootLockerGameEndpoints::GetServerTimeEndpoint,
+        {},
+        EmptyQueryParams,
+        PlayerData,
+        FTimeResponseDelegate::CreateLambda([PlayerData, OnCompletedRequest](FLootLockerTimeResponse PingResponse)
+        {
+            if (PingResponse.StatusCode == 0)
+            {
+                FLootLockerConnectionStateResponse Response;
+                Response.success = false;
+                Response.StatusCode = 0;
+                Response.State = ELootLockerConnectionState::NoConnection;
+                Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                Response.ErrorData = PingResponse.ErrorData;
+                Response.Context = PingResponse.Context;
+                OnCompletedRequest.ExecuteIfBound(Response);
+                return;
+            }
+
+            if (PingResponse.success)
+            {
+                FLootLockerConnectionStateResponse Response;
+                Response.success = true;
+                Response.StatusCode = PingResponse.StatusCode;
+                Response.State = ELootLockerConnectionState::SignedInAndConnected;
+                Response.ServerTime = PingResponse.date;
+                Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                Response.Context = PingResponse.Context;
+                OnCompletedRequest.ExecuteIfBound(Response);
+                return;
+            }
+
+            int32 StatusCode = PingResponse.StatusCode;
+
+            if (StatusCode >= 500)
+            {
+                FLootLockerConnectionStateResponse Response;
+                Response.success = false;
+                Response.StatusCode = StatusCode;
+                Response.State = ELootLockerConnectionState::ServerError;
+                Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                Response.ErrorData = PingResponse.ErrorData;
+                Response.Context = PingResponse.Context;
+                OnCompletedRequest.ExecuteIfBound(Response);
+                return;
+            }
+
+            // 401 = token expired (or a banned player's auto-refresh synthesized a 401).
+            // 403 = forbidden — could also be a ban.
+            // In both cases, call ban-status to check whether the player is actually banned.
+            if (StatusCode == 401 || StatusCode == 403)
+            {
+                ULootLockerBanRequestHandler::GetPlayerBanStatus(
+                    PlayerData.PlayerUlid,
+                    FLootLockerBanStatusDelegate::CreateLambda([PingResponse, StatusCode, OnCompletedRequest](FLootLockerBanStatusResponse BanResponse)
+                    {
+                        FLootLockerConnectionStateResponse Response;
+                        Response.success = false;
+                        Response.StatusCode = StatusCode;
+                        Response.FullTextFromServer = PingResponse.FullTextFromServer;
+                        Response.ErrorData = PingResponse.ErrorData;
+                        Response.Context = PingResponse.Context;
+
+                        if (BanResponse.success && BanResponse.is_banned)
+                        {
+                            Response.State = ELootLockerConnectionState::Banned;
+                            Response.BanDetails = BanResponse.ban;
+                        }
+                        else
+                        {
+                            Response.State = ELootLockerConnectionState::SessionExpired;
+                        }
+                        OnCompletedRequest.ExecuteIfBound(Response);
+                    })
+                );
+                return;
+            }
+
+            // Any other failure (e.g. 400, 429) — map to ServerError so State is consistent with StatusCode.
+            FLootLockerConnectionStateResponse Response;
+            Response.success = false;
+            Response.StatusCode = StatusCode;
+            Response.State = ELootLockerConnectionState::ServerError;
+            Response.FullTextFromServer = PingResponse.FullTextFromServer;
+            Response.ErrorData = PingResponse.ErrorData;
+            Response.Context = PingResponse.Context;
+            OnCompletedRequest.ExecuteIfBound(Response);
+        })
     );
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPurchasesRequestHandler.cpp
@@ -130,6 +130,32 @@ FString ULootLockerPurchasesRequestHandler::RedeemEpicStorePurchaseForCharacter(
     return LLAPI<FLootLockerResponse>::CallAPI(PurchaseRequest, ULootLockerGameEndpoints::RedeemEpicStorePurchase, {}, {}, PlayerData, OnCompleted);
 }
 
+FString ULootLockerPurchasesRequestHandler::GetXboxServiceTicket(const FLootLockerPlayerData& PlayerData, const FLootLockerXboxServiceTicketDelegate& OnCompleted)
+{
+    return LLAPI<FLootLockerXboxServiceTicketResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::XboxServiceTicket, {}, {}, PlayerData, OnCompleted);
+}
+
+FString ULootLockerPurchasesRequestHandler::RedeemXboxStorePurchaseForPlayer(const FLootLockerPlayerData& PlayerData, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompleted)
+{
+    const FLootLockerRedeemXboxStorePurchaseForPlayerRequest PurchaseRequest{
+        UserCollectionsId,
+        ProductId
+    };
+
+    return LLAPI<FLootLockerResponse>::CallAPI(PurchaseRequest, ULootLockerGameEndpoints::RedeemXboxStorePurchase, {}, {}, PlayerData, OnCompleted);
+}
+
+FString ULootLockerPurchasesRequestHandler::RedeemXboxStorePurchaseForClass(const FLootLockerPlayerData& PlayerData, const int ClassId, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompleted)
+{
+    FLootLockerRedeemXboxStorePurchaseForClassRequest PurchaseRequest = FLootLockerRedeemXboxStorePurchaseForClassRequest();
+    PurchaseRequest.Class_id = ClassId;
+    PurchaseRequest.User_collections_id = UserCollectionsId;
+    PurchaseRequest.Product_id = ProductId;
+    FString JsonString = LootLockerUtilities::UStructToJsonString(PurchaseRequest);
+    JsonString.ReplaceInline(TEXT("Class_id"), TEXT("character_id"), ESearchCase::IgnoreCase);
+    return LLAPI<FLootLockerResponse>::CallAPIUsingRawJSON(JsonString, ULootLockerGameEndpoints::RedeemXboxStorePurchase, {}, {}, PlayerData, OnCompleted);
+}
+
 FString ULootLockerPurchasesRequestHandler::RedeemPlayStationStorePurchaseForPlayer(const FLootLockerPlayerData& PlayerData, const FString& TransactionId, const FString& AuthCode, const FString& EntitlementLabel, const FString& ServiceLabel, const FString& ServiceName, const int Environment, const int UseCount, const FLootLockerDefaultDelegate& OnCompleted)
 {
     TSharedRef<FJsonObject> JsonObject = MakeShareable(new FJsonObject);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -265,22 +265,14 @@ void ULootLockerConfig::LoadFileConfig()
         return;
     }
 
-    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(*PluginName);
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
     if (!Plugin.IsValid())
     {
         bFileConfigChecked = true;
         return;
     }
 
-    // Build filename: PackageName + "PreConfig" + optional "-" + ConfigFileIdentifier + ".bytes"
-    FString FileName = PackageName + TEXT("PreConfig");
-    if (!ConfigFileIdentifier.IsEmpty())
-    {
-        FileName += TEXT("-") + ConfigFileIdentifier;
-    }
-    FileName += TEXT(".bytes");
-
-    const FString FilePath = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Config"), FileName);
+    const FString FilePath = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Config"), PreConfigFileName);
 
     FString Content;
     if (!FFileHelper::LoadFileToString(Content, *FilePath))
@@ -360,9 +352,7 @@ void ULootLockerConfig::ApplyFileConfigIfPresent()
 }
 
 #if ENGINE_MAJOR_VERSION < 5
-const FString ULootLockerConfig::PackageName = TEXT("LootLocker");
-const FString ULootLockerConfig::PluginName = TEXT("LootLockerSDK");
-const FString ULootLockerConfig::ConfigFileIdentifier = TEXT("");
+const FString ULootLockerConfig::PreConfigFileName = TEXT("LootLockerPreConfig.bytes");
 bool ULootLockerConfig::bFileConfigChecked = false;
 TOptional<FLootLockerFileConfig> ULootLockerConfig::FileConfig;
 #endif

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -4,16 +4,19 @@
 #include "Misc/Paths.h"
 #include "Misc/DateTime.h"
 #include "Misc/ConfigCacheIni.h"
+#include "Misc/FileHelper.h"
+#include "Interfaces/IPluginManager.h"
+#include "JsonObjectConverter.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/AES.h"
+#include "Misc/Base64.h"
 
 namespace {
     // Used for runtime log level override
     static bool bRuntimeLogLevelOverrideSet = false;
     static ELootLockerLogLevel RuntimeLogLevelOverride = ELootLockerLogLevel::NoLogging;
-}
-
-ULootLockerConfig::ULootLockerConfig()
-{
-    LootLockerLogLevel = ELootLockerLogLevel::Warning;
 }
 
 void ULootLockerConfig::SetRuntimeLogLevel(ELootLockerLogLevel NewLevel)
@@ -142,4 +145,210 @@ bool ULootLockerConfig::IsPresenceEnabledInEditor()
 {
     const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
     return Config->bEnablePresence && Config->bEnablePresenceInEditor;
+}
+
+// ========================================================================
+// FILE CONFIG IMPLEMENTATION
+// ========================================================================
+
+bool ULootLockerConfig::IsFileConfigActive()
+{
+    if (!bFileConfigChecked)
+    {
+        GetDefault<ULootLockerConfig>()->LoadFileConfig();
+    }
+    return FileConfig.IsSet();
+}
+
+// Hardcoded decryption key for pre-config files.
+// This is intentionally embedded rather than configurable — the scheme is only meant to
+// keep the API key out of casual plain-text searches, not to provide cryptographic security.
+inline static const FAES::FAESKey GetFileConfigDecryptionKey()
+{
+    static const uint8 KeyBytes[32] = {
+        0x4C, 0x6F, 0x6F, 0x74, 0x4C, 0x6F, 0x63, 0x6B,
+        0x65, 0x72, 0x50, 0x72, 0x65, 0x43, 0x6F, 0x6E,
+        0x66, 0x69, 0x67, 0x4B, 0x65, 0x79, 0x32, 0x30,
+        0x32, 0x35, 0x41, 0x45, 0x53, 0x32, 0x35, 0x36
+    };
+    FAES::FAESKey Key;
+    FMemory::Memcpy(Key.Key, KeyBytes, 32);
+    return Key;
+}
+
+TOptional<FLootLockerFileConfig> ULootLockerConfig::ParseFileConfigContent(const FString& Content)
+{
+    if (Content.IsEmpty())
+    {
+        return {};
+    }
+
+    FString JsonString;
+
+    // Try plain JSON first
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+    if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
+    {
+        JsonString = Content;
+    }
+    else
+    {
+        // Try AES-256-ECB + PKCS7 + Base64 decryption
+        TArray<uint8> EncryptedData;
+        if (!FBase64::Decode(Content, EncryptedData))
+        {
+            return {};
+        }
+
+        const FAES::FAESKey DecryptionKey = GetFileConfigDecryptionKey();
+        FAES::DecryptData(EncryptedData.GetData(), EncryptedData.Num(), DecryptionKey);
+
+        // Remove PKCS7 padding
+        if (EncryptedData.Num() > 0)
+        {
+            const uint8 PaddingValue = EncryptedData.Last();
+            if (PaddingValue > 0 && PaddingValue <= 16 && PaddingValue <= EncryptedData.Num())
+            {
+                bool bValidPadding = true;
+                for (int32 i = 1; i <= PaddingValue; ++i)
+                {
+                    if (EncryptedData[EncryptedData.Num() - i] != PaddingValue)
+                    {
+                        bValidPadding = false;
+                        break;
+                    }
+                }
+                if (bValidPadding)
+                {
+                    EncryptedData.SetNum(EncryptedData.Num() - PaddingValue);
+                }
+            }
+        }
+
+        // Convert decrypted bytes to UTF-8 string
+        JsonString = FString(EncryptedData.Num(), UTF8_TO_TCHAR(reinterpret_cast<const char*>(EncryptedData.GetData())));
+
+        // Re-parse the decrypted JSON
+        Reader = TJsonReaderFactory<>::Create(JsonString);
+        if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+        {
+            return {};
+        }
+    }
+
+    FLootLockerFileConfig Config;
+    if (!FJsonObjectConverter::JsonObjectToUStruct(JsonObject.ToSharedRef(), &Config, 0, 0))
+    {
+        return {};
+    }
+
+    // api_key is the gating field — empty or missing means "inactive"
+    if (Config.api_key.IsEmpty())
+    {
+        return {};
+    }
+
+    return Config;
+}
+
+void ULootLockerConfig::LoadFileConfig()
+{
+    if (bFileConfigChecked)
+    {
+        return;
+    }
+
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(*PluginName);
+    if (!Plugin.IsValid())
+    {
+        bFileConfigChecked = true;
+        return;
+    }
+
+    // Build filename: PackageName + "PreConfig" + optional "-" + ConfigFileIdentifier + ".bytes"
+    FString FileName = PackageName + TEXT("PreConfig");
+    if (!ConfigFileIdentifier.IsEmpty())
+    {
+        FileName += TEXT("-") + ConfigFileIdentifier;
+    }
+    FileName += TEXT(".bytes");
+
+    const FString FilePath = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Config"), FileName);
+
+    FString Content;
+    if (!FFileHelper::LoadFileToString(Content, *FilePath))
+    {
+        bFileConfigChecked = true;
+        return;
+    }
+
+    FileConfig = ParseFileConfigContent(Content);
+    bFileConfigChecked = true;
+}
+
+void ULootLockerConfig::ApplyFileConfigIfPresent()
+{
+    if (!FileConfig.IsSet())
+    {
+        ULootLockerConfig* Default = GetMutableDefault<ULootLockerConfig>();
+        Default->bIsFileConfigLocked = false;
+        return;
+    }
+
+    const FLootLockerFileConfig& FC = FileConfig.GetValue();
+    ULootLockerConfig* Config = GetMutableDefault<ULootLockerConfig>();
+
+    Config->LootLockerGameKey = FC.api_key;
+    if (!FC.domain_key.IsEmpty())
+    {
+        Config->DomainKey = FC.domain_key;
+    }
+    if (!FC.game_version.IsEmpty())
+    {
+        Config->GameVersion = FC.game_version;
+    }
+    Config->IsValidGameVersion = IsSemverString(Config->GameVersion);
+    Config->AllowTokenRefresh = FC.allow_token_refresh;
+    Config->LogOutsideOfEditor = FC.log_outside_of_editor;
+
+    // Map log_level enum string -> ELootLockerLogLevel via static enum reflection
+    if (!FC.log_level.IsEmpty())
+    {
+        const UEnum* Enum = StaticEnum<ELootLockerLogLevel>();
+        const int64 Value = Enum->GetValueByNameString(FC.log_level);
+        if (Value != INDEX_NONE)
+        {
+            Config->LootLockerLogLevel = static_cast<ELootLockerLogLevel>(Value);
+        }
+    }
+
+    Config->bEnableFileLogging = FC.enable_file_logging;
+    Config->bEnablePresence = FC.enable_presence;
+    Config->bEnablePresenceAutoConnect = FC.enable_presence_auto_connect;
+    Config->bEnablePresenceAutoDisconnectOnFocusChange = FC.enable_presence_auto_disconnect_on_focus_change;
+    Config->bEnablePresenceInEditor = FC.enable_presence_in_editor;
+
+    // Map multi_user_session_mode enum string
+    if (!FC.multi_user_session_mode.IsEmpty())
+    {
+        const UEnum* Enum = StaticEnum<ELootLockerMultiUserSessionMode>();
+        const int64 Value = Enum->GetValueByNameString(FC.multi_user_session_mode);
+        if (Value != INDEX_NONE && Value != static_cast<int64>(ELootLockerMultiUserSessionMode::NotSet))
+        {
+            Config->MultiUserSessionMode = static_cast<ELootLockerMultiUserSessionMode>(Value);
+        }
+    }
+
+    Config->bUseLegacyHTTPStack = FC.use_legacy_http_stack;
+    Config->bIsFileConfigLocked = true;
+
+    if (Config->bEnableFileLogging)
+    {
+        EnableFileLogging(Config->LogFileName.IsEmpty() ? TEXT("LootLockerLog") : Config->LogFileName);
+    }
+    else
+    {
+        DisableFileLogging();
+    }
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -3,6 +3,7 @@
 #include "LootLockerConfig.h"
 #include "Misc/Paths.h"
 #include "Misc/DateTime.h"
+#include "Misc/ConfigCacheIni.h"
 
 namespace {
     // Used for runtime log level override
@@ -96,6 +97,39 @@ bool ULootLockerConfig::IsPresenceAutoDisconnectOnFocusChangeEnabled()
 {
     const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
     return Config->bEnablePresence && Config->bEnablePresenceAutoDisconnectOnFocusChange;
+}
+
+// ========================================================================
+// MULTI USER CONFIGURATION IMPLEMENTATION
+// ========================================================================
+
+void ULootLockerConfig::MigrateSettingsIfNeeded()
+{
+	// Check whether MultiUserSessionMode has ever been written to the INI file.
+	// If the key is absent (pre-migration install), choose the correct default:
+	//   - Existing project (API key already configured) -> Hotseat, for backwards compatibility.
+	//   - New install (no API key yet)                  -> SingleSession, the simpler default.
+	// After writing the value the key will be present on all subsequent loads and this block is skipped.
+	const FString IniFilePath = FPaths::ProjectConfigDir() / TEXT("DefaultGame.ini");
+	FString ExistingValue;
+	const bool bWasExplicitlySet = GConfig && GConfig->GetString(
+		TEXT("/Script/LootLockerSDK.LootLockerConfig"),
+		TEXT("MultiUserSessionMode"),
+		ExistingValue,
+		IniFilePath
+	);
+
+	if (!bWasExplicitlySet)
+	{
+		MultiUserSessionMode = LootLockerGameKey.IsEmpty()
+			? ELootLockerMultiUserSessionMode::SingleSession
+			: ELootLockerMultiUserSessionMode::Hotseat;
+#if ENGINE_MAJOR_VERSION >= 5
+		TryUpdateDefaultConfigFile();
+#else
+		UpdateDefaultConfigFile();
+#endif
+	}
 }
 
 bool ULootLockerConfig::IsPresenceEnabledInEditor()

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -9,7 +9,6 @@
 #include "JsonObjectConverter.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
-#include "HAL/PlatformProcess.h"
 #include "Misc/AES.h"
 #include "Misc/Base64.h"
 
@@ -201,6 +200,12 @@ TOptional<FLootLockerFileConfig> ULootLockerConfig::ParseFileConfigContent(const
             return {};
         }
 
+        // FAES operates on whole blocks (AES block size is 16 bytes)
+        if (EncryptedData.Num() == 0 || (EncryptedData.Num() % 16) != 0)
+        {
+            return {};
+        }
+
         const FAES::FAESKey DecryptionKey = GetFileConfigDecryptionKey();
         FAES::DecryptData(EncryptedData.GetData(), EncryptedData.Num(), DecryptionKey);
 
@@ -226,8 +231,9 @@ TOptional<FLootLockerFileConfig> ULootLockerConfig::ParseFileConfigContent(const
             }
         }
 
-        // Convert decrypted bytes to UTF-8 string
-        JsonString = FString(EncryptedData.Num(), UTF8_TO_TCHAR(reinterpret_cast<const char*>(EncryptedData.GetData())));
+        // Convert decrypted bytes to UTF-8 string (ensure null-terminated for UTF8_TO_TCHAR)
+        EncryptedData.Add(0);
+        JsonString = UTF8_TO_TCHAR(reinterpret_cast<const char*>(EncryptedData.GetData()));
 
         // Re-parse the decrypted JSON
         Reader = TJsonReaderFactory<>::Create(JsonString);
@@ -352,3 +358,11 @@ void ULootLockerConfig::ApplyFileConfigIfPresent()
         DisableFileLogging();
     }
 }
+
+#if ENGINE_MAJOR_VERSION < 5
+const FString ULootLockerConfig::PackageName = TEXT("LootLocker");
+const FString ULootLockerConfig::PluginName = TEXT("LootLockerSDK");
+const FString ULootLockerConfig::ConfigFileIdentifier = TEXT("");
+bool ULootLockerConfig::bFileConfigChecked = false;
+TOptional<FLootLockerFileConfig> ULootLockerConfig::FileConfig;
+#endif

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -110,7 +110,9 @@ void ULootLockerConfig::MigrateSettingsIfNeeded()
 	//   - Existing project (API key already configured) -> Hotseat, for backwards compatibility.
 	//   - New install (no API key yet)                  -> SingleSession, the simpler default.
 	// After writing the value the key will be present on all subsequent loads and this block is skipped.
-	const FString IniFilePath = FPaths::ProjectConfigDir() / TEXT("DefaultGame.ini");
+	// Use GetDefaultConfigFilename() so the read target matches the write target used by
+	// TryUpdateDefaultConfigFile()/UpdateDefaultConfigFile(), regardless of platform or test harness.
+	const FString IniFilePath = GetDefaultConfigFilename();
 	FString ExistingValue;
 	const bool bWasExplicitlySet = GConfig && GConfig->GetString(
 		TEXT("/Script/LootLockerSDK.LootLockerConfig"),
@@ -124,10 +126,14 @@ void ULootLockerConfig::MigrateSettingsIfNeeded()
 		MultiUserSessionMode = LootLockerGameKey.IsEmpty()
 			? ELootLockerMultiUserSessionMode::SingleSession
 			: ELootLockerMultiUserSessionMode::Hotseat;
+#if WITH_EDITOR
+		// Only persist to disk in Editor contexts — packaged builds may be installed to
+		// read-only locations, and the runtime value set above is sufficient there.
 #if ENGINE_MAJOR_VERSION >= 5
 		TryUpdateDefaultConfigFile();
 #else
 		UpdateDefaultConfigFile();
+#endif
 #endif
 	}
 }

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerConfig.cpp
@@ -154,7 +154,7 @@ bool ULootLockerConfig::IsFileConfigActive()
 {
     if (!bFileConfigChecked)
     {
-        GetDefault<ULootLockerConfig>()->LoadFileConfig();
+        ULootLockerConfig::LoadFileConfig();
     }
     return FileConfig.IsSet();
 }
@@ -295,7 +295,7 @@ void ULootLockerConfig::LoadFileConfig()
 
 void ULootLockerConfig::ApplyFileConfigIfPresent()
 {
-    if (!FileConfig.IsSet())
+    if (!IsFileConfigActive())
     {
         ULootLockerConfig* Default = GetMutableDefault<ULootLockerConfig>();
         Default->bIsFileConfigLocked = false;

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -31,6 +31,7 @@ FLootLockerEndPoints ULootLockerGameEndpoints::SteamSessionEndpoint = InitEndpoi
 FLootLockerEndPoints ULootLockerGameEndpoints::StartDiscordSessionEndpoint = InitEndpoint("session/discord", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::RefreshDiscordSessionEndpoint = InitEndpoint("session/discord", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::PlaystationNetworkV3SessionEndpoint = InitEndpoint("session/psn-v3/v1/login", ELootLockerHTTPMethod::POST);
+FLootLockerEndPoints ULootLockerGameEndpoints::GetPlayerBanStatusEndpoint = InitEndpoint("session/ban-status", ELootLockerHTTPMethod::POST);
 
 // Connected Accounts
 FLootLockerEndPoints ULootLockerGameEndpoints::ListConnectedAccountsEndpoint = InitEndpoint("v1/connected-accounts", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -210,6 +210,9 @@ FLootLockerEndPoints ULootLockerGameEndpoints::RedeemGooglePlayStorePurchase = I
 FLootLockerEndPoints ULootLockerGameEndpoints::RedeemEpicStorePurchase = InitEndpoint("store/epic/redeem", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::RedeemPlayStationStorePurchase = InitEndpoint("store/playstation/redeem", ELootLockerHTTPMethod::POST);
 
+FLootLockerEndPoints ULootLockerGameEndpoints::XboxServiceTicket = InitEndpoint("store/xbox/ticket", ELootLockerHTTPMethod::POST);
+FLootLockerEndPoints ULootLockerGameEndpoints::RedeemXboxStorePurchase = InitEndpoint("store/xbox/redeem", ELootLockerHTTPMethod::POST);
+
 FLootLockerEndPoints ULootLockerGameEndpoints::BeginSteamPurchaseRedemption = InitEndpoint("store/steam/redeem/begin", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::QuerySteamPurchaseRedemptionStatus = InitEndpoint("store/steam/redeem/query", ELootLockerHTTPMethod::POST);
 FLootLockerEndPoints ULootLockerGameEndpoints::FinalizeSteamPurchaseRedemption = InitEndpoint("store/steam/redeem/finalise", ELootLockerHTTPMethod::POST);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -278,6 +278,7 @@ FLootLockerEndPoints ULootLockerGameEndpoints::CreateWallet = InitEndpoint("wall
 FLootLockerEndPoints ULootLockerGameEndpoints::ListCatalogs = InitEndpoint("catalogs", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::DeprecatedListCatalogItemsByKey = InitEndpoint("catalog/key/{0}/prices", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::ListCatalogItemsByKey = InitEndpoint("catalogs/inspired-ibex/v1/catalog/key/{0}/list", ELootLockerHTTPMethod::GET);
+FLootLockerEndPoints ULootLockerGameEndpoints::ListCatalogItemsById = InitEndpoint("catalogs/inspired-ibex/v1/catalog/items", ELootLockerHTTPMethod::POST);
 
 // Entitlements
 FLootLockerEndPoints ULootLockerGameEndpoints::ListEntitlements = InitEndpoint("entitlements", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -81,7 +81,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
 	FHttpModule* HttpModule = &FHttpModule::Get();
     if(SDKVersion.IsEmpty())
     {
-	    const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(*ULootLockerConfig::PluginName);
+	    const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
         if (Ptr.IsValid())
         {
             SDKVersion = Ptr->GetDescriptor().VersionName;
@@ -244,7 +244,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     FHttpModule* HttpModule = &FHttpModule::Get();
     if (SDKVersion.IsEmpty())
     {
-        TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(*ULootLockerConfig::PluginName);
+        TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
         if (Ptr.IsValid())
         {
             SDKVersion = Ptr->GetDescriptor().VersionName;

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerHttpClient.cpp
@@ -81,7 +81,7 @@ FString ULootLockerHttpClient::SendApi(const FString& endPoint, const FString& r
 	FHttpModule* HttpModule = &FHttpModule::Get();
     if(SDKVersion.IsEmpty())
     {
-	    const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin("LootLockerSDK");
+	    const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(*ULootLockerConfig::PluginName);
         if (Ptr.IsValid())
         {
             SDKVersion = Ptr->GetDescriptor().VersionName;
@@ -244,7 +244,7 @@ FString ULootLockerHttpClient::UploadFile(const FString& endPoint, const FString
     FHttpModule* HttpModule = &FHttpModule::Get();
     if (SDKVersion.IsEmpty())
     {
-        TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin("LootLockerSDK");
+        TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(*ULootLockerConfig::PluginName);
         if (Ptr.IsValid())
         {
             SDKVersion = Ptr->GetDescriptor().VersionName;

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerLogger.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerLogger.cpp
@@ -2,6 +2,7 @@
 #include "LootLockerLogger.h"
 #include "LootLockerSDK.h"
 #include "LootLockerConfig.h"
+#include "Utils/LootLockerUtilities.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 
@@ -137,9 +138,9 @@ void FLootLockerLogger::LogHttpRequest(const FLootLockerHttpLogEntry& Entry)
         Entry.Duration,
         Entry.StatusCode);
     if (!Entry.RequestData.IsEmpty())
-        LogLine += FString::Printf(TEXT("\n   Request Data: %s"), *Entry.RequestData);
+        LogLine += FString::Printf(TEXT("\n   Request Data: %s"), *LootLockerUtilities::ObfuscateJsonStringForLogging(Entry.RequestData));
     if (!Entry.ResponseData.IsEmpty())
-        LogLine += FString::Printf(TEXT("\n   Response Data: %s"), *Entry.ResponseData);
+        LogLine += FString::Printf(TEXT("\n   Response Data: %s"), *LootLockerUtilities::ObfuscateJsonStringForLogging(Entry.ResponseData));
     if (!Entry.RequestHeaders.IsEmpty())
         LogLine += FString::Printf(TEXT("\n   Request Headers: %s"), *Entry.RequestHeaders);
     if (!Entry.ErrorData.Message.IsEmpty())

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -23,7 +23,7 @@ void ULootLockerManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 
 void ULootLockerManager::SetPlayerUlidToActive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::SetPlayerUlidToActive(PlayerUlid);
+    ULootLockerStateData::MakePlayerActive(PlayerUlid);
 }
 
 void ULootLockerManager::SetAllPlayersToInactive()

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1902,6 +1902,14 @@ FString ULootLockerManager::ListCatalogItemsV2(const FString& ForPlayerWithUlid,
     }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::ListCatalogItemsById(const FString& ForPlayerWithUlid, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseBP& OnComplete)
+{
+    return ULootLockerSDKManager::ListCatalogItemsById(CatalogListingIds, IncludeMetadata, MetadataKeys, FLootLockerListCatalogItemsByIdResponseDelegate::CreateLambda([OnComplete](const FLootLockerListCatalogItemsByIdResponse& Response)
+    {
+        OnComplete.ExecuteIfBound(Response);
+    }), ForPlayerWithUlid);
+}
+
 TArray<FLootLockerInlinedCatalogEntry> ULootLockerManager::ConvertCatalogToInlineItems(const FLootLockerListCatalogPricesResponse& Catalog)
 {
     return ULootLockerCatalogRequestHandler::ConvertCatalogToInlineItems(Catalog);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -21,6 +21,11 @@ void ULootLockerManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
     return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
+void ULootLockerManager::SetPlayerUlidToActive(const FString& PlayerUlid)
+{
+    return ULootLockerStateData::SetPlayerUlidToActive(PlayerUlid);
+}
+
 void ULootLockerManager::SetAllPlayersToInactive()
 {
     ULootLockerStateData::SetAllPlayersToInactive();
@@ -2196,6 +2201,14 @@ FString ULootLockerManager::GetGameInfo(const FGameInfoResponseDelegateBP& OnCom
     {
         OnCompletedRequestBP.ExecuteIfBound(Response);
     }));
+}
+
+FString ULootLockerManager::CheckConnectionStatus(const FString& ForPlayerWithUlid, const FLootLockerConnectionStateResponseBP& OnCompletedRequestBP)
+{
+    return ULootLockerSDKManager::CheckConnectionStatus(FLootLockerConnectionStateDelegate::CreateLambda([OnCompletedRequestBP](FLootLockerConnectionStateResponse Response)
+    {
+        OnCompletedRequestBP.ExecuteIfBound(Response);
+    }), ForPlayerWithUlid);
 }
 
 // Followers (Unified with optional pagination parameters)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -18,7 +18,7 @@ TArray<FString> ULootLockerManager::GetActivePlayerUlids()
 
 void ULootLockerManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
+    ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
 void ULootLockerManager::SetPlayerUlidToActive(const FString& PlayerUlid)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1470,6 +1470,30 @@ FString ULootLockerManager::RedeemEpicStorePurchaseForCharacter(const FString& F
         }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::GetXboxServiceTicket(const FString& ForPlayerWithUlid, const FLootLockerXboxServiceTicketResponseBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::GetXboxServiceTicket(FLootLockerXboxServiceTicketDelegate::CreateLambda([OnCompletedRequest](FLootLockerXboxServiceTicketResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
+FString ULootLockerManager::RedeemXboxStorePurchaseForPlayer(const FString& ForPlayerWithUlid, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultResponseBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::RedeemXboxStorePurchaseForPlayer(UserCollectionsId, ProductId, FLootLockerDefaultDelegate::CreateLambda([OnCompletedRequest](FLootLockerResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
+FString ULootLockerManager::RedeemXboxStorePurchaseForClass(const FString& ForPlayerWithUlid, int ClassId, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultResponseBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::RedeemXboxStorePurchaseForClass(ClassId, UserCollectionsId, ProductId, FLootLockerDefaultDelegate::CreateLambda([OnCompletedRequest](FLootLockerResponse Response)
+        {
+            OnCompletedRequest.ExecuteIfBound(Response);
+        }), ForPlayerWithUlid);
+}
+
 #ifdef LOOTLOCKER_BETA_PLAYSTATION_IAP
 // FString ULootLockerManager::RedeemPlayStationStorePurchase(const FString& ForPlayerWithUlid, const FString& TransactionId, const FString& AuthCode, const FString& EntitlementLabel, const FString& ServiceLabel, const FString& ServiceName, const int Environment, const int UseCount, const FLootLockerDefaultResponseBP& OnCompletedRequest)
 // {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -320,6 +320,14 @@ FString ULootLockerManager::EndSession(const FString& ForPlayerWithUlid, const F
     }), ForPlayerWithUlid);
 }
 
+FString ULootLockerManager::GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusResponseBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::GetPlayerBanStatus(PlayerUlid, FLootLockerBanStatusDelegate::CreateLambda([OnCompletedRequest](const FLootLockerBanStatusResponse& Response)
+    {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
 //==================================================
 // Connected Accounts
 //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -247,6 +247,11 @@ FString ULootLockerSDKManager::EndSession(const FLootLockerDefaultDelegate& OnCo
     return ULootLockerAuthenticationRequestHandler::EndSession(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), OnCompleteRequest);
 }
 
+FString ULootLockerSDKManager::GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest)
+{
+    return ULootLockerBanRequestHandler::GetPlayerBanStatus(PlayerUlid, OnCompletedRequest);
+}
+
 //==================================================
 // Connected Accounts
 //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -20,6 +20,11 @@ void ULootLockerSDKManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
     return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
+void ULootLockerSDKManager::SetPlayerUlidToActive(const FString& PlayerUlid)
+{
+    return ULootLockerStateData::MakePlayerActive(PlayerUlid);
+}
+
 void ULootLockerSDKManager::SetAllPlayersToInactive()
 {
     ULootLockerStateData::SetAllPlayersToInactive();
@@ -1681,6 +1686,42 @@ FString ULootLockerSDKManager::GetLastActivePlatform(const FString& ForPlayerWit
 FString ULootLockerSDKManager::GetGameInfo(const FGameInfoResponseDelegate& OnComplete)
 {
     return ULootLockerMiscellaneousRequestHandler::GetGameInfo(OnComplete);
+}
+
+FString ULootLockerSDKManager::CheckConnectionStatus(const FLootLockerConnectionStateDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    const ULootLockerConfig* Config = GetDefault<ULootLockerConfig>();
+    if (Config == nullptr || Config->LootLockerGameKey.IsEmpty())
+    {
+        FLootLockerConnectionStateResponse Error;
+        Error.success = false;
+        Error.StatusCode = 0;
+        Error.State = ELootLockerConnectionState::NotInitialized;
+        OnCompletedRequest.ExecuteIfBound(Error);
+        return "";
+    }
+
+    // Resolve the ULID so we can pass it to SaveStateExistsForPlayer if needed.
+    FString ResolvedUlid = ForPlayerWithUlid.IsEmpty() ? ULootLockerStateData::GetDefaultPlayerUlid() : ForPlayerWithUlid;
+
+    // Only proceed if the player is currently active in the multi-player session.
+    // Using an inactive player's credentials would risk activating them as a side
+    // effect of a successful ping or an automatic token refresh.
+    const TSharedPtr<FLootLockerPlayerData> PlayerData = ULootLockerStateData::GetStateForPlayerOrDefaultIfActive(ResolvedUlid);
+    if (!PlayerData.IsValid() || PlayerData->Token.IsEmpty())
+    {
+        FLootLockerConnectionStateResponse Error;
+        Error.success = false;
+        Error.StatusCode = 0;
+        // Distinguish: saved credentials that are inactive vs. no credentials at all.
+        Error.State = (!ResolvedUlid.IsEmpty() && ULootLockerStateData::SaveStateExistsForPlayer(ResolvedUlid))
+            ? ELootLockerConnectionState::SavedButInactive
+            : ELootLockerConnectionState::NotSignedIn;
+        OnCompletedRequest.ExecuteIfBound(Error);
+        return "";
+    }
+
+    return ULootLockerMiscellaneousRequestHandler::CheckConnectionStatus(*PlayerData, OnCompletedRequest);
 }
 
 // ========================================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -2,6 +2,7 @@
 
 #include "LootLockerSDKManager.h"
 
+#include "LootLockerConfig.h"
 #include "LootLockerStateData.h"
 #include "LootLockerPresenceManager.h"
 #include "LootLockerHttpClient.h"
@@ -301,6 +302,17 @@ FString ULootLockerSDKManager::ConnectRemoteSessionAccount(const FString& Code, 
 
 FString ULootLockerSDKManager::TransferIdentityProvidersBetweenAccounts(const FString& FromPlayerWithUlid,	const FString& ToPlayerWithUlid, TArray<ELootLockerAccountProvider> ProvidersToTransfer, const FLootLockerListConnectedAccountsResponseDelegate& OnComplete)
 {
+    const ELootLockerMultiUserSessionMode CurrentMode = GetDefault<ULootLockerConfig>()->MultiUserSessionMode;
+    if (CurrentMode == ELootLockerMultiUserSessionMode::SingleSession || CurrentMode == ELootLockerMultiUserSessionMode::ProfileSwitching)
+    {
+        const FString ModeString = UEnum::GetValueAsString(CurrentMode);
+        auto ErrorResponse = LootLockerResponseFactory::Error<FLootLockerListConnectedAccountsResponse>(
+            FString::Printf(TEXT("TransferIdentityProvidersBetweenAccounts requires Hotseat multi-user session mode because it needs two simultaneously active local sessions. Current mode: %s"), *ModeString),
+            LootLockerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT,
+            FromPlayerWithUlid);
+        OnComplete.ExecuteIfBound(ErrorResponse);
+        return "";
+    }
     const auto& fromPlayer = GetSavedStateOrDefaultOrEmptyForPlayer(FromPlayerWithUlid);
     const auto& toPlayer = GetSavedStateOrDefaultOrEmptyForPlayer(ToPlayerWithUlid);
     return ULootLockerConnectedAccountsRequestHandler::TransferIdentityProvidersBetweenAccounts(fromPlayer, toPlayer, ProvidersToTransfer, OnComplete);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1386,6 +1386,25 @@ FString ULootLockerSDKManager::ListCatalogItems(const FString& CatalogKey, int P
     return ULootLockerCatalogRequestHandler::ListCatalogItemsV2(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogKey, PerPage, Page, OnComplete);
 }
 
+FString ULootLockerSDKManager::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete, const FString& ForPlayerWithUlid /* = "" */)
+{
+    if (CatalogListingIds.Num() == 0)
+    {
+        FLootLockerListCatalogItemsByIdResponse ErrorResponse = LootLockerResponseFactory::Error<FLootLockerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", -1, ForPlayerWithUlid);
+        OnComplete.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    if (CatalogListingIds.Num() > 100)
+    {
+        FLootLockerListCatalogItemsByIdResponse ErrorResponse = LootLockerResponseFactory::Error<FLootLockerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", -1, ForPlayerWithUlid);
+        OnComplete.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    return ULootLockerCatalogRequestHandler::ListCatalogItemsById(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CatalogListingIds, IncludeMetadata, MetadataKeys, OnComplete);
+}
+
 // Entitlements
 FString ULootLockerSDKManager::ListEntitlements(const int Count, const FString& After, const FLootLockerListEntitlementsResponseDelegate& OnComplete, const FString& ForPlayerWithUlid /* = "" */)
 {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -22,7 +22,7 @@ void ULootLockerSDKManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 
 void ULootLockerSDKManager::SetPlayerUlidToActive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::MakePlayerActive(PlayerUlid);
+    ULootLockerStateData::MakePlayerActive(PlayerUlid);
 }
 
 void ULootLockerSDKManager::SetAllPlayersToInactive()
@@ -1697,6 +1697,7 @@ FString ULootLockerSDKManager::CheckConnectionStatus(const FLootLockerConnection
         Error.success = false;
         Error.StatusCode = 0;
         Error.State = ELootLockerConnectionState::NotInitialized;
+        Error.Context.PlayerUlid = ForPlayerWithUlid;
         OnCompletedRequest.ExecuteIfBound(Error);
         return "";
     }
@@ -1713,6 +1714,7 @@ FString ULootLockerSDKManager::CheckConnectionStatus(const FLootLockerConnection
         FLootLockerConnectionStateResponse Error;
         Error.success = false;
         Error.StatusCode = 0;
+        Error.Context.PlayerUlid = ResolvedUlid;
         // Distinguish: saved credentials that are inactive vs. no credentials at all.
         Error.State = (!ResolvedUlid.IsEmpty() && ULootLockerStateData::SaveStateExistsForPlayer(ResolvedUlid))
             ? ELootLockerConnectionState::SavedButInactive

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -17,7 +17,7 @@ TArray<FString> ULootLockerSDKManager::GetActivePlayerUlids()
 
 void ULootLockerSDKManager::SetPlayerUlidToInactive(const FString& PlayerUlid)
 {
-    return ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
+    ULootLockerStateData::SetPlayerUlidToInactive(PlayerUlid);
 }
 
 void ULootLockerSDKManager::SetPlayerUlidToActive(const FString& PlayerUlid)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1094,6 +1094,21 @@ FString ULootLockerSDKManager::RedeemEpicStorePurchaseForCharacter(const FString
     return ULootLockerPurchasesRequestHandler::RedeemEpicStorePurchaseForCharacter(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CharacterId, AccountId, BearerToken, EntitlementIds, SandboxId, OnCompletedRequest);
 }
 
+FString ULootLockerSDKManager::GetXboxServiceTicket(const FLootLockerXboxServiceTicketDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid)
+{
+    return ULootLockerPurchasesRequestHandler::GetXboxServiceTicket(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), OnCompletedRequest);
+}
+
+FString ULootLockerSDKManager::RedeemXboxStorePurchaseForPlayer(const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid)
+{
+    return ULootLockerPurchasesRequestHandler::RedeemXboxStorePurchaseForPlayer(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), UserCollectionsId, ProductId, OnCompletedRequest);
+}
+
+FString ULootLockerSDKManager::RedeemXboxStorePurchaseForClass(int ClassId, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid)
+{
+    return ULootLockerPurchasesRequestHandler::RedeemXboxStorePurchaseForClass(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), ClassId, UserCollectionsId, ProductId, OnCompletedRequest);
+}
+
 #ifdef LOOTLOCKER_BETA_PLAYSTATION_IAP
 // FString ULootLockerSDKManager::RedeemPlayStationStorePurchase(const FString& TransactionId, const FString& AuthCode, const FString& EntitlementLabel, const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ServiceLabel, const FString& ServiceName, const int Environment, const int UseCount, const FString& ForPlayerWithUlid)
 // {

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -149,46 +149,45 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 	}
 	FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Saved LootLocker player state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
 
-	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	ActivePlayerData.Add(PlayerData.PlayerUlid, MakeShared<FLootLockerPlayerData>(PlayerData));
+	
 	{
-		// Wipe all saved state for other players. The new player has already been saved above,
-		// so clearing after the successful save prevents irreversible data loss on IO errors.
-		ClearAllSavedStatesExceptForPlayer(PlayerData.PlayerUlid);
+		FLootLockerStateMetaData metaState = LoadMetaState();
+		metaState.SavedPlayerStateUlids.AddUnique(PlayerData.PlayerUlid);
+		SetMetaState(metaState);
 	}
 
-	// Note: after ClearAllSavedStatesExceptForPlayer() the meta state retains only this player.
-	FLootLockerStateMetaData metaState = LoadMetaState();
-
-	if (Mode == ELootLockerMultiUserSessionMode::ProfileSwitching)
+	switch (Mode)
 	{
-		// Deactivate all other players (keep in cold cache) and set the new player as the sole active default.
-		SetAllPlayersToInactiveExceptForPlayer(PlayerData.PlayerUlid);
-		metaState = LoadMetaState(); // reload after the deactivation may have updated default
-		metaState.DefaultPlayer = PlayerData.PlayerUlid;
-	}
-	else if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
-	{
-		// Only one player ever exists — always make them the default.
-		metaState.DefaultPlayer = PlayerData.PlayerUlid;
-		SetDefaultPlayerUlid(PlayerData.PlayerUlid);
-	}
-	else
-	{
-		// Hotseat (and NotSet, which resolves to Hotseat at runtime): the first authenticated
-		// player in the session is the default; subsequent authentications do not change it.
-		if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0)
+	case ELootLockerMultiUserSessionMode::SingleSession:
 		{
-			metaState.DefaultPlayer = PlayerData.PlayerUlid;
-			SetDefaultPlayerUlid(PlayerData.PlayerUlid);
+			// Wipe all saved state for other players. The new player has already been saved above,
+			// so clearing after the successful save prevents irreversible data loss on IO errors.
+			// This also sets the new player as the default and updates the meta state
+			ClearAllSavedStatesExceptForPlayer(PlayerData.PlayerUlid);
+		}
+		break;
+	case ELootLockerMultiUserSessionMode::ProfileSwitching:
+		{
+			// Deactivate all other players (keep in cold cache) and set the new player as the sole active default.
+			// This also sets the new player as the default and updates the meta state
+			SetAllPlayersToInactiveExceptForPlayer(PlayerData.PlayerUlid);
+		}
+		break;
+	case ELootLockerMultiUserSessionMode::NotSet:
+	case ELootLockerMultiUserSessionMode::Hotseat:
+	default:
+		{
+			FLootLockerStateMetaData metaState = LoadMetaState();
+			// Hotseat (and NotSet, which resolves to Hotseat at runtime): the first authenticated
+			// player in the session is the default; subsequent authentications do not change it.
+			if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0 || (ActivePlayerData.Num() == 1 && ActivePlayerData.Contains(PlayerData.PlayerUlid)))
+			{
+				SetDefaultPlayerUlid(PlayerData.PlayerUlid);
+			}
 		}
 	}
 
-	if (!metaState.SavedPlayerStateUlids.Contains(PlayerData.PlayerUlid))
-	{
-		metaState.SavedPlayerStateUlids.Add(PlayerData.PlayerUlid);
-		SetMetaState(metaState);
-	}
-	ActivePlayerData.Add(PlayerData.PlayerUlid, MakeShared<FLootLockerPlayerData>(PlayerData));
 	ULootLockerPresenceManager::NotifyPlayerActivated(PlayerData.PlayerUlid);
 }
 

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -3,6 +3,7 @@
 
 #include "LootLockerStateData.h"
 
+#include "LootLockerConfig.h"
 #include "LootLockerPlayerData.h"
 #include "LootLockerPresenceManager.h"
 #include "LootLockerSDK.h"
@@ -139,6 +140,15 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 		return;
 	}
 
+	const ELootLockerMultiUserSessionMode Mode = GetDefault<ULootLockerConfig>()->MultiUserSessionMode;
+
+	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	{
+		// Wipe all existing player state before saving the new player.
+		// There should only ever be one player in the system.
+		ClearAllSavedStates();
+	}
+
 	FString TargetSaveSlot = PlayerDataSaveSlot + "_" + PlayerData.PlayerUlid;
 	if (!UGameplayStatics::SaveGameToSlot(ULootLockerPlayerDataSaveGame::Create(PlayerData), TargetSaveSlot, SaveIndex)) {
 		FLootLockerLogger::LogWarning(FString::Printf(TEXT("Failed to save LootLocker state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
@@ -146,12 +156,33 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 	}
 	FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Saved LootLocker player state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
 
+	// Note: after ClearAllSavedStates() the meta state is freshly empty — LoadMetaState() returns a clean slate.
 	FLootLockerStateMetaData metaState = LoadMetaState();
-	if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0)
+
+	if (Mode == ELootLockerMultiUserSessionMode::ProfileSwitching)
 	{
+		// Deactivate all other players (keep in cold cache) and set the new player as the sole active default.
+		SetAllPlayersToInactiveExceptForPlayer(PlayerData.PlayerUlid);
+		metaState = LoadMetaState(); // reload after the deactivation may have updated default
+		metaState.DefaultPlayer = PlayerData.PlayerUlid;
+	}
+	else if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	{
+		// Only one player ever exists — always make them the default.
 		metaState.DefaultPlayer = PlayerData.PlayerUlid;
 		SetDefaultPlayerUlid(PlayerData.PlayerUlid);
 	}
+	else
+	{
+		// Hotseat (and NotSet, which resolves to Hotseat at runtime): the first authenticated
+		// player in the session is the default; subsequent authentications do not change it.
+		if (metaState.DefaultPlayer.IsEmpty() || ActivePlayerData.Num() == 0)
+		{
+			metaState.DefaultPlayer = PlayerData.PlayerUlid;
+			SetDefaultPlayerUlid(PlayerData.PlayerUlid);
+		}
+	}
+
 	if (!metaState.SavedPlayerStateUlids.Contains(PlayerData.PlayerUlid))
 	{
 		metaState.SavedPlayerStateUlids.Add(PlayerData.PlayerUlid);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerStateData.cpp
@@ -142,13 +142,6 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 
 	const ELootLockerMultiUserSessionMode Mode = GetDefault<ULootLockerConfig>()->MultiUserSessionMode;
 
-	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
-	{
-		// Wipe all existing player state before saving the new player.
-		// There should only ever be one player in the system.
-		ClearAllSavedStates();
-	}
-
 	FString TargetSaveSlot = PlayerDataSaveSlot + "_" + PlayerData.PlayerUlid;
 	if (!UGameplayStatics::SaveGameToSlot(ULootLockerPlayerDataSaveGame::Create(PlayerData), TargetSaveSlot, SaveIndex)) {
 		FLootLockerLogger::LogWarning(FString::Printf(TEXT("Failed to save LootLocker state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
@@ -156,7 +149,14 @@ void ULootLockerStateData::SavePlayerData(const FLootLockerPlayerData& PlayerDat
 	}
 	FLootLockerLogger::LogVerbose(FString::Printf(TEXT("Saved LootLocker player state to disk for player with ulid %s"), *PlayerData.PlayerUlid));
 
-	// Note: after ClearAllSavedStates() the meta state is freshly empty — LoadMetaState() returns a clean slate.
+	if (Mode == ELootLockerMultiUserSessionMode::SingleSession)
+	{
+		// Wipe all saved state for other players. The new player has already been saved above,
+		// so clearing after the successful save prevents irreversible data loss on IO errors.
+		ClearAllSavedStatesExceptForPlayer(PlayerData.PlayerUlid);
+	}
+
+	// Note: after ClearAllSavedStatesExceptForPlayer() the meta state retains only this player.
 	FLootLockerStateMetaData metaState = LoadMetaState();
 
 	if (Mode == ELootLockerMultiUserSessionMode::ProfileSwitching)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/Utils/LootLockerUtilities.cpp
@@ -15,7 +15,26 @@ const TArray<FObfuscationDetails> UObfuscationSettings::FieldsToObfuscate =
     FObfuscationDetails(FString("password"), "*", 0, 0, true),
     FObfuscationDetails(FString("domain_key"), "*", 3, 3, true),
     FObfuscationDetails(FString("session_token"), "*", 3, 3, true),
-    FObfuscationDetails(FString("token"), "*", 3, 3, true)
+    FObfuscationDetails(FString("token"), "*", 3, 3, true),
+    // Auth & session credentials
+    FObfuscationDetails(FString("steam_ticket"), "*", 3, 3, true),
+    FObfuscationDetails(FString("id_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("auth_code"), "*", 3, 3, true),
+    FObfuscationDetails(FString("apple_authorization_code"), "*", 3, 3, true),
+    FObfuscationDetails(FString("xbox_user_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("nsa_id_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("access_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("refresh_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("nonce"), "*", 3, 3, true),
+    FObfuscationDetails(FString("signature"), "*", 3, 3, true),
+    FObfuscationDetails(FString("salt"), "*", 3, 3, true),
+    FObfuscationDetails(FString("source_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("target_token"), "*", 3, 3, true),
+    // Purchase / IAP credentials
+    FObfuscationDetails(FString("purchase_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("bearer_token"), "*", 3, 3, true),
+    FObfuscationDetails(FString("user_collections_id"), "*", 3, 3, true),
+    FObfuscationDetails(FString("service_ticket"), "*", 3, 3, true)
 };
 
 FString ULootLockerEnumUtils::GetEnum(const TCHAR* Enum, int32 EnumValue)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
@@ -33,7 +33,7 @@ struct FLootLockerBanStatusResponse : public FLootLockerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool is_banned = false;
     /// Details about the active ban. Populated when is_banned is true.
-    /// Check Code == "player_banned" or is_banned before accessing these fields.
+    /// Check is_banned before accessing these fields. On failure, ErrorData.Code contains the error code.
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FLootLockerBanInfo ban;
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerBanRequestHandler.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LootLockerResponse.h"
+#include "LootLockerErrorData.h"
+#include "LootLockerPlayerData.h"
+#include "LootLockerBanRequestHandler.generated.h"
+
+//==================================================
+// Request / Response Definitions
+//==================================================
+
+/// @addtogroup Authentication
+/// @{
+
+USTRUCT(BlueprintType)
+struct FLootLockerBanStatusRequest
+{
+    GENERATED_BODY()
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+    FString game_api_key = "";
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+    FString player_id = "";
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerBanStatusResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /// Whether the player is currently banned.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool is_banned = false;
+    /// Details about the active ban. Populated when is_banned is true.
+    /// Check Code == "player_banned" or is_banned before accessing these fields.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerBanInfo ban;
+};
+
+/// @}
+
+//==================================================
+// Delegate
+//==================================================
+
+DECLARE_DELEGATE_OneParam(FLootLockerBanStatusDelegate, FLootLockerBanStatusResponse);
+
+//==================================================
+// Handler
+//==================================================
+
+UCLASS()
+class LOOTLOCKERSDK_API ULootLockerBanRequestHandler : public UObject
+{
+    GENERATED_BODY()
+public:
+    ULootLockerBanRequestHandler() {}
+
+    /**
+     * Get the ban status for a player.
+     * Use this after receiving a 403 player_banned response from a session start to retrieve
+     * the ban reason and duration. Does not require an active player session.
+     * @param PlayerUlid The ULID of the player to query
+     * @param OnCompletedRequest Delegate called when the request completes
+     * @return A unique id for this request used to match callbacks
+     */
+    static FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest);
+};

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
@@ -6,6 +6,7 @@
 #include "CoreMinimal.h"
 #include "LootLockerPlayerData.h"
 #include "LootLockerResponse.h"
+#include "GameAPI/LootLockerMetadataRequestHandler.h"
 #include "LootLockerCatalogRequestHandler.generated.h"
 
 //==================================================
@@ -610,9 +611,10 @@ struct FLootLockerGroupDetails
     FString Description = "";
     /**
      * The metadata of the Group.
+     * @deprecated This field was never used and will be removed.
      */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    TArray<FLootLockerCatalogGroupMetadata> Metadata;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker", meta = (DeprecatedProperty, DeprecationMessage = "This field was never used and will be removed"))
+    TArray<FLootLockerCatalogGroupMetadata> Metadata; // Deprecation date 2026-06-30
     /**
      * The ID of the reward.
      */
@@ -921,6 +923,233 @@ struct FLootLockerListCatalogPricesV2Response : public FLootLockerResponse
     TArray<FLootLockerInlinedCatalogEntry> GetLootLockerInlinedCatalogEntries() const;
 };
 
+/**
+ * Metadata include configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerMetadataInclude
+{
+    GENERATED_BODY()
+    /**
+    * If true, all metadata entries for the item are returned.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool All = false;
+
+    /**
+    * Specific metadata key names to filter by. Only used when bAll is false.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> Keys;
+};
+
+/**
+ * Optional includes configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerCatalogItemsIncludes
+{
+    GENERATED_BODY()
+    /**
+    * Metadata include configuration. If not set, metadata is not included.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerMetadataInclude Metadata;
+};
+
+/**
+ * Request body for looking up catalog items by their catalog_listing_ids.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdRequest
+{
+    GENERATED_BODY()
+    /**
+    * Array of catalog_listing_id strings to look up (max 100)
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FString> Ids;
+
+    /**
+    * Optional includes configuration to control what additional data is returned
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCatalogItemsIncludes Includes;
+};
+
+/**
+ * A group association with the entity detail inlined directly.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerInlinedGroupAssociation
+{
+    GENERATED_BODY()
+    /**
+    * The entity kind of this association (asset, currency, progression_points, progression_reset)
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    ELootLockerCatalogEntryEntityKind Kind = ELootLockerCatalogEntryEntityKind::Asset;
+
+    /**
+    * The unique id of the entity
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Id;
+
+    /**
+    * The catalog listing id for this association
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Catalog_listing_id;
+
+    /**
+    * Asset details inlined, populated when kind is asset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerAssetDetails Asset_detail;
+
+    /**
+    * Currency details inlined, populated when kind is currency
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCurrencyDetails Currency_detail;
+
+    /**
+    * Progression point details inlined, populated when kind is progression_points
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionPointDetails Progression_point_detail;
+
+    /**
+    * Progression reset details inlined, populated when kind is progression_reset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionResetDetails Progression_reset_detail;
+};
+
+/**
+ * Group detail used by the ListCatalogItemsById endpoint, where association details are
+ * inlined directly into each association entry by the backend.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerInlinedGroupDetailsWithAssociations
+{
+    GENERATED_BODY()
+    /**
+    * The name of the Group.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Name;
+
+    /**
+    * The description of the Group.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Description;
+
+    /**
+    * The ID of the reward.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Id;
+
+    /**
+    * The catalog listing id for this group detail.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Catalog_listing_id;
+
+    /**
+    * Associations with entity details inlined directly.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerInlinedGroupAssociation> Associations;
+};
+
+/**
+ * A catalog entry with entity details inlined directly. Used by the ListCatalogItemsById endpoint.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdEntry : public FLootLockerCatalogEntry
+{
+    GENERATED_BODY()
+    /**
+    * Asset details inlined, non-null when entity_kind is asset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerAssetDetails Asset_detail;
+
+    /**
+    * Currency details inlined, non-null when entity_kind is currency
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCurrencyDetails Currency_detail;
+
+    /**
+    * Progression point details inlined, non-null when entity_kind is progression_points
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionPointDetails Progression_point_detail;
+
+    /**
+    * Progression reset details inlined, non-null when entity_kind is progression_reset
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerProgressionResetDetails Progression_reset_detail;
+
+    /**
+    * Group details inlined, non-null when entity_kind is group
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerInlinedGroupDetailsWithAssociations Group_detail;
+
+    /**
+    * Metadata entries. Populated when includes.metadata is set.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerMetadataEntry> Metadata;
+};
+
+/**
+ * Describes why a specific catalog_listing_id could not be resolved.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdError
+{
+    GENERATED_BODY()
+    /**
+    * The catalog_listing_id that failed
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Id;
+
+    /**
+    * The reason (e.g. "not_found")
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Reason;
+};
+
+/**
+ * Response for the ListCatalogItemsById endpoint.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListCatalogItemsByIdResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+    * Array of inlined catalog entries matching the successfully resolved IDs
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerListCatalogItemsByIdEntry> Items;
+
+    /**
+    * Errors for IDs that could not be resolved. Omitted when all IDs succeeded.
+    */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerListCatalogItemsByIdError> Errors;
+};
+
 //==================================================
 // Delegate Definitions
 //==================================================
@@ -947,7 +1176,10 @@ DECLARE_DELEGATE_OneParam(FInternalLootLockerListCatalogPricesResponseDelegate, 
  * Internal C++ response delegate for listing items and prices in a catalog with details as arrays
  */
 DECLARE_DELEGATE_OneParam(FInternalLootLockerListCatalogPricesV2ResponseDelegate, FInternalLootLockerListCatalogPricesV2Response);
-
+/**
+ * Delegate for ListCatalogItemsById response
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerListCatalogItemsByIdResponseDelegate, FLootLockerListCatalogItemsByIdResponse);
 
 //==================================================
 // API Class Definition
@@ -964,6 +1196,7 @@ public:
     static FString ListCatalogs(const FLootLockerPlayerData& PlayerData, const FLootLockerListCatalogsResponseDelegate& OnComplete);
     static FString ListCatalogItems(const FLootLockerPlayerData& PlayerData, const FString& CatalogKey, int Count, const FString& After, const FLootLockerListCatalogPricesResponseDelegate& OnComplete);
     static FString ListCatalogItemsV2(const FLootLockerPlayerData& PlayerData, const FString& CatalogKey, int PerPage, int Page, const FLootLockerListCatalogPricesV2ResponseDelegate& OnComplete);
+    static FString ListCatalogItemsById(const FLootLockerPlayerData& PlayerData, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete);
     static TArray<FLootLockerInlinedCatalogEntry> ConvertCatalogToInlineItems(const FLootLockerListCatalogPricesResponse& Catalog)
     {
         return Catalog.GetLootLockerInlinedCatalogEntries();

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCatalogRequestHandler.h
@@ -320,6 +320,20 @@ struct FLootLockerCatalogPlaystationStoreListing
 };
 
 /**
+ * Holds the Xbox Store product identifier associated with a catalog entry listing.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerCatalogXboxStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * The id of the product in Xbox Store that can be purchased and then used to redeem this catalog entry
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Product_id = "";
+};
+
+/**
  * Aggregates the platform-specific store listing information configured for a catalog entry across all supported storefronts.
  */
 USTRUCT(BlueprintType, Category = "LootLocker")
@@ -356,6 +370,11 @@ struct FLootLockerCatalogEntryListings
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FLootLockerCatalogPlaystationStoreListing Playstation_store;
+    /**
+     * The listing information (if configured) for Xbox Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerCatalogXboxStoreListing Xbox_store;
 };
 
 /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCharacterRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerCharacterRequestHandler.h
@@ -103,6 +103,8 @@ struct FLootLockerListCharacterResponseItem {
 	FString name = "";
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString id = "";
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+	FString ulid = "";
 };
 
 USTRUCT(BlueprintType)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
@@ -458,11 +458,6 @@ struct FLootLockerLeaderboardDetails
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
-     * Whether this leaderboard allows manual resets to be requested via the server API.
-     **/
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool Allow_manual_resets = false;
-    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -474,7 +469,6 @@ struct FLootLockerLeaderboardDetails
     TArray<FLootLockerLeaderboardReward> Rewards;
     /**
      * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
-     * Only populated when Allow_manual_resets is true.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;
@@ -530,11 +524,6 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
-     * Whether this leaderboard allows manual resets to be requested via the server API.
-     **/
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool Allow_manual_resets = false;
-    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -546,7 +535,6 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
     TArray<FLootLockerLeaderboardReward> Rewards;
     /**
      * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
-     * Only populated when Allow_manual_resets is true.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerLeaderboardRequestHandler.h
@@ -380,6 +380,30 @@ struct FLootLockerLeaderboardReward
 };
 
 USTRUCT(BlueprintType)
+/**
+ * A pending manual reset for a leaderboard that has been requested but not yet processed.
+ **/
+struct FLootLockerLeaderboardUpcomingReset
+{
+    GENERATED_BODY()
+    /**
+     * The unique ID of this manual reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int Id = 0;
+    /**
+     * An optional human-readable name for this reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Name = "";
+    /**
+     * The UTC time at which this reset is scheduled to be processed (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Scheduled_for = "";
+};
+
+USTRUCT(BlueprintType)
 struct FLootLockerLeaderboardDetails
 {
     GENERATED_BODY()
@@ -434,6 +458,11 @@ struct FLootLockerLeaderboardDetails
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
+     * Whether this leaderboard allows manual resets to be requested via the server API.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool Allow_manual_resets = false;
+    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -443,6 +472,12 @@ struct FLootLockerLeaderboardDetails
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardReward> Rewards;
+    /**
+     * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
+     * Only populated when Allow_manual_resets is true.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;
 };
 
 USTRUCT(BlueprintType)
@@ -495,6 +530,11 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     bool Has_metadata = false;
     /**
+     * Whether this leaderboard allows manual resets to be requested via the server API.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool Allow_manual_resets = false;
+    /**
      * Schedule of the Leaderboard.
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -504,6 +544,12 @@ struct FLootLockerLeaderboardDetailsResponse : public FLootLockerResponse
      **/
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     TArray<FLootLockerLeaderboardReward> Rewards;
+    /**
+     * Pending manual resets that have been requested but not yet processed, ordered by scheduled_for ascending.
+     * Only populated when Allow_manual_resets is true.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerLeaderboardUpcomingReset> Upcoming_resets;
 };
 
 USTRUCT(BlueprintType)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerMiscellaneousRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerMiscellaneousRequestHandler.h
@@ -71,6 +71,48 @@ struct FLootLockerGameInfoResponse : public FLootLockerResponse
     FLootLockerGameInfo Info;
 };
 
+/// The state of a player's connection and session with the LootLocker backend.
+/// Returned by CheckConnectionStatus.
+UENUM(BlueprintType)
+enum class ELootLockerConnectionState : uint8
+{
+    /// The SDK has not been configured (game API key is not set).
+    NotInitialized      UMETA(DisplayName = "Not Initialized"),
+    /// No session token exists in local state for the specified player.
+    NotSignedIn         UMETA(DisplayName = "Not Signed In"),
+    /// The player has saved credentials on disk but is not currently active in the
+    /// multi-player session. Call SetPlayerUlidToActive (or start a new session) to activate
+    /// them before calling CheckConnectionStatus again.
+    SavedButInactive    UMETA(DisplayName = "Saved But Inactive"),
+    /// The session token is valid and the server is reachable (ping returned 200).
+    SignedInAndConnected UMETA(DisplayName = "Signed In And Connected"),
+    /// A session token exists but the server returned 401 or 403 and the player is not banned.
+    SessionExpired      UMETA(DisplayName = "Session Expired"),
+    /// A session token exists but the player is currently banned.
+    Banned              UMETA(DisplayName = "Banned"),
+    /// The server could not be reached (no network, timeout, or status code 0).
+    NoConnection        UMETA(DisplayName = "No Connection"),
+    /// The server returned a 5xx error or an unexpected non-success status code.
+    ServerError         UMETA(DisplayName = "Server Error"),
+};
+
+/**
+*/
+USTRUCT(BlueprintType)
+struct FLootLockerConnectionStateResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /// The determined connection and session state for the player.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    ELootLockerConnectionState State = ELootLockerConnectionState::NotInitialized;
+    /// Server timestamp returned by the ping. Populated only when State is SignedInAndConnected.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString ServerTime = "";
+    /// Details about the active ban. Populated only when State is Banned.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerBanInfo BanDetails;
+};
+
 //==================================================
 // Delegate Definitions
 //==================================================
@@ -84,6 +126,10 @@ DECLARE_DELEGATE_OneParam(FTimeResponseDelegate, FLootLockerTimeResponse);
  * C++ response delegate for fetching game info
  */
 DECLARE_DELEGATE_OneParam(FGameInfoResponseDelegate, FLootLockerGameInfoResponse);
+/**
+ * C++ response delegate for CheckConnectionStatus
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerConnectionStateDelegate, FLootLockerConnectionStateResponse);
 
 //==================================================
 // API Class Definition
@@ -99,4 +145,5 @@ public:
 	static FString GetServerTime(const FLootLockerPlayerData& PlayerData, const FTimeResponseDelegate& OnCompletedRequest);
 	static FString GetLastActivePlatform(const FLootLockerPlayerData& PlayerData);
     static FString GetGameInfo(const FGameInfoResponseDelegate& OnCompletedRequest);
+    static FString CheckConnectionStatus(const FLootLockerPlayerData& PlayerData, const FLootLockerConnectionStateDelegate& OnCompletedRequest);
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerNotificationsRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerNotificationsRequestHandler.h
@@ -665,10 +665,12 @@ struct FLootLockerNotificationRewardAsset
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString Asset_ulid = "";
     /**
-      The ID of the Asset Instance that was granted. Will be 0 if the reward did not result in an asset instance grant (for example in group rewards).
+      The IDs of the Asset Instances that were granted. Will be empty if the reward did not result
+      in any asset instance grants. For multi-quantity purchases all granted instance IDs are listed.
+      For group rewards each nested asset entry carries its own Asset_instance_ids.
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int Asset_instance_id = 0;
+    TArray<int64> Asset_instance_ids;
 };
 
 /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerNotificationsRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerNotificationsRequestHandler.h
@@ -664,6 +664,11 @@ struct FLootLockerNotificationRewardAsset
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString Asset_ulid = "";
+    /**
+      The ID of the Asset Instance that was granted. Will be 0 if the reward did not result in an asset instance grant (for example in group rewards).
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int Asset_instance_id = 0;
 };
 
 /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPurchasesRequestHandler.h
@@ -166,6 +166,63 @@ struct FLootLockerRedeemEpicStorePurchaseForCharacterRequest : public FLootLocke
     FString Character_id = "";
 };
 
+/**
+ * Response from a request to get an Xbox service ticket.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerXboxServiceTicketResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+     * The service ticket to use for Xbox store purchase redemption
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Service_ticket = "";
+    /**
+     * How many seconds until the ticket expires
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int Expires_in = 0;
+    /**
+     * The date and time when the ticket expires
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Expires_at = "";
+};
+
+/**
+ * Request to redeem an Xbox Store purchase for the current player.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerRedeemXboxStorePurchaseForPlayerRequest
+{
+    GENERATED_BODY()
+    /**
+     * The Xbox user collections ID (JWT) that identifies the user making the purchase
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString User_collections_id = "";
+    /**
+     * The id of the Xbox Store product to redeem
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Product_id = "";
+};
+
+/**
+ * Request to redeem an Xbox Store purchase for a class.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerRedeemXboxStorePurchaseForClassRequest : public FLootLockerRedeemXboxStorePurchaseForPlayerRequest
+{
+    GENERATED_BODY()
+    /**
+     * The id of the class to redeem this purchase for
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    int Class_id = 0;
+};
+
 /// @addtogroup Purchasing
 /// @{
 UENUM(BlueprintType, Category = "LootLocker")
@@ -568,6 +625,8 @@ struct FLootLockerCreateStripeCheckoutSessionResponse : public FLootLockerRespon
 
 /** C++ response callback delegate; receives an @ref FLootLockerCreateStripeCheckoutSessionResponse result. */
 DECLARE_DELEGATE_OneParam(FLootLockerCreateStripeCheckoutSessionDelegate, FLootLockerCreateStripeCheckoutSessionResponse);
+/** C++ response callback delegate; receives an @ref FLootLockerXboxServiceTicketResponse result. */
+DECLARE_DELEGATE_OneParam(FLootLockerXboxServiceTicketDelegate, FLootLockerXboxServiceTicketResponse);
 
 /// @}
 UCLASS()
@@ -593,6 +652,12 @@ public:
     static FString RedeemEpicStorePurchase(const FLootLockerPlayerData& PlayerData, const FString& AccountId, const FString& BearerToken, const TArray<FString>& EntitlementIds, const FString& SandboxId, const FLootLockerDefaultDelegate& OnCompleted);
 
     static FString RedeemEpicStorePurchaseForCharacter(const FLootLockerPlayerData& PlayerData, const FString& CharacterId, const FString& AccountId, const FString& BearerToken, const TArray<FString>& EntitlementIds, const FString& SandboxId, const FLootLockerDefaultDelegate& OnCompleted);
+
+    static FString GetXboxServiceTicket(const FLootLockerPlayerData& PlayerData, const FLootLockerXboxServiceTicketDelegate& OnCompleted);
+
+    static FString RedeemXboxStorePurchaseForPlayer(const FLootLockerPlayerData& PlayerData, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompleted);
+
+    static FString RedeemXboxStorePurchaseForClass(const FLootLockerPlayerData& PlayerData, const int ClassId, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompleted);
 
     static FString RedeemPlayStationStorePurchaseForPlayer(const FLootLockerPlayerData& PlayerData, const FString& TransactionId, const FString& AuthCode, const FString& EntitlementLabel, const FString& ServiceLabel = "", const FString& ServiceName = "", const int Environment = -1, const int UseCount = -1, const FLootLockerDefaultDelegate& OnCompleted = FLootLockerDefaultDelegate());
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -112,7 +112,7 @@ public:
 
 	/**
 	 * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
-	 * the SDK to look for "LootLockerPreConfig-acme.bytes" instead of "LootLockerPreConfig.bytes".
+	 * the SDK to look for "<PackageName>PreConfig-acme.bytes" instead of "<PackageName>PreConfig.bytes".
 	 */
 #if ENGINE_MAJOR_VERSION >= 5
 	inline static const FString ConfigFileIdentifier = TEXT("");
@@ -123,7 +123,6 @@ public:
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override
 	{
-		ApplyFileConfigIfPresent();
 		if (PropertyChangedEvent.GetPropertyName() == "GameVersion")
 		{
 			IsValidGameVersion = IsSemverString(GameVersion);
@@ -149,13 +148,18 @@ public:
 		MigrateSettingsIfNeeded();
 		LoadFileConfig();
 		ApplyFileConfigIfPresent();
-		if(bEnableFileLogging)
+		// File logging is already handled by ApplyFileConfigIfPresent
+		// when a file config is active. So skip it when file config is active.
+		if (!bIsFileConfigLocked)
 		{
-			EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerLog" : LogFileName);
-		}
-		else
-		{
-			DisableFileLogging();
+			if(bEnableFileLogging)
+			{
+				EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerLog" : LogFileName);
+			}
+			else
+			{
+				DisableFileLogging();
+			}
 		}
 		UObject::PostInitProperties();
 	}

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -12,6 +12,7 @@
 #include "CoreMinimal.h"
 #include "Logging/LogVerbosity.h"
 #include "LootLockerLogLevel.h"
+#include "LootLockerFileConfig.h"
 
 #include "LootLockerConfig.generated.h"
 
@@ -82,12 +83,35 @@ public:
 	
 	FLootLockerConfigurationUpdateDelegate OnConfigurationUpdated;
 
+	/**
+	 * Returns true when a pre-configured file config is active and governing settings.
+	 * When true, the Project Settings panel is locked to prevent drift from the file config.
+	 */
+	static bool IsFileConfigActive();
+
+	/**
+	 * Parses a pre-config file's raw content (plain JSON or encrypted) into an FLootLockerFileConfig.
+	 * Returns an empty TOptional when content is invalid or api_key is missing/empty.
+	 * Exposed publicly so unit tests can call it without needing a real plugin on disk.
+	 */
+	static TOptional<FLootLockerFileConfig> ParseFileConfigContent(const FString& Content);
+
 	/** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
 	inline static const FString PackageName = TEXT("LootLocker");
+
+	/** Name of the Unreal plugin (matches the .uplugin filename). Does not change when PackageName is rebranded. */
+	inline static const FString PluginName = TEXT("LootLockerSDK");
+
+	/**
+	 * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
+	 * the SDK to look for "LootLockerPreConfig-acme.bytes" instead of "LootLockerPreConfig.bytes".
+	 */
+	inline static const FString ConfigFileIdentifier = TEXT("");
 
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override
 	{
+		ApplyFileConfigIfPresent();
 		if (PropertyChangedEvent.GetPropertyName() == "GameVersion")
 		{
 			IsValidGameVersion = IsSemverString(GameVersion);
@@ -111,6 +135,8 @@ public:
 	{
 		IsValidGameVersion = IsSemverString(GameVersion);
 		MigrateSettingsIfNeeded();
+		LoadFileConfig();
+		ApplyFileConfigIfPresent();
 		if(bEnableFileLogging)
 		{
 			EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerLog" : LogFileName);
@@ -124,30 +150,32 @@ public:
 
 	UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLocker", Meta = (EditCondition = "IsOutdatedSDK", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
 	FString OutdatedSDKWarning = "This version of LootLocker is no longer updated through fab because of fab guidelines. Please use GitHub releases to update: https://github.com/lootlocker/unreal-sdk/releases";
+	UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLocker", Meta = (EditCondition = "bIsFileConfigLocked", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "INFO:"), Transient)
+	FString FileConfigActiveNotice = "Settings are governed by the pre-configured file config shipped with the plugin and cannot be changed from the editor.";
 	/// API Key used to talk to LootLocker. The API key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (DisplayName = "LootLocker API Key"))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (DisplayName = "LootLocker API Key", EditCondition = "!bIsFileConfigLocked"))
 	FString LootLockerGameKey = "";
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString GameVersion = "";
 	UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLocker", Meta = (EditCondition = "!IsValidGameVersion", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
 	FString InvalidGameVersionWarning = "Game version needs to follow a numeric Semantic Versioning pattern: X.Y.Z.B with the sections denoting MAJOR.MINOR.PATCH.BUILD and the last two being optional. Read more at https://docs.lootlocker.com/the-basics/core-concepts/glossary#game-version";
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
 	bool AllowTokenRefresh = true;
 	/// Domain Key used to talk to LootLocker. The Domain key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (EditCondition = "!bIsFileConfigLocked"))
 	FString DomainKey = "";
 	/// When true, HTTP requests are routed through the legacy ULootLockerHttpClient stack instead of the new
 	/// FLootLockerHTTPExecutionQueue. Use this as a temporary escape hatch if you encounter issues with the
 	/// new queue. This setting has no effect when the project is compiled with LOOTLOCKER_FORCE_LEGACY_HTTP_STACK=1
 	/// (which always uses the legacy stack regardless of this value). This option will be removed once the
 	/// execution queue is declared stable.
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (DisplayName = "Use Legacy HTTP Stack"))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (DisplayName = "Use Legacy HTTP Stack", EditCondition = "!bIsFileConfigLocked"))
 	bool bUseLegacyHTTPStack = false;
 	/// Allow LootLocker to log non error logs outside the editor. This is false by default to avoid log spamming and unintentional logging of data (as LootLocker logs requests and responses vs LootLocker).
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging")
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (EditCondition = "!bIsFileConfigLocked"))
 	bool LogOutsideOfEditor = false;
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (DisplayName = "LootLocker Log Level"))
-    ELootLockerLogLevel LootLockerLogLevel;
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (DisplayName = "LootLocker Log Level", EditCondition = "!bIsFileConfigLocked"))
+    ELootLockerLogLevel LootLockerLogLevel = ELootLockerLogLevel::Warning;
 
 	UFUNCTION()
 	static bool ShouldLog()
@@ -225,9 +253,9 @@ public:
     UFUNCTION(BlueprintCallable, Category = "LootLocker|Presence")
     static bool IsPresenceEnabledInEditor();
 
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (DisplayName = "Enable File Logging"))
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (DisplayName = "Enable File Logging", EditCondition = "!bIsFileConfigLocked"))
     bool bEnableFileLogging = false;
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (DisplayName = "Name of LootLocker Log File", EditCondition = "bEnableFileLogging", EditConditionHides))
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Logging", Meta = (DisplayName = "Name of LootLocker Log File", EditCondition = "bEnableFileLogging && !bIsFileConfigLocked", EditConditionHides))
     FString LogFileName = TEXT("LootLockerLog");
 	UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLocker|Logging", Meta = (EditCondition = "bEnableFileLogging", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "Actual Log File (on current device)"), Transient)
 	FString LongLogFilePath = "";
@@ -237,19 +265,19 @@ public:
 	// ========================================================================
 	
 	/** Enable or disable the entire Presence system globally */
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Enable Presence System"))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Enable Presence System", EditCondition = "!bIsFileConfigLocked"))
 	bool bEnablePresence = false;
 
 	/** Whether to automatically connect presence when sessions are established */
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Auto-Connect on Session Start", EditCondition = "bEnablePresence", EditConditionHides))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Auto-Connect on Session Start", EditCondition = "bEnablePresence && !bIsFileConfigLocked", EditConditionHides))
 	bool bEnablePresenceAutoConnect = true;
 
 	/** Whether to automatically disconnect presence when the application loses focus or goes to background */
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Auto-Disconnect on Focus Loss", EditCondition = "bEnablePresence", EditConditionHides))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Auto-Disconnect on Focus Loss", EditCondition = "bEnablePresence && !bIsFileConfigLocked", EditConditionHides))
 	bool bEnablePresenceAutoDisconnectOnFocusChange = true;
 
 	/** Enable presence features in the editor (for testing purposes) */
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Enable In Editor", EditCondition = "bEnablePresence", EditConditionHides))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Enable In Editor", EditCondition = "bEnablePresence && !bIsFileConfigLocked", EditConditionHides))
 	bool bEnablePresenceInEditor = true;
 
 	// ========================================================================
@@ -269,12 +297,16 @@ public:
 	 * Each new authentication deactivates all others and becomes the sole active default. Best for
 	 * games with account selection screens.
 	 */
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Multi User", Meta = (DisplayName = "Multi User Session Mode"))
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Multi User", Meta = (DisplayName = "Multi User Session Mode", EditCondition = "!bIsFileConfigLocked"))
 	ELootLockerMultiUserSessionMode MultiUserSessionMode = ELootLockerMultiUserSessionMode::NotSet;
 private:
 	FString LogFilePath = "";
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
 	bool IsValidGameVersion = true;
+	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
+	bool bIsFileConfigLocked = false;
+	inline static bool bFileConfigChecked = false;
+	inline static TOptional<FLootLockerFileConfig> FileConfig;
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
 	bool IsOutdatedSDK /** Value in ifdef */
 #ifdef LOOTLOCKER_SHOW_OUTDATED_SDK_MESSAGE
@@ -293,8 +325,8 @@ private:
 	 *  then persists the result so subsequent loads skip this check. */
 	void MigrateSettingsIfNeeded();
 
-public:
-    ULootLockerConfig();
-private:
+	static void LoadFileConfig();
+	void ApplyFileConfigIfPresent();
 };
+
 /// @}

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -161,7 +161,7 @@ public:
     FString GameVersion = "";
 	UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLocker", Meta = (EditCondition = "!IsValidGameVersion", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
 	FString InvalidGameVersionWarning = "Game version needs to follow a numeric Semantic Versioning pattern: X.Y.Z.B with the sections denoting MAJOR.MINOR.PATCH.BUILD and the last two being optional. Read more at https://docs.lootlocker.com/the-basics/core-concepts/glossary#game-version";
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker")
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (EditCondition = "!bIsFileConfigLocked"))
 	bool AllowTokenRefresh = true;
 	/// Domain Key used to talk to LootLocker. The Domain key can be found in `Settings > API Keys` in the Web Console: https://console.lootlocker.com/settings/api-keys
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker", Meta = (EditCondition = "!bIsFileConfigLocked"))

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -96,28 +96,14 @@ public:
 	 */
 	static TOptional<FLootLockerFileConfig> ParseFileConfigContent(const FString& Content);
 
-	/** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
-#if ENGINE_MAJOR_VERSION >= 5
-	inline static const FString PackageName = TEXT("LootLocker");
-#else
-	static const FString PackageName;
-#endif
-
-	/** Name of the Unreal plugin (matches the .uplugin filename). Does not change when PackageName is rebranded. */
-#if ENGINE_MAJOR_VERSION >= 5
-	inline static const FString PluginName = TEXT("LootLockerSDK");
-#else
-	static const FString PluginName;
-#endif
-
 	/**
-	 * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
-	 * the SDK to look for "<PackageName>PreConfig-acme.bytes" instead of "<PackageName>PreConfig.bytes".
+	 * Filename of the pre-config file that the SDK looks for in the plugin's Config directory.
+	 * Default: "LootLockerPreConfig.bytes"
 	 */
 #if ENGINE_MAJOR_VERSION >= 5
-	inline static const FString ConfigFileIdentifier = TEXT("");
+	inline static const FString PreConfigFileName = TEXT("LootLockerPreConfig.bytes");
 #else
-	static const FString ConfigFileIdentifier;
+	static const FString PreConfigFileName;
 #endif
 
 #if WITH_EDITOR

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -20,6 +20,50 @@
  */
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FLootLockerConfigurationUpdateDelegate, const FString&, SettingName);
 
+/**
+ * Controls how the SDK handles multiple player sessions when a new authentication succeeds.
+ * Determines which player is considered the "default" for API calls that do not specify a player ULID.
+ */
+UENUM(BlueprintType, Category = "LootLocker")
+enum class ELootLockerMultiUserSessionMode : uint8
+{
+	/**
+	 * [Not yet configured] The SDK will automatically set the correct mode the first time the project is
+	 * loaded with this version of the SDK: new installs (no API key) get SingleSession, existing projects
+	 * get Hotseat for backwards compatibility. This value should never be set manually.
+	 */
+	NotSet          UMETA(Hidden),
+
+	/**
+	 * Multiple active sessions are allowed simultaneously.
+	 * The first player to authenticate in a game session becomes the default.
+	 * Subsequent authentications are additive — they join the active pool but do not change the default.
+	 * All player data is retained in persistent cache between sessions.
+	 *
+	 * Best for: local multiplayer, couch co-op, or any game where multiple players share a device at the same time.
+	 */
+	Hotseat         UMETA(DisplayName = "Hotseat"),
+
+	/**
+	 * Only one player session exists at any given time.
+	 * Each new authentication completely wipes all previous session data before saving the new player as the sole active default.
+	 * There is always exactly one player in the system; no historical data is kept.
+	 *
+	 * Best for: standard single-player games where only one account should ever exist on the device.
+	 */
+	SingleSession   UMETA(DisplayName = "Single Session"),
+
+	/**
+	 * Only one player is active at a time, but historical player sessions are retained in a cold cache.
+	 * Each new authentication makes that player the sole active and default while all previously active
+	 * players are deactivated — but their session data remains on-device.
+	 * You can switch back to a previously-authenticated player without re-authenticating.
+	 *
+	 * Best for: games with an account selection screen, or games where players switch between accounts.
+	 */
+	ProfileSwitching UMETA(DisplayName = "Profile Switching"),
+};
+
 UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "LootLocker SDK Settings"))
 class LOOTLOCKERSDK_API ULootLockerConfig : public UObject
 {
@@ -63,6 +107,7 @@ public:
 	virtual void PostInitProperties() override
 	{
 		IsValidGameVersion = IsSemverString(GameVersion);
+		MigrateSettingsIfNeeded();
 		if(bEnableFileLogging)
 		{
 			EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerLog" : LogFileName);
@@ -203,6 +248,26 @@ public:
 	/** Enable presence features in the editor (for testing purposes) */
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Presence", Meta = (DisplayName = "Enable In Editor", EditCondition = "bEnablePresence", EditConditionHides))
 	bool bEnablePresenceInEditor = true;
+
+	// ========================================================================
+	// MULTI USER CONFIGURATION
+	// ========================================================================
+
+	/**
+	 * Controls how the SDK handles multiple player sessions when a new authentication succeeds.
+	 *
+	 * Hotseat: Multiple active sessions allowed. The first authenticated player is default; subsequent
+	 * authentications are additive. Best for local multiplayer / couch co-op.
+	 *
+	 * Single Session: Only one player session exists at a time. New authentications wipe all previous
+	 * session data. Best for standard single-player games.
+	 *
+	 * Profile Switching: Only one player active at a time, but historical players kept in cold cache.
+	 * Each new authentication deactivates all others and becomes the sole active default. Best for
+	 * games with account selection screens.
+	 */
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLocker|Multi User", Meta = (DisplayName = "Multi User Session Mode"))
+	ELootLockerMultiUserSessionMode MultiUserSessionMode = ELootLockerMultiUserSessionMode::NotSet;
 private:
 	FString LogFilePath = "";
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
@@ -218,6 +283,12 @@ private:
 #if ENGINE_MAJOR_VERSION >= 5
 	inline static const std::regex SemverPattern = std::regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?(?:\\.(0|[1-9]\\d*))?$" );
 #endif
+
+	/** Performs a one-time migration of settings that were introduced after initial project setup.
+	 *  Specifically handles MultiUserSessionMode: if not present in DefaultGame.ini (pre-migration install),
+	 *  sets Hotseat for existing projects (backwards compatible) or SingleSession for new installs,
+	 *  then persists the result so subsequent loads skip this check. */
+	void MigrateSettingsIfNeeded();
 
 public:
     ULootLockerConfig();

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -82,6 +82,9 @@ public:
 	
 	FLootLockerConfigurationUpdateDelegate OnConfigurationUpdated;
 
+	/** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
+	inline static const FString PackageName = TEXT("LootLocker");
+
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override
 	{

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerConfig.h
@@ -97,16 +97,28 @@ public:
 	static TOptional<FLootLockerFileConfig> ParseFileConfigContent(const FString& Content);
 
 	/** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
+#if ENGINE_MAJOR_VERSION >= 5
 	inline static const FString PackageName = TEXT("LootLocker");
+#else
+	static const FString PackageName;
+#endif
 
 	/** Name of the Unreal plugin (matches the .uplugin filename). Does not change when PackageName is rebranded. */
+#if ENGINE_MAJOR_VERSION >= 5
 	inline static const FString PluginName = TEXT("LootLockerSDK");
+#else
+	static const FString PluginName;
+#endif
 
 	/**
 	 * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
 	 * the SDK to look for "LootLockerPreConfig-acme.bytes" instead of "LootLockerPreConfig.bytes".
 	 */
+#if ENGINE_MAJOR_VERSION >= 5
 	inline static const FString ConfigFileIdentifier = TEXT("");
+#else
+	static const FString ConfigFileIdentifier;
+#endif
 
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override
@@ -305,8 +317,13 @@ private:
 	bool IsValidGameVersion = true;
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
 	bool bIsFileConfigLocked = false;
+#if ENGINE_MAJOR_VERSION >= 5
 	inline static bool bFileConfigChecked = false;
 	inline static TOptional<FLootLockerFileConfig> FileConfig;
+#else
+	static bool bFileConfigChecked;
+	static TOptional<FLootLockerFileConfig> FileConfig;
+#endif
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLocker")
 	bool IsOutdatedSDK /** Value in ifdef */
 #ifdef LOOTLOCKER_SHOW_OUTDATED_SDK_MESSAGE

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerErrorData.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerErrorData.h
@@ -5,6 +5,26 @@
 #include "CoreMinimal.h"
 #include "LootLockerErrorData.generated.h"
 
+/// Details about a player's active ban.
+USTRUCT(BlueprintType)
+struct FLootLockerBanInfo
+{
+    GENERATED_BODY()
+    /// The reason for the ban. One of "manual" or "chargeback".
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString ban_reason = "";
+    /// The time the ban was issued, as an ISO 8601 timestamp.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString banned_on = "";
+    /// The time the ban expires, as an ISO 8601 timestamp.
+    /// Empty string when the ban is permanent; check the Permanent field to confirm.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString banned_until = "";
+    /// True if the ban has no expiry date.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    bool permanent = false;
+};
+
 USTRUCT(BlueprintType)
 struct FLootLockerErrorData
 {
@@ -29,4 +49,8 @@ struct FLootLockerErrorData
     /// A free text description of the problem and potential suggestions for fixing it
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString Message = "";
+    /// When Code is "player_banned", contains sanitized details about the active ban.
+    /// Fields will have default (empty/false) values for all other error codes.
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerBanInfo ban;
 };

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFileConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFileConfig.h
@@ -9,8 +9,8 @@
 #include "LootLockerFileConfig.generated.h"
 
 /**
- * Data struct for the pre-configured file config, loaded at startup from the LootLockerPreConfig file
- * in the plugin's Config directory. When present and containing a non-empty api_key, it overrides
+ * Data struct for the pre-configured file config, loaded at startup from the "<PackageName>PreConfig[-<identifier>].bytes"
+ * file in the plugin's Config directory. When present and containing a non-empty api_key, it overrides
  * DefaultGame.ini settings and locks the editor UI to prevent drift.
  *
  * The file supports plain JSON or AES-256-ECB + PKCS7 + Base64 encrypted content. Plain JSON is

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFileConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFileConfig.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+/// @addtogroup Init
+/// @{
+
+#include "CoreMinimal.h"
+#include "LootLockerFileConfig.generated.h"
+
+/**
+ * Data struct for the pre-configured file config, loaded at startup from the LootLockerPreConfig file
+ * in the plugin's Config directory. When present and containing a non-empty api_key, it overrides
+ * DefaultGame.ini settings and locks the editor UI to prevent drift.
+ *
+ * The file supports plain JSON or AES-256-ECB + PKCS7 + Base64 encrypted content. Plain JSON is
+ * recommended during development; encrypted files should be used for distribution.
+ *
+ * Build-time flags (enable_google_subsystem_helper, etc.) live in the optional "build_flags" JSON
+ * section and are consumed only by Build.cs at compile time — not at runtime.
+ *
+ * Supported JSON fields:
+ *   api_key                                       (string, required — empty or missing means "inactive")
+ *   domain_key                                    (string)
+ *   game_version                                  (string, default "1.0.0.0")
+ *   allow_token_refresh                           (bool, default true)
+ *   log_outside_of_editor                         (bool, default false)
+ *   log_level                                     (string: "Error"|"Warning"|"Display"|"Verbose"|"VeryVerbose"|"NoLogging", default "Warning")
+ *   enable_file_logging                           (bool, default false)
+ *   enable_presence                               (bool, default false)
+ *   enable_presence_auto_connect                  (bool, default true)
+ *   enable_presence_auto_disconnect_on_focus_change (bool, default true)
+ *   enable_presence_in_editor                     (bool, default true)
+ *   multi_user_session_mode                       (string: "Hotseat"|"SingleSession"|"ProfileSwitching", default "NotSet")
+ *   use_legacy_http_stack                         (bool, default false)
+ *
+ * Build-time only (parsed by Build.cs, ignored at runtime):
+ *   build_flags.enable_google_subsystem_helper    (bool)
+ *   build_flags.show_outdated_sdk_message         (bool)
+ *   build_flags.enable_beta_error_reporting       (bool)
+ *   build_flags.force_legacy_http_stack           (bool)
+ */
+USTRUCT()
+struct LOOTLOCKERSDK_API FLootLockerFileConfig
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	FString api_key;
+
+	UPROPERTY()
+	FString domain_key;
+
+	UPROPERTY()
+	FString game_version = TEXT("1.0.0.0");
+
+	UPROPERTY()
+	bool allow_token_refresh = true;
+
+	UPROPERTY()
+	bool log_outside_of_editor = false;
+
+	/** Enum name string: "Error"|"Warning"|"Display"|"Verbose"|"VeryVerbose"|"NoLogging" */
+	UPROPERTY()
+	FString log_level = TEXT("Warning");
+
+	UPROPERTY()
+	bool enable_file_logging = false;
+
+	UPROPERTY()
+	bool enable_presence = false;
+
+	UPROPERTY()
+	bool enable_presence_auto_connect = true;
+
+	UPROPERTY()
+	bool enable_presence_auto_disconnect_on_focus_change = true;
+
+	UPROPERTY()
+	bool enable_presence_in_editor = true;
+
+	/** Enum name string: "Hotseat"|"SingleSession"|"ProfileSwitching" */
+	UPROPERTY()
+	FString multi_user_session_mode = TEXT("NotSet");
+
+	UPROPERTY()
+	bool use_legacy_http_stack = false;
+};
+
+/// @}

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFileConfig.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerFileConfig.h
@@ -31,7 +31,7 @@
  *   enable_presence_auto_connect                  (bool, default true)
  *   enable_presence_auto_disconnect_on_focus_change (bool, default true)
  *   enable_presence_in_editor                     (bool, default true)
- *   multi_user_session_mode                       (string: "Hotseat"|"SingleSession"|"ProfileSwitching", default "NotSet")
+ *   multi_user_session_mode                       (string: "Hotseat"|"SingleSession"|"ProfileSwitching"|"NotSet", default "NotSet" is internal and will be resolved at first launch")
  *   use_legacy_http_stack                         (bool, default false)
  *
  * Build-time only (parsed by Build.cs, ignored at runtime):
@@ -79,7 +79,7 @@ struct LOOTLOCKERSDK_API FLootLockerFileConfig
 	UPROPERTY()
 	bool enable_presence_in_editor = true;
 
-	/** Enum name string: "Hotseat"|"SingleSession"|"ProfileSwitching" */
+	/** Enum name string: "Hotseat"|"SingleSession"|"ProfileSwitching". Default "NotSet" means "do not override". */
 	UPROPERTY()
 	FString multi_user_session_mode = TEXT("NotSet");
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -64,6 +64,7 @@ public:
     static FLootLockerEndPoints StartDiscordSessionEndpoint;
     static FLootLockerEndPoints RefreshDiscordSessionEndpoint;
     static FLootLockerEndPoints PlaystationNetworkV3SessionEndpoint;
+    static FLootLockerEndPoints GetPlayerBanStatusEndpoint;
 
     // Connected Accounts
     static FLootLockerEndPoints ListConnectedAccountsEndpoint;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -313,6 +313,7 @@ public:
     static FLootLockerEndPoints ListCatalogs;
     static FLootLockerEndPoints DeprecatedListCatalogItemsByKey;
     static FLootLockerEndPoints ListCatalogItemsByKey;
+    static FLootLockerEndPoints ListCatalogItemsById;
 
     // Entitlements
     static FLootLockerEndPoints ListEntitlements;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -244,6 +244,9 @@ public:
     static FLootLockerEndPoints RedeemEpicStorePurchase;
     static FLootLockerEndPoints RedeemPlayStationStorePurchase;
 
+    static FLootLockerEndPoints XboxServiceTicket;
+    static FLootLockerEndPoints RedeemXboxStorePurchase;
+
     static FLootLockerEndPoints BeginSteamPurchaseRedemption;
     static FLootLockerEndPoints QuerySteamPurchaseRedemptionStatus;
     static FLootLockerEndPoints FinalizeSteamPurchaseRedemption;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -377,6 +377,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogsResponseBP, FLootLocker
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogPricesResponseBP, FLootLockerListCatalogPricesResponse, Response);
 /** Blueprint response delegate for listing catalog prices responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogPricesV2ResponseBP, FLootLockerListCatalogPricesV2Response, Response);
+/** Blueprint response delegate for listing catalog items by id responses */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCatalogItemsByIdResponseBP, FLootLockerListCatalogItemsByIdResponse, Response);
 /** Blueprint response delegate for internal listing catalog prices responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FInternalLootLockerListCatalogPricesResponseBP, FInternalLootLockerListCatalogPricesResponse, Response);
 /** Blueprint response delegate for internal listing catalog prices responses */
@@ -3491,6 +3493,18 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "PerPage,Page,ForPlayerWithUlid", PerPage = -1, Page = -1, ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsV2(const FString& ForPlayerWithUlid, const FString& CatalogKey, int PerPage, int Page, const FLootLockerListCatalogPricesV2ResponseBP& OnComplete);
+
+    /**
+     List catalog items by their catalog_listing_ids. Returns entries with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. Only applicable if IncludeMetadata is true. If empty, all metadata is returned.
+     @param OnComplete Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys,ForPlayerWithUlid"))
+    static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsById(const FString& ForPlayerWithUlid, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseBP& OnComplete);
 
     /**
      Inline the data items from a catalog response into the catalog items

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -7,6 +7,7 @@
 #include "GameAPI/LootLockerAssetInstancesRequestHandler.h"
 #include "GameAPI/LootLockerAssetsRequestHandler.h"
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
+#include "GameAPI/LootLockerBanRequestHandler.h"
 #include "GameAPI/LootLockerBalanceRequestHandler.h"
 #include "GameAPI/LootLockerBroadcastRequestHandler.h"
 #include "GameAPI/LootLockerCatalogRequestHandler.h"
@@ -74,6 +75,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerAppleGameCenterSessionResponseBP, F
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerMetaSessionResponseBP, FLootLockerMetaSessionResponse, Var);
 /** Blueprint response delegate for Discord authentication session responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FDiscordSessionResponseBP, FLootLockerDiscordSessionResponse, Var);
+/** Blueprint response delegate for player ban status responses */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerBanStatusResponseBP, FLootLockerBanStatusResponse, Response);
 
 //==================================================
 // Connected Accounts Delegates
@@ -1000,6 +1003,20 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication")
     static UPARAM(DisplayName = "RequestId") FString EndSession(const FString& ForPlayerWithUlid, const FLootLockerDefaultResponseBP& OnEndSessionRequestCompleted);
+
+    /**
+     Get the ban status for a player.
+
+     Use this after a session start fails with error code `player_banned` to retrieve the ban
+     reason and duration so the game client can surface it to the player.
+     This endpoint authenticates with a game API key and does not require an active player session.
+
+     @param PlayerUlid The ULID of the player to query
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication", meta = (AdvancedDisplay = "PlayerUlid", PlayerUlid = ""))
+    static UPARAM(DisplayName = "RequestId") FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusResponseBP& OnCompletedRequest);
 
     //==================================================
     // Connected Accounts

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -1015,7 +1015,7 @@ public:
      @param OnCompletedRequest Delegate for handling the server response
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
-    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication", meta = (AdvancedDisplay = "PlayerUlid", PlayerUlid = ""))
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Authentication")
     static UPARAM(DisplayName = "RequestId") FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusResponseBP& OnCompletedRequest);
 
     //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -4102,7 +4102,7 @@ public:
      - NotInitialized      — the SDK has not been configured (game API key is not set).
      - NotSignedIn         — no saved credentials exist for the specified player.
      - SavedButInactive    — the player has saved credentials but is not currently active in the
-                             multi-player session. Call MakePlayerActive or start a new session first.
+                             multi-player session. Call SetPlayerUlidToActive or start a new session first.
      - NoConnection        — the server could not be reached (no network, timeout, or status 0).
      - SignedInAndConnected — the session is valid and the server is reachable.
      - SessionExpired      — a session exists but the token is no longer valid (401 or non-ban 403).

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -1128,6 +1128,10 @@ public:
      IMPORTANT: This is destructive for the source player; transferred providers will no longer authenticate that player.
      Limitations: Source must own the providers; destination must not already have them; providers must be active in game settings.
 
+     NOTE: Requires ELootLockerMultiUserSessionMode::Hotseat to be configured (ULootLockerConfig::MultiUserSessionMode),
+     because this method needs two simultaneously active local sessions. It returns an error if the current mode is
+     SingleSession or ProfileSwitching.
+
      @param FromPlayerWithUlid ULID of the authenticated source player (providers moved FROM)
      @param ToPlayerWithUlid ULID of the authenticated destination player (providers moved TO)
      @param ProvidersToTransfer List of identity providers to transfer

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -445,6 +445,10 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FTimeResponseDelegateBP, FLootLockerTimeRespon
  Blueprint response delegate for fetching game info
 */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FGameInfoResponseDelegateBP, FLootLockerGameInfoResponse, Response);
+/**
+ Blueprint response delegate for CheckConnectionStatus
+*/
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerConnectionStateResponseBP, FLootLockerConnectionStateResponse, Response);
 
 //==================================================
 // Presence Delegates
@@ -477,6 +481,14 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Player State")
     static void SetPlayerUlidToInactive(const FString& PlayerUlid);
+
+    /**
+     Mark a player's state as active
+
+    @param PlayerUlid ULID of the player to set active
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Player State")
+    static void SetPlayerUlidToActive(const FString& PlayerUlid);
 
     /**
      Mark all currently active players as inactive
@@ -4081,6 +4093,32 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Miscellaneous")
     static UPARAM(DisplayName = "RequestId") FString GetGameInfo(const FGameInfoResponseDelegateBP& OnCompletedRequestBP);
+
+    /**
+     Check the current connection and session state for a player.
+
+     Performs fast local checks first, then a lightweight ping to the LootLocker servers.
+     Returns one of the following states:
+     - NotInitialized      — the SDK has not been configured (game API key is not set).
+     - NotSignedIn         — no saved credentials exist for the specified player.
+     - SavedButInactive    — the player has saved credentials but is not currently active in the
+                             multi-player session. Call MakePlayerActive or start a new session first.
+     - NoConnection        — the server could not be reached (no network, timeout, or status 0).
+     - SignedInAndConnected — the session is valid and the server is reachable.
+     - SessionExpired      — a session exists but the token is no longer valid (401 or non-ban 403).
+     - Banned              — the player is currently banned; BanDetails is populated.
+     - ServerError         — the server returned a 5xx or other unexpected error.
+
+     Note: if automatic token refresh is enabled in the SDK config (AllowTokenRefresh), the underlying
+     HTTP client may attempt a refresh when the ping returns 401 or 403. This method reports the
+     resulting state after any such automatic behavior — it does not explicitly request a refresh.
+
+    @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied the default player is used
+    @param OnCompletedRequestBP Delegate for handling the response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Miscellaneous", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString CheckConnectionStatus(const FString& ForPlayerWithUlid, const FLootLockerConnectionStateResponseBP& OnCompletedRequestBP);
 
     //==================================================
     // Presence

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -281,6 +281,8 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerQuerySteamPurchaseRedemptionStatusD
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerRefundByEntitlementIdsResponseDelegate, FLootLockerRefundByEntitlementIdsResponse, Response);
 /** Blueprint response delegate for creating a Stripe Checkout session */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerCreateStripeCheckoutSessionDelegateBP, FLootLockerCreateStripeCheckoutSessionResponse, Response);
+/** Blueprint response delegate for getting an Xbox service ticket */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerXboxServiceTicketResponseBP, FLootLockerXboxServiceTicketResponse, Response);
 /** Blueprint response delegate for initiating an async purchase */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerAsyncPurchaseInitiatedDelegateBP, FLootLockerAsyncPurchaseInitiatedResponse, Response);
 /** Blueprint response delegate for polling the status of an async purchase */
@@ -2745,6 +2747,41 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString RedeemEpicStorePurchaseForCharacter(const FString& ForPlayerWithUlid, const FString& CharacterId, const FString& AccountId, const FString& BearerToken, const TArray<FString>& EntitlementIds, const FString& SandboxId, const FLootLockerDefaultResponseBP& OnCompletedRequest);
+
+    /**
+      Get an Xbox service ticket that can be used to redeem an Xbox Store purchase.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used.
+      @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString GetXboxServiceTicket(const FString& ForPlayerWithUlid, const FLootLockerXboxServiceTicketResponseBP& OnCompletedRequest);
+
+    /**
+      Redeem a purchase made towards the Xbox Store for the current player.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used.
+      @param UserCollectionsId The Xbox user collections ID (JWT) identifying the user
+      @param ProductId The Xbox Store product id to redeem
+      @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString RedeemXboxStorePurchaseForPlayer(const FString& ForPlayerWithUlid, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultResponseBP& OnCompletedRequest);
+
+    /**
+      Redeem a purchase made towards the Xbox Store for a class owned by the player.
+
+      @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used.
+      @param ClassId The id of the class to redeem this purchase for
+      @param UserCollectionsId The Xbox user collections ID (JWT) identifying the user
+      @param ProductId The Xbox Store product id to redeem
+      @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Purchases", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString RedeemXboxStorePurchaseForClass(const FString& ForPlayerWithUlid, int ClassId, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultResponseBP& OnCompletedRequest);
 
 #ifdef LOOTLOCKER_BETA_PLAYSTATION_IAP
     /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -3503,7 +3503,7 @@ public:
      @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
      @return A unique id for this request
     */
-    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys,ForPlayerWithUlid"))
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Catalog", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys,ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsById(const FString& ForPlayerWithUlid, const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseBP& OnComplete);
 
     /**

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -3165,6 +3165,17 @@ public:
      */
     static FString ListCatalogItems(const FString & CatalogKey, const FLootLockerListCatalogPricesV2ResponseDelegate & OnComplete, const FString& ForPlayerWithUlid = "") { return ListCatalogItems(CatalogKey, -1, 0, OnComplete, ForPlayerWithUlid); }
 
+    /**
+     List catalog items by their catalog_listing_ids. Returns entries with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. Only applicable if IncludeMetadata is true. If empty, all metadata is returned.
+     @param OnComplete Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+     */
+    static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerListCatalogItemsByIdResponseDelegate& OnComplete, const FString& ForPlayerWithUlid = "");
+
     /// @}
 
     //==================================================

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -6,6 +6,7 @@
 #include "GameAPI/LootLockerAssetInstancesRequestHandler.h"
 #include "GameAPI/LootLockerAssetsRequestHandler.h"
 #include "GameAPI/LootLockerAuthenticationRequestHandler.h"
+#include "GameAPI/LootLockerBanRequestHandler.h"
 #include "GameAPI/LootLockerBalanceRequestHandler.h"
 #include "GameAPI/LootLockerBroadcastRequestHandler.h"
 #include "GameAPI/LootLockerCatalogRequestHandler.h"
@@ -529,6 +530,19 @@ public:
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     static FString EndSession(const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Get the ban status for a player.
+
+     Use this after a session start fails with error code `player_banned` to retrieve the ban
+     reason and duration so the game client can surface it to the player.
+     This endpoint authenticates with a game API key and does not require an active player session.
+
+     @param PlayerUlid The ULID of the player to query
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString GetPlayerBanStatus(const FString& PlayerUlid, const FLootLockerBanStatusDelegate& OnCompletedRequest);
 
     /// @}
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -644,6 +644,10 @@ public:
 
      Destructive: providers move from source to target player. Entire operation fails if any provider cannot be transferred.
 
+     NOTE: Requires ELootLockerMultiUserSessionMode::Hotseat to be configured (ULootLockerConfig::MultiUserSessionMode),
+     because this method needs two simultaneously active local sessions. It returns an error if the current mode is
+     SingleSession or ProfileSwitching.
+
      Limitations:
       - Source must own each provider
       - Target must not already have provider

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -66,6 +66,13 @@ public:
     static void SetPlayerUlidToInactive(const FString& PlayerUlid);
 
     /**
+    Mark a player's state as active
+
+     @param PlayerUlid ULID of the player to set active
+     */
+    static void SetPlayerUlidToActive(const FString& PlayerUlid);
+
+    /**
      Mark all currently active players as inactive
      */
     static void SetAllPlayersToInactive();
@@ -3740,6 +3747,31 @@ public:
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     static FString GetGameInfo(const FGameInfoResponseDelegate& OnComplete);
+
+    /**
+     Check the current connection and session state for a player.
+
+     Performs fast local checks first, then a lightweight ping to the LootLocker servers.
+     Returns one of the following states:
+     - NotInitialized   — the SDK has not been configured (game API key is not set).
+     - NotSignedIn      — no saved credentials exist for the specified player.
+     - SavedButInactive — the player has saved credentials but is not currently active in the
+                          multi-player session. Call SetPlayerUlidToActive or start a new session first.
+     - NoConnection     — the server could not be reached (no network, timeout, or status 0).
+     - SignedInAndConnected — the session is valid and the server is reachable.
+     - SessionExpired   — a session exists but the token is no longer valid (401 or non-ban 403).
+     - Banned           — the player is currently banned; BanDetails is populated.
+     - ServerError      — the server returned a 5xx or other unexpected error.
+
+     Note: if automatic token refresh is enabled in the SDK config (AllowTokenRefresh), the underlying
+     HTTP client may attempt a refresh when the ping returns 401 or 403. This method reports the
+     resulting state after any such automatic behavior — it does not explicitly request a refresh.
+
+     @param OnCompletedRequest Delegate called when the check is complete
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString CheckConnectionStatus(const FLootLockerConnectionStateDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
     /// @}
 

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -2463,6 +2463,38 @@ public:
      */
     static FString RedeemEpicStorePurchaseForCharacter(const FString& CharacterId, const FString& AccountId, const FString& BearerToken, const TArray<FString>& EntitlementIds, const FString& SandboxId, const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
+    /**
+     Get an Xbox service ticket that can be used to redeem an Xbox Store purchase.
+
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+     */
+    static FString GetXboxServiceTicket(const FLootLockerXboxServiceTicketDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Redeem a purchase made towards the Xbox Store for the current player.
+
+     @param UserCollectionsId The Xbox user collections ID (JWT) identifying the user
+     @param ProductId The Xbox Store product id to redeem
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+     */
+    static FString RedeemXboxStorePurchaseForPlayer(const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /**
+     Redeem a purchase made towards the Xbox Store for a class owned by the player.
+
+     @param ClassId The id of the class to redeem this purchase for
+     @param UserCollectionsId The Xbox user collections ID (JWT) identifying the user
+     @param ProductId The Xbox Store product id to redeem
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request
+     */
+    static FString RedeemXboxStorePurchaseForClass(int ClassId, const FString& UserCollectionsId, const FString& ProductId, const FLootLockerDefaultDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
 #ifdef LOOTLOCKER_BETA_PLAYSTATION_IAP
     /**
       Redeem a purchase that was made successfully towards the PlayStation Store for the current player

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerFileConfigTest.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerFileConfigTest.cpp
@@ -21,7 +21,7 @@
 BEGIN_DEFINE_SPEC(
     FLootLockerFileConfigSpec,
     "LootLocker.FileConfig",
-    EAutomationTestFlags::EditorContext | EAutomationTestFlags::SmokeFilter)
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 END_DEFINE_SPEC(FLootLockerFileConfigSpec)
 
 void FLootLockerFileConfigSpec::Define()

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerFileConfigTest.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerFileConfigTest.cpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2021 LootLocker
+
+// Unit tests for ULootLockerConfig::ParseFileConfigContent.
+//
+// These tests run without a real plugin/file on disk and exercise the parsing
+// of plain-JSON file config content, including default-value fallback, empty
+// api_key rejection, and enum string → value round-trips.
+//
+// Run headless (no backend required):
+//   UnrealEditor.exe "YourProject.uproject" -run=automation
+//     -ExecCmds="automation RunTests LootLocker.FileConfig"
+//     -unattended -nullrhi -nosound -stdout
+
+#include "Runtime/Launch/Resources/Version.h"
+#include "LootLockerConfig.h"
+#include "LootLockerFileConfig.h"
+#include "Misc/AutomationTest.h"
+
+#if ENGINE_MAJOR_VERSION > 4
+
+BEGIN_DEFINE_SPEC(
+    FLootLockerFileConfigSpec,
+    "LootLocker.FileConfig",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::SmokeFilter)
+END_DEFINE_SPEC(FLootLockerFileConfigSpec)
+
+void FLootLockerFileConfigSpec::Define()
+{
+    // -------------------------------------------------------------------------
+    // Empty / invalid input
+    // -------------------------------------------------------------------------
+
+    It("Returns empty TOptional for empty content", [this]()
+    {
+        auto Result = ULootLockerConfig::ParseFileConfigContent(TEXT(""));
+        TestFalse("TOptional should not be set", Result.IsSet());
+    });
+
+    It("Returns empty TOptional for non-JSON content", [this]()
+    {
+        auto Result = ULootLockerConfig::ParseFileConfigContent(TEXT("not json at all"));
+        TestFalse("TOptional should not be set", Result.IsSet());
+    });
+
+    It("Returns empty TOptional when api_key is absent", [this]()
+    {
+        const FString Json = TEXT(R"({"domain_key":"dk","game_version":"2.0.0.0"})");
+        auto Result = ULootLockerConfig::ParseFileConfigContent(Json);
+        TestFalse("TOptional should not be set when api_key is absent", Result.IsSet());
+    });
+
+    It("Returns empty TOptional when api_key is an empty string", [this]()
+    {
+        const FString Json = TEXT(R"({"api_key":""})");
+        auto Result = ULootLockerConfig::ParseFileConfigContent(Json);
+        TestFalse("TOptional should not be set when api_key is empty", Result.IsSet());
+    });
+
+    // -------------------------------------------------------------------------
+    // Minimal / partial JSON (defaults must be preserved)
+    // -------------------------------------------------------------------------
+
+    It("Activates when only api_key is provided and fills defaults", [this]()
+    {
+        const FString Json = TEXT(R"({"api_key":"test-key"})");
+        auto Result = ULootLockerConfig::ParseFileConfigContent(Json);
+        if (!TestTrue("TOptional should be set", Result.IsSet())) return;
+
+        const FLootLockerFileConfig& Config = Result.GetValue();
+        TestEqual("api_key",                   Config.api_key,              FString(TEXT("test-key")));
+        TestEqual("domain_key default",        Config.domain_key,           FString(TEXT("")));
+        TestEqual("game_version default",      Config.game_version,         FString(TEXT("1.0.0.0")));
+        TestTrue( "allow_token_refresh default",  Config.allow_token_refresh);
+        TestFalse("log_outside_of_editor default", Config.log_outside_of_editor);
+        TestEqual("log_level default",         Config.log_level,            FString(TEXT("Warning")));
+        TestFalse("enable_file_logging default",   Config.enable_file_logging);
+        TestFalse("enable_presence default",       Config.enable_presence);
+        TestTrue( "enable_presence_auto_connect default",  Config.enable_presence_auto_connect);
+        TestTrue( "enable_presence_auto_disconnect_on_focus_change default", Config.enable_presence_auto_disconnect_on_focus_change);
+        TestTrue( "enable_presence_in_editor default",     Config.enable_presence_in_editor);
+        TestEqual("multi_user_session_mode default", Config.multi_user_session_mode, FString(TEXT("NotSet")));
+        TestFalse("use_legacy_http_stack default", Config.use_legacy_http_stack);
+    });
+
+    // -------------------------------------------------------------------------
+    // Full JSON (all runtime fields)
+    // -------------------------------------------------------------------------
+
+    It("Parses all runtime fields correctly", [this]()
+    {
+        const FString Json = TEXT(R"({
+            "api_key": "live-key-123",
+            "domain_key": "my-domain",
+            "game_version": "3.1.4.1",
+            "allow_token_refresh": false,
+            "log_outside_of_editor": true,
+            "log_level": "Verbose",
+            "enable_file_logging": true,
+            "enable_presence": true,
+            "enable_presence_auto_connect": false,
+            "enable_presence_auto_disconnect_on_focus_change": false,
+            "enable_presence_in_editor": false,
+            "multi_user_session_mode": "SingleSession",
+            "use_legacy_http_stack": true
+        })");
+
+        auto Result = ULootLockerConfig::ParseFileConfigContent(Json);
+        if (!TestTrue("TOptional should be set", Result.IsSet())) return;
+
+        const FLootLockerFileConfig& Config = Result.GetValue();
+        TestEqual("api_key",                      Config.api_key,              FString(TEXT("live-key-123")));
+        TestEqual("domain_key",                   Config.domain_key,           FString(TEXT("my-domain")));
+        TestEqual("game_version",                 Config.game_version,         FString(TEXT("3.1.4.1")));
+        TestFalse("allow_token_refresh",          Config.allow_token_refresh);
+        TestTrue( "log_outside_of_editor",        Config.log_outside_of_editor);
+        TestEqual("log_level",                    Config.log_level,            FString(TEXT("Verbose")));
+        TestTrue( "enable_file_logging",          Config.enable_file_logging);
+        TestTrue( "enable_presence",              Config.enable_presence);
+        TestFalse("enable_presence_auto_connect", Config.enable_presence_auto_connect);
+        TestFalse("enable_presence_auto_disconnect_on_focus_change", Config.enable_presence_auto_disconnect_on_focus_change);
+        TestFalse("enable_presence_in_editor",    Config.enable_presence_in_editor);
+        TestEqual("multi_user_session_mode",      Config.multi_user_session_mode, FString(TEXT("SingleSession")));
+        TestTrue( "use_legacy_http_stack",        Config.use_legacy_http_stack);
+    });
+
+    // -------------------------------------------------------------------------
+    // build_flags section is silently ignored at runtime
+    // -------------------------------------------------------------------------
+
+    It("Ignores build_flags section without error", [this]()
+    {
+        const FString Json = TEXT(R"({
+            "api_key": "key",
+            "build_flags": {
+                "enable_google_subsystem_helper": true,
+                "force_legacy_http_stack": true
+            }
+        })");
+
+        auto Result = ULootLockerConfig::ParseFileConfigContent(Json);
+        TestTrue("TOptional should be set even with build_flags present", Result.IsSet());
+    });
+
+    // -------------------------------------------------------------------------
+    // Enum string round-trips via ApplyFileConfigIfPresent (via StaticEnum reflection)
+    // -------------------------------------------------------------------------
+
+    Describe("log_level strings map to ELootLockerLogLevel via reflection", [this]()
+    {
+        const TArray<TPair<FString, ELootLockerLogLevel>> Cases = {
+            { TEXT("Error"),       ELootLockerLogLevel::Error       },
+            { TEXT("Warning"),     ELootLockerLogLevel::Warning     },
+            { TEXT("Display"),     ELootLockerLogLevel::Display     },
+            { TEXT("Verbose"),     ELootLockerLogLevel::Verbose     },
+            { TEXT("VeryVerbose"), ELootLockerLogLevel::VeryVerbose },
+            { TEXT("NoLogging"),   ELootLockerLogLevel::NoLogging   },
+        };
+
+        for (const auto& Pair : Cases)
+        {
+            const FString LogLevelName = Pair.Key;
+            const ELootLockerLogLevel Expected = Pair.Value;
+
+            It(FString::Printf(TEXT("'%s' maps correctly"), *LogLevelName), [this, LogLevelName, Expected]()
+            {
+                const UEnum* Enum = StaticEnum<ELootLockerLogLevel>();
+                if (!TestNotNull("ELootLockerLogLevel UEnum must exist", Enum)) return;
+
+                const int64 Value = Enum->GetValueByNameString(LogLevelName);
+                TestNotEqual(FString::Printf(TEXT("'%s' must be a valid enum name"), *LogLevelName),
+                    Value, static_cast<int64>(INDEX_NONE));
+                TestEqual("Mapped value matches expected",
+                    static_cast<ELootLockerLogLevel>(Value), Expected);
+            });
+        }
+    });
+
+    Describe("multi_user_session_mode strings map to ELootLockerMultiUserSessionMode via reflection", [this]()
+    {
+        const TArray<TPair<FString, ELootLockerMultiUserSessionMode>> Cases = {
+            { TEXT("Hotseat"),         ELootLockerMultiUserSessionMode::Hotseat         },
+            { TEXT("SingleSession"),   ELootLockerMultiUserSessionMode::SingleSession   },
+            { TEXT("ProfileSwitching"),ELootLockerMultiUserSessionMode::ProfileSwitching },
+        };
+
+        for (const auto& Pair : Cases)
+        {
+            const FString ModeName = Pair.Key;
+            const ELootLockerMultiUserSessionMode Expected = Pair.Value;
+
+            It(FString::Printf(TEXT("'%s' maps correctly"), *ModeName), [this, ModeName, Expected]()
+            {
+                const UEnum* Enum = StaticEnum<ELootLockerMultiUserSessionMode>();
+                if (!TestNotNull("ELootLockerMultiUserSessionMode UEnum must exist", Enum)) return;
+
+                const int64 Value = Enum->GetValueByNameString(ModeName);
+                TestNotEqual(FString::Printf(TEXT("'%s' must be a valid enum name"), *ModeName),
+                    Value, static_cast<int64>(INDEX_NONE));
+                TestEqual("Mapped value matches expected",
+                    static_cast<ELootLockerMultiUserSessionMode>(Value), Expected);
+            });
+        }
+    });
+}
+
+#endif // ENGINE_MAJOR_VERSION > 4

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerTestGame.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/LootLockerTestGame.cpp
@@ -681,6 +681,7 @@ void FLootLockerTestGame::InitializeLootLockerSDK() const
 	Config->LootLockerGameKey = GetActiveApiKey();
 	Config->GameVersion       = TEXT("0.0.0.1");
 	Config->DomainKey         = GameDomainKey;
+	Config->MultiUserSessionMode = ELootLockerMultiUserSessionMode::Hotseat;
 
 	// If the domain key is empty (e.g. env-var shortcut), check for a companion env var
 	if (Config->DomainKey.IsEmpty())

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserManagement.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserManagement.cpp
@@ -26,6 +26,7 @@ void FTestLootLockerMultiUserManagement::Define()
 		bOk = Game.EnableGuestLogin();
 		if (!bOk) { Done.Execute(); return; }
 		Game.InitializeLootLockerSDK();
+		GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::Hotseat;
 
 		// Start player 1 as the main session
 		test_util::StartSession();

--- a/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserSessionModes.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Tests/MultiUserSessionModes.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2021 LootLocker
+
+#include <future>
+
+#include "LootLockerConfig.h"
+#include "LootLockerPlatformManager.h"
+#include "LootLockerSDKManager.h"
+#include "LootLockerSessionOptionals.h"
+#include "LootLockerStateData.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationCommon.h"
+#include "TestUtils.h"
+#include "LootLockerTestGame.h"
+
+#if ENGINE_MAJOR_VERSION > 4
+BEGIN_DEFINE_SPEC(FTestLootLockerMultiUserSessionModes, "LootLocker.MultiUserSessionModes",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+	FLootLockerTestGame Game;
+END_DEFINE_SPEC(FTestLootLockerMultiUserSessionModes)
+
+void FTestLootLockerMultiUserSessionModes::Define()
+{
+	LatentBeforeEach(EAsyncExecution::ThreadPool, [this](const FDoneDelegate& Done)
+	{
+		bool bOk = FLootLockerTestGame::CreateGame(Game, TEXT("MultiUserSessionModes"));
+		if (!bOk) { Done.Execute(); return; }
+		bOk = Game.EnableGuestLogin();
+		if (!bOk) { Done.Execute(); return; }
+		Game.InitializeLootLockerSDK();
+		ULootLockerStateData::ClearAllSavedStates();
+		Done.Execute();
+	});
+
+	LatentAfterEach(EAsyncExecution::ThreadPool, [this](const FDoneDelegate& Done)
+	{
+		Game.DeleteGame();
+		Done.Execute();
+	});
+
+	Describe("SingleSession", [this]()
+	{
+		LatentIt("SecondAuth_ClearsFirst", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::SingleSession;
+
+			test_util::StartSession();
+			const FString Player1Ulid = ULootLockerStateData::GetSavedStateForFirstPlayer().PlayerUlid;
+			if (Player1Ulid.IsEmpty()) { AddError(TEXT("First session failed")); TestDone.Execute(); return; }
+
+			// When
+			const test_util::FTestPlayerSession P2 = test_util::StartAdditionalSession();
+			if (!P2.bSuccess) { AddError(TEXT("Second session failed")); TestDone.Execute(); return; }
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+			const FString DefaultUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+
+			TestEqual("SingleSession should retain only 1 cached player", CachedUlids.Num(), 1);
+			TestEqual("SingleSession should retain only 1 active player", ActiveUlids.Num(), 1);
+			TestFalse("First player should have been cleared from cache", CachedUlids.Contains(Player1Ulid));
+			TestTrue("Second player should remain in cache", CachedUlids.Contains(P2.PlayerUlid));
+			TestEqual("Second player should be the default", DefaultUlid, P2.PlayerUlid);
+
+			TestDone.Execute();
+		});
+
+		LatentIt("ReauthSamePlayer_DoesNotClearPlayer", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::SingleSession;
+
+			const FString Identifier = TEXT("reauth_test_user");
+
+			// First login
+			ULootLockerStateData::ClearAllSavedStates();
+			const auto [Promise1, Delegate1] = test_util::CreateDelegate<FLootLockerAuthenticationResponse, FLootLockerSessionResponse>();
+			ULootLockerSDKManager::GuestLogin(Delegate1, Identifier, FLootLockerSessionOptionals{});
+			const auto Response1 = test_util::WaitAndGet(Promise1, 60);
+			if (!Response1.success) { AddError(TEXT("First login failed")); TestDone.Execute(); return; }
+			FLootLockerPlayerData PD1 = FLootLockerPlayerData::Create(
+				Response1.session_token, TEXT(""), Response1.player_identifier, Response1.player_ulid,
+				Response1.public_uid, TEXT(""), TEXT(""), TEXT(""),
+				ULootLockerPlatforms::GetPlatformRepresentationForPlatform(ELootLockerPlatform::Guest),
+				FDateTime::Now().ToString(), Response1.player_created_at);
+			ULootLockerStateData::SavePlayerData(PD1);
+			const FString Player1Ulid = Response1.player_ulid;
+
+			// When — re-authenticate using the same identifier
+			const auto [Promise2, Delegate2] = test_util::CreateDelegate<FLootLockerAuthenticationResponse, FLootLockerSessionResponse>();
+			ULootLockerSDKManager::GuestLogin(Delegate2, Identifier, FLootLockerSessionOptionals{});
+			const auto Response2 = test_util::WaitAndGet(Promise2, 60);
+			if (!Response2.success) { AddError(TEXT("Re-auth login failed")); TestDone.Execute(); return; }
+			FLootLockerPlayerData PD2 = FLootLockerPlayerData::Create(
+				Response2.session_token, TEXT(""), Response2.player_identifier, Response2.player_ulid,
+				Response2.public_uid, TEXT(""), TEXT(""), TEXT(""),
+				ULootLockerPlatforms::GetPlatformRepresentationForPlatform(ELootLockerPlatform::Guest),
+				FDateTime::Now().ToString(), Response2.player_created_at);
+			ULootLockerStateData::SavePlayerData(PD2);
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+
+			TestEqual("Re-authenticating same identifier should return same ULID", Response2.player_ulid, Player1Ulid);
+			TestEqual("SingleSession should retain only 1 cached player after re-auth", CachedUlids.Num(), 1);
+			TestEqual("SingleSession should retain only 1 active player after re-auth", ActiveUlids.Num(), 1);
+			TestTrue("Re-authenticated player should still be cached", CachedUlids.Contains(Player1Ulid));
+
+			TestDone.Execute();
+		});
+	});
+
+	Describe("ProfileSwitching", [this]()
+	{
+		LatentIt("SecondAuth_DeactivatesFirstButKeepsBothCached", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::ProfileSwitching;
+
+			test_util::StartSession();
+			const FString Player1Ulid = ULootLockerStateData::GetSavedStateForFirstPlayer().PlayerUlid;
+			if (Player1Ulid.IsEmpty()) { AddError(TEXT("First session failed")); TestDone.Execute(); return; }
+
+			// When
+			const test_util::FTestPlayerSession P2 = test_util::StartAdditionalSession();
+			if (!P2.bSuccess) { AddError(TEXT("Second session failed")); TestDone.Execute(); return; }
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+			const FString DefaultUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+
+			TestEqual("ProfileSwitching should retain both players in cache", CachedUlids.Num(), 2);
+			TestEqual("ProfileSwitching should leave only 1 active player", ActiveUlids.Num(), 1);
+			TestTrue("First player should still be in cache", CachedUlids.Contains(Player1Ulid));
+			TestTrue("Second player should be in cache", CachedUlids.Contains(P2.PlayerUlid));
+			TestFalse("First player should be inactive", ActiveUlids.Contains(Player1Ulid));
+			TestTrue("Second player should be active", ActiveUlids.Contains(P2.PlayerUlid));
+			TestEqual("Second player should be the default", DefaultUlid, P2.PlayerUlid);
+
+			TestDone.Execute();
+		});
+	});
+
+	Describe("Hotseat", [this]()
+	{
+		LatentIt("MultipleAuths_AllRemainActive_FirstIsDefault", EAsyncExecution::ThreadPool, [this](const FDoneDelegate TestDone)
+		{
+			if (!Game.IsValid())
+			{
+				AddError(TEXT("Game setup failed")); TestDone.Execute(); return;
+			}
+
+			// Given
+			GetMutableDefault<ULootLockerConfig>()->MultiUserSessionMode = ELootLockerMultiUserSessionMode::Hotseat;
+
+			test_util::StartSession();
+			const FString Player1Ulid = ULootLockerStateData::GetSavedStateForFirstPlayer().PlayerUlid;
+			if (Player1Ulid.IsEmpty()) { AddError(TEXT("First session failed")); TestDone.Execute(); return; }
+
+			// When — start two more sessions
+			const test_util::FTestPlayerSession P2 = test_util::StartAdditionalSession();
+			if (!P2.bSuccess) { AddError(TEXT("Second session failed")); TestDone.Execute(); return; }
+
+			const test_util::FTestPlayerSession P3 = test_util::StartAdditionalSession();
+			if (!P3.bSuccess) { AddError(TEXT("Third session failed")); TestDone.Execute(); return; }
+
+			// Then
+			const TArray<FString> CachedUlids = ULootLockerStateData::GetCachedPlayerUlids();
+			const TArray<FString> ActiveUlids = ULootLockerStateData::GetActivePlayerUlids();
+			const FString DefaultUlid = ULootLockerStateData::GetDefaultPlayerUlid();
+
+			TestEqual("Hotseat should retain all 3 players in cache", CachedUlids.Num(), 3);
+			TestEqual("Hotseat should keep all 3 players active", ActiveUlids.Num(), 3);
+			TestTrue("First player should be in cache", CachedUlids.Contains(Player1Ulid));
+			TestTrue("Second player should be in cache", CachedUlids.Contains(P2.PlayerUlid));
+			TestTrue("Third player should be in cache", CachedUlids.Contains(P3.PlayerUlid));
+			TestEqual("First player should remain the default in Hotseat mode", DefaultUlid, Player1Ulid);
+
+			TestDone.Execute();
+		});
+	});
+}
+#endif

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class LootLockerSDKEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore"
+            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore", "Json", "JsonUtilities"
         });
 
         PublicDependencyModuleNames.AddRange(new string[] {

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class LootLockerSDKEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore", "Json", "JsonUtilities"
+            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerSDK", "InputCore", "Json"
         });
 
         PublicDependencyModuleNames.AddRange(new string[] {

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
@@ -8,7 +8,6 @@
 #include "Widgets/Layout/SBox.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Misc/App.h"
-#include "LootLockerConfig.h"
 
 static const FName LootLockerLogViewerTabName("LootLockerLogViewer");
 
@@ -33,21 +32,20 @@ public:
                         SNew(SLootLockerLogViewerWidget)
                     ];
             })
-        ).SetDisplayName(FText::FromString(ULootLockerConfig::PackageName + TEXT(" Log Viewer")))
+        ).SetDisplayName(FText::FromString(TEXT("LootLocker Log Viewer")))
          .SetMenuType(ETabSpawnerMenuType::Enabled);
 
-        // Register menu entry under Tools > <PackageName> Tools
+        // Register menu entry under Tools > LootLocker Tools
         UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateLambda([]
         {
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Tools");
             if (Menu)
             {
-                const FString LLSectionName = ULootLockerConfig::PackageName + TEXT(" Tools");
-                FToolMenuSection& Section = Menu->AddSection(*LLSectionName, FText::FromString(LLSectionName));
+                FToolMenuSection& Section = Menu->AddSection("LootLocker Tools", FText::FromString(TEXT("LootLocker Tools")));
                 Section.AddMenuEntry(
                     "LootLockerLogViewerMenuEntry",
-                    FText::FromString(ULootLockerConfig::PackageName + TEXT(" Log Viewer")),
-                    FText::FromString(FString::Printf(TEXT("Open the %s Log Viewer window."), *ULootLockerConfig::PackageName)),
+                    FText::FromString(TEXT("LootLocker Log Viewer")),
+                    FText::FromString(TEXT("Open the LootLocker Log Viewer window.")),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateLambda([]
                     {
@@ -57,7 +55,7 @@ public:
                 Section.AddMenuEntry(
                     "LootLockerCheckForUpdates",
                     FText::FromString("Check for Updates"),
-                    FText::FromString(FString::Printf(TEXT("Check if a newer version of the %s SDK is available."), *ULootLockerConfig::PackageName)),
+                    FText::FromString(TEXT("Check if a newer version of the LootLocker SDK is available.")),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateStatic(&FLootLockerUpdateChecker::ManualCheck))
                 );

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
@@ -36,7 +36,7 @@ public:
         ).SetDisplayName(FText::FromString(ULootLockerConfig::PackageName + TEXT(" Log Viewer")))
          .SetMenuType(ETabSpawnerMenuType::Enabled);
 
-        // Register menu entry under Tools > LootLocker Tools
+        // Register menu entry under Tools > <PackageName> Tools
         UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateLambda([]
         {
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Tools");

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) LootLocker. All Rights Reserved.
 #include "Modules/ModuleManager.h"
 #include "LootLockerLogViewerWidget.h"
+#include "LootLockerUpdateChecker.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "LevelEditor.h"
 #include "ToolMenus.h"
@@ -51,12 +52,23 @@ public:
                         FGlobalTabmanager::Get()->TryInvokeTab(LootLockerLogViewerTabName);
                     }))
                 );
+                Section.AddMenuEntry(
+                    "LootLockerCheckForUpdates",
+                    FText::FromString("Check for Updates"),
+                    FText::FromString("Check if a newer version of the LootLocker SDK is available."),
+                    FSlateIcon(),
+                    FUIAction(FExecuteAction::CreateStatic(&FLootLockerUpdateChecker::ManualCheck))
+                );
             }
         }));
+
+        // Delayed update check (fires after StartupDelaySeconds)
+        FLootLockerUpdateChecker::Initialize();
     }
 
     virtual void ShutdownModule() override
     {
+        FLootLockerUpdateChecker::Shutdown();
         FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(LootLockerLogViewerTabName);
     }
 };

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerSDKEditor.cpp
@@ -8,6 +8,7 @@
 #include "Widgets/Layout/SBox.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Misc/App.h"
+#include "LootLockerConfig.h"
 
 static const FName LootLockerLogViewerTabName("LootLockerLogViewer");
 
@@ -32,7 +33,7 @@ public:
                         SNew(SLootLockerLogViewerWidget)
                     ];
             })
-        ).SetDisplayName(FText::FromString("LootLocker Log Viewer"))
+        ).SetDisplayName(FText::FromString(ULootLockerConfig::PackageName + TEXT(" Log Viewer")))
          .SetMenuType(ETabSpawnerMenuType::Enabled);
 
         // Register menu entry under Tools > LootLocker Tools
@@ -41,11 +42,12 @@ public:
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Tools");
             if (Menu)
             {
-                FToolMenuSection& Section = Menu->AddSection("LootLocker Tools", FText::FromString("LootLocker Tools"));
+                const FString LLSectionName = ULootLockerConfig::PackageName + TEXT(" Tools");
+                FToolMenuSection& Section = Menu->AddSection(*LLSectionName, FText::FromString(LLSectionName));
                 Section.AddMenuEntry(
                     "LootLockerLogViewerMenuEntry",
-                    FText::FromString("LootLocker Log Viewer"),
-                    FText::FromString("Open the LootLocker Log Viewer window."),
+                    FText::FromString(ULootLockerConfig::PackageName + TEXT(" Log Viewer")),
+                    FText::FromString(FString::Printf(TEXT("Open the %s Log Viewer window."), *ULootLockerConfig::PackageName)),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateLambda([]
                     {
@@ -55,7 +57,7 @@ public:
                 Section.AddMenuEntry(
                     "LootLockerCheckForUpdates",
                     FText::FromString("Check for Updates"),
-                    FText::FromString("Check if a newer version of the LootLocker SDK is available."),
+                    FText::FromString(FString::Printf(TEXT("Check if a newer version of the %s SDK is available."), *ULootLockerConfig::PackageName)),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateStatic(&FLootLockerUpdateChecker::ManualCheck))
                 );

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) LootLocker. All Rights Reserved.
 #include "LootLockerUpdateChecker.h"
-#include "LootLockerConfig.h"
 #include "SLootLockerUpdateNotification.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
@@ -122,7 +121,7 @@ void FLootLockerUpdateChecker::OnResponseReceived(
         if (bManual)
         {
             FNotificationInfo Info(FText::FromString(
-                FString::Printf(TEXT("%s: Could not reach GitHub to check for updates."), *ULootLockerConfig::PackageName)));
+                TEXT("LootLocker: Could not reach GitHub to check for updates.")));
             Info.ExpireDuration = 5.0f;
             Info.bFireAndForget = true;
             FSlateNotificationManager::Get().AddNotification(Info);
@@ -192,7 +191,7 @@ void FLootLockerUpdateChecker::ShowUpdateNotification(
     }
 
     const TSharedRef<SWindow> Window = SNew(SWindow)
-        .Title(FText::FromString(FString::Printf(TEXT("%s SDK Update Available"), *ULootLockerConfig::PackageName)))
+        .Title(FText::FromString(TEXT("LootLocker SDK Update Available")))
         .ClientSize(FVector2D(560.0f, 210.0f))
         .SupportsMinimize(false)
         .SupportsMaximize(false)
@@ -213,7 +212,7 @@ void FLootLockerUpdateChecker::ShowUpdateNotification(
 void FLootLockerUpdateChecker::ShowUpToDateNotification()
 {
     FNotificationInfo Info(FText::FromString(
-        FString::Printf(TEXT("%s SDK is up to date!"), *ULootLockerConfig::PackageName)));
+        TEXT("LootLocker SDK is up to date!")));
     Info.ExpireDuration = 5.0f;
     Info.bFireAndForget = true;
     FSlateNotificationManager::Get().AddNotification(Info);

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) LootLocker. All Rights Reserved.
 #include "LootLockerUpdateChecker.h"
+#include "LootLockerConfig.h"
 #include "SLootLockerUpdateNotification.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
@@ -120,11 +121,8 @@ void FLootLockerUpdateChecker::OnResponseReceived(
     {
         if (bManual)
         {
-            UE_LOG(LogLootLockerSDKEditor, Warning,
-                TEXT("LootLocker update check failed (HTTP %d)."),
-                Response.IsValid() ? Response->GetResponseCode() : 0);
-
-            FNotificationInfo Info(FText::FromString(TEXT("LootLocker: Could not reach GitHub to check for updates.")));
+            FNotificationInfo Info(FText::FromString(
+                FString::Printf(TEXT("%s: Could not reach GitHub to check for updates."), *ULootLockerConfig::PackageName)));
             Info.ExpireDuration = 5.0f;
             Info.bFireAndForget = true;
             FSlateNotificationManager::Get().AddNotification(Info);
@@ -194,7 +192,7 @@ void FLootLockerUpdateChecker::ShowUpdateNotification(
     }
 
     const TSharedRef<SWindow> Window = SNew(SWindow)
-        .Title(FText::FromString(TEXT("LootLocker SDK Update Available")))
+        .Title(FText::FromString(FString::Printf(TEXT("%s SDK Update Available"), *ULootLockerConfig::PackageName)))
         .ClientSize(FVector2D(560.0f, 210.0f))
         .SupportsMinimize(false)
         .SupportsMaximize(false)
@@ -214,7 +212,8 @@ void FLootLockerUpdateChecker::ShowUpdateNotification(
 
 void FLootLockerUpdateChecker::ShowUpToDateNotification()
 {
-    FNotificationInfo Info(FText::FromString(TEXT("LootLocker SDK is up to date!")));
+    FNotificationInfo Info(FText::FromString(
+        FString::Printf(TEXT("%s SDK is up to date!"), *ULootLockerConfig::PackageName)));
     Info.ExpireDuration = 5.0f;
     Info.bFireAndForget = true;
     FSlateNotificationManager::Get().AddNotification(Info);

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#include "LootLockerUpdateChecker.h"
+#include "SLootLockerUpdateNotification.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+#include "Interfaces/IPluginManager.h"
+#include "Misc/DateTime.h"
+#include "Misc/ConfigCacheIni.h"
+#include "Misc/App.h"
+#include "Containers/Ticker.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "HAL/PlatformProcess.h"
+#include "Logging/LogMacros.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogLootLockerSDKEditor, Log, All);
+
+// --- Static member definitions ---
+FTSTicker::FDelegateHandle FLootLockerUpdateChecker::TickerHandle;
+double FLootLockerUpdateChecker::ElapsedStartupSeconds = 0.0;
+const TCHAR* FLootLockerUpdateChecker::ConfigSection = TEXT("/Script/LootLockerSDKEditor.UpdateChecker");
+const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
+    TEXT("https://api.github.com/repos/lootlocker/unreal-sdk/releases/latest");
+
+// ---------------------------------------------------------------------------
+
+void FLootLockerUpdateChecker::Initialize()
+{
+    ElapsedStartupSeconds = 0.0;
+    TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
+        FTickerDelegate::CreateStatic(&FLootLockerUpdateChecker::OnStartupTick),
+        0.0f  // tick every frame; we measure elapsed time ourselves
+    );
+}
+
+void FLootLockerUpdateChecker::Shutdown()
+{
+    if (TickerHandle.IsValid())
+    {
+        FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+        TickerHandle.Reset();
+    }
+}
+
+void FLootLockerUpdateChecker::ManualCheck()
+{
+    CheckForUpdate(/*bManual=*/true);
+}
+
+bool FLootLockerUpdateChecker::OnStartupTick(float DeltaTime)
+{
+    ElapsedStartupSeconds += DeltaTime;
+    if (ElapsedStartupSeconds >= StartupDelaySeconds)
+    {
+        // Remove ticker — we only need one startup check
+        TickerHandle.Reset();
+        CheckForUpdate(/*bManual=*/false);
+        return false;  // unregister
+    }
+    return true;  // keep ticking
+}
+
+void FLootLockerUpdateChecker::CheckForUpdate(bool bManual)
+{
+    if (!bManual && !ShouldCheck())
+    {
+        return;
+    }
+    FetchLatestRelease(bManual);
+}
+
+bool FLootLockerUpdateChecker::ShouldCheck()
+{
+    if (GetNeverNotify())
+    {
+        return false;
+    }
+
+    const FDateTime RemindAfter = GetRemindAfterTime();
+    if (FDateTime::UtcNow() < RemindAfter)
+    {
+        return false;
+    }
+
+    const FDateTime LastChecked = GetLastCheckedTime();
+    const FTimespan TimeSinceLastCheck = FDateTime::UtcNow() - LastChecked;
+    if (TimeSinceLastCheck.GetTotalHours() < CheckIntervalHours)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool FLootLockerUpdateChecker::ShouldNotify(const FString& LatestVersion)
+{
+    return GetSkippedVersion() != LatestVersion;
+}
+
+void FLootLockerUpdateChecker::FetchLatestRelease(bool bManual)
+{
+    TSharedRef<IHttpRequest> Request = FHttpModule::Get().CreateRequest();
+    Request->SetURL(GitHubReleasesUrl);
+    Request->SetVerb(TEXT("GET"));
+    Request->SetHeader(TEXT("Accept"), TEXT("application/vnd.github.v3+json"));
+    Request->SetHeader(TEXT("User-Agent"), TEXT("LootLockerSDK-UnrealEditor"));
+
+    // Capture bManual by value in the lambda binding
+    Request->OnProcessRequestComplete().BindLambda(
+        [bManual](FHttpRequestPtr Req, FHttpResponsePtr Resp, bool bWasSuccessful)
+        {
+            FLootLockerUpdateChecker::OnResponseReceived(Req, Resp, bWasSuccessful, bManual);
+        }
+    );
+
+    Request->ProcessRequest();
+}
+
+void FLootLockerUpdateChecker::OnResponseReceived(
+    FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual)
+{
+    if (!bWasSuccessful || !Response.IsValid() || Response->GetResponseCode() != 200)
+    {
+        if (bManual)
+        {
+            UE_LOG(LogLootLockerSDKEditor, Warning,
+                TEXT("LootLocker update check failed (HTTP %d)."),
+                Response.IsValid() ? Response->GetResponseCode() : 0);
+
+            FNotificationInfo Info(FText::FromString(TEXT("LootLocker: Could not reach GitHub to check for updates.")));
+            Info.ExpireDuration = 5.0f;
+            Info.bFireAndForget = true;
+            FSlateNotificationManager::Get().AddNotification(Info);
+        }
+        return;
+    }
+
+    TSharedPtr<FJsonObject> JsonObject;
+    const TSharedRef<TJsonReader<>> Reader =
+        TJsonReaderFactory<>::Create(Response->GetContentAsString());
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        UE_LOG(LogLootLockerSDKEditor, Warning, TEXT("LootLocker update check: failed to parse GitHub response."));
+        return;
+    }
+
+    FString TagName = JsonObject->GetStringField(TEXT("tag_name"));  // e.g. "v10.5.0"
+    const FString HtmlUrl = JsonObject->GetStringField(TEXT("html_url"));
+
+    // Strip leading 'v' or 'V'
+    if (TagName.StartsWith(TEXT("v")) || TagName.StartsWith(TEXT("V")))
+    {
+        TagName.RightChopInline(1);
+    }
+
+    // Strip any pre-release suffix (e.g. "10.5.0-beta.1" → "10.5.0")
+    int32 DashIndex;
+    if (TagName.FindChar(TEXT('-'), DashIndex))
+    {
+        TagName = TagName.Left(DashIndex);
+    }
+    int32 PlusIndex;
+    if (TagName.FindChar(TEXT('+'), PlusIndex))
+    {
+        TagName = TagName.Left(PlusIndex);
+    }
+
+    SaveLastCheckedTime(FDateTime::UtcNow());
+
+    if (IsVersionNewer(TagName, GetCurrentVersion()))
+    {
+        if (bManual || ShouldNotify(TagName))
+        {
+            ShowUpdateNotification(TagName, HtmlUrl, bManual);
+        }
+    }
+    else if (bManual)
+    {
+        ShowUpToDateNotification();
+    }
+}
+
+void FLootLockerUpdateChecker::ShowUpdateNotification(
+    const FString& LatestVersion, const FString& ReleaseUrl, bool bManual)
+{
+    if (!FSlateApplication::IsInitialized())
+    {
+        return;
+    }
+
+    const TSharedRef<SWindow> Window = SNew(SWindow)
+        .Title(FText::FromString(TEXT("LootLocker SDK Update Available")))
+        .ClientSize(FVector2D(560.0f, 210.0f))
+        .SupportsMinimize(false)
+        .SupportsMaximize(false)
+        .IsTopmostWindow(false)
+        .SizingRule(ESizingRule::FixedSize);
+
+    Window->SetContent(
+        SNew(SLootLockerUpdateNotification)
+            .CurrentVersion(GetCurrentVersion())
+            .LatestVersion(LatestVersion)
+            .ReleaseUrl(ReleaseUrl)
+            .ParentWindow(Window)
+    );
+
+    FSlateApplication::Get().AddWindow(Window);
+}
+
+void FLootLockerUpdateChecker::ShowUpToDateNotification()
+{
+    FNotificationInfo Info(FText::FromString(TEXT("LootLocker SDK is up to date!")));
+    Info.ExpireDuration = 5.0f;
+    Info.bFireAndForget = true;
+    FSlateNotificationManager::Get().AddNotification(Info);
+}
+
+bool FLootLockerUpdateChecker::IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion)
+{
+    TArray<FString> RemoteParts, LocalParts;
+    RemoteVersion.ParseIntoArray(RemoteParts, TEXT("."));
+    LocalVersion.ParseIntoArray(LocalParts, TEXT("."));
+
+    const int32 MaxParts = FMath::Max(RemoteParts.Num(), LocalParts.Num());
+    for (int32 i = 0; i < MaxParts; ++i)
+    {
+        const int32 Remote = (i < RemoteParts.Num()) ? FCString::Atoi(*RemoteParts[i]) : 0;
+        const int32 Local  = (i < LocalParts.Num())  ? FCString::Atoi(*LocalParts[i])  : 0;
+        if (Remote > Local) return true;
+        if (Remote < Local) return false;
+    }
+    return false;  // equal
+}
+
+bool FLootLockerUpdateChecker::IsFabManaged()
+{
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
+    if (!Plugin.IsValid())
+    {
+        return false;
+    }
+    return Plugin->GetBaseDir().Contains(TEXT("Marketplace"));
+}
+
+FString FLootLockerUpdateChecker::GetCurrentVersion()
+{
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
+    if (Plugin.IsValid())
+    {
+        return Plugin->GetDescriptor().VersionName;
+    }
+    return TEXT("0.0.0");
+}
+
+// --- Config helpers ---
+
+bool FLootLockerUpdateChecker::GetNeverNotify()
+{
+    bool bValue = false;
+    GConfig->GetBool(ConfigSection, TEXT("NeverNotify"), bValue, GEditorPerProjectIni);
+    return bValue;
+}
+
+void FLootLockerUpdateChecker::SetNeverNotify(bool bValue)
+{
+    GConfig->SetBool(ConfigSection, TEXT("NeverNotify"), bValue, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FString FLootLockerUpdateChecker::GetSkippedVersion()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("SkippedVersion"), Value, GEditorPerProjectIni);
+    return Value;
+}
+
+void FLootLockerUpdateChecker::SetSkippedVersion(const FString& Version)
+{
+    GConfig->SetString(ConfigSection, TEXT("SkippedVersion"), *Version, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FDateTime FLootLockerUpdateChecker::GetRemindAfterTime()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("RemindAfterUtc"), Value, GEditorPerProjectIni);
+    FDateTime Result;
+    if (FDateTime::ParseIso8601(*Value, Result))
+    {
+        return Result;
+    }
+    return FDateTime::MinValue();
+}
+
+void FLootLockerUpdateChecker::SetRemindAfterTime(const FDateTime& Time)
+{
+    GConfig->SetString(ConfigSection, TEXT("RemindAfterUtc"), *Time.ToIso8601(), GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FDateTime FLootLockerUpdateChecker::GetLastCheckedTime()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("LastCheckedUtc"), Value, GEditorPerProjectIni);
+    FDateTime Result;
+    if (FDateTime::ParseIso8601(*Value, Result))
+    {
+        return Result;
+    }
+    return FDateTime::MinValue();
+}
+
+void FLootLockerUpdateChecker::SaveLastCheckedTime(const FDateTime& Time)
+{
+    GConfig->SetString(ConfigSection, TEXT("LastCheckedUtc"), *Time.ToIso8601(), GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -22,7 +22,6 @@ DEFINE_LOG_CATEGORY_STATIC(LogLootLockerSDKEditor, Log, All);
 
 // --- Static member definitions ---
 FTSTicker::FDelegateHandle FLootLockerUpdateChecker::TickerHandle;
-double FLootLockerUpdateChecker::ElapsedStartupSeconds = 0.0;
 const TCHAR* FLootLockerUpdateChecker::ConfigSection = TEXT("/Script/LootLockerSDKEditor.UpdateChecker");
 const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
     TEXT("https://api.github.com/repos/lootlocker/unreal-sdk/releases/latest");
@@ -31,10 +30,10 @@ const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
 
 void FLootLockerUpdateChecker::Initialize()
 {
-    ElapsedStartupSeconds = 0.0;
+    // Fire once after StartupDelaySeconds — return false in the callback to auto-unregister.
     TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
         FTickerDelegate::CreateStatic(&FLootLockerUpdateChecker::OnStartupTick),
-        0.0f  // tick every frame; we measure elapsed time ourselves
+        StartupDelaySeconds
     );
 }
 
@@ -54,15 +53,8 @@ void FLootLockerUpdateChecker::ManualCheck()
 
 bool FLootLockerUpdateChecker::OnStartupTick(float DeltaTime)
 {
-    ElapsedStartupSeconds += DeltaTime;
-    if (ElapsedStartupSeconds >= StartupDelaySeconds)
-    {
-        // Remove ticker — we only need one startup check
-        TickerHandle.Reset();
-        CheckForUpdate(/*bManual=*/false);
-        return false;  // unregister
-    }
-    return true;  // keep ticking
+    CheckForUpdate(/*bManual=*/false);
+    return false;  // one-shot — unregister immediately
 }
 
 void FLootLockerUpdateChecker::CheckForUpdate(bool bManual)
@@ -150,8 +142,15 @@ void FLootLockerUpdateChecker::OnResponseReceived(
         return;
     }
 
-    FString TagName = JsonObject->GetStringField(TEXT("tag_name"));  // e.g. "v10.5.0"
-    const FString HtmlUrl = JsonObject->GetStringField(TEXT("html_url"));
+    FString TagName;
+    FString HtmlUrl;
+    if (!JsonObject->TryGetStringField(TEXT("tag_name"), TagName) ||
+        !JsonObject->TryGetStringField(TEXT("html_url"), HtmlUrl))
+    {
+        UE_LOG(LogLootLockerSDKEditor, Warning,
+            TEXT("LootLocker update check: GitHub response is missing expected fields."));
+        return;
+    }
 
     // Strip leading 'v' or 'V'
     if (TagName.StartsWith(TEXT("v")) || TagName.StartsWith(TEXT("V")))
@@ -177,7 +176,7 @@ void FLootLockerUpdateChecker::OnResponseReceived(
     {
         if (bManual || ShouldNotify(TagName))
         {
-            ShowUpdateNotification(TagName, HtmlUrl, bManual);
+            ShowUpdateNotification(TagName, HtmlUrl);
         }
     }
     else if (bManual)
@@ -187,7 +186,7 @@ void FLootLockerUpdateChecker::OnResponseReceived(
 }
 
 void FLootLockerUpdateChecker::ShowUpdateNotification(
-    const FString& LatestVersion, const FString& ReleaseUrl, bool bManual)
+    const FString& LatestVersion, const FString& ReleaseUrl)
 {
     if (!FSlateApplication::IsInitialized())
     {
@@ -236,16 +235,6 @@ bool FLootLockerUpdateChecker::IsVersionNewer(const FString& RemoteVersion, cons
         if (Remote < Local) return false;
     }
     return false;  // equal
-}
-
-bool FLootLockerUpdateChecker::IsFabManaged()
-{
-    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerSDK"));
-    if (!Plugin.IsValid())
-    {
-        return false;
-    }
-    return Plugin->GetBaseDir().Contains(TEXT("Marketplace"));
 }
 
 FString FLootLockerUpdateChecker::GetCurrentVersion()

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.cpp
@@ -21,7 +21,11 @@
 DEFINE_LOG_CATEGORY_STATIC(LogLootLockerSDKEditor, Log, All);
 
 // --- Static member definitions ---
+#if ENGINE_MAJOR_VERSION >= 5
 FTSTicker::FDelegateHandle FLootLockerUpdateChecker::TickerHandle;
+#else
+FDelegateHandle FLootLockerUpdateChecker::TickerHandle;
+#endif
 const TCHAR* FLootLockerUpdateChecker::ConfigSection = TEXT("/Script/LootLockerSDKEditor.UpdateChecker");
 const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
     TEXT("https://api.github.com/repos/lootlocker/unreal-sdk/releases/latest");
@@ -31,17 +35,28 @@ const TCHAR* FLootLockerUpdateChecker::GitHubReleasesUrl =
 void FLootLockerUpdateChecker::Initialize()
 {
     // Fire once after StartupDelaySeconds — return false in the callback to auto-unregister.
+#if ENGINE_MAJOR_VERSION >= 5
     TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
         FTickerDelegate::CreateStatic(&FLootLockerUpdateChecker::OnStartupTick),
         StartupDelaySeconds
     );
+#else
+    TickerHandle = FTicker::GetCoreTicker().AddTicker(
+        FTickerDelegate::CreateStatic(&FLootLockerUpdateChecker::OnStartupTick),
+        StartupDelaySeconds
+    );
+#endif
 }
 
 void FLootLockerUpdateChecker::Shutdown()
 {
     if (TickerHandle.IsValid())
     {
+#if ENGINE_MAJOR_VERSION >= 5
         FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+#else
+        FTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+#endif
         TickerHandle.Reset();
     }
 }
@@ -96,7 +111,7 @@ bool FLootLockerUpdateChecker::ShouldNotify(const FString& LatestVersion)
 
 void FLootLockerUpdateChecker::FetchLatestRelease(bool bManual)
 {
-    TSharedRef<IHttpRequest> Request = FHttpModule::Get().CreateRequest();
+    FHttpRequestPtr Request = FHttpModule::Get().CreateRequest();
     Request->SetURL(GitHubReleasesUrl);
     Request->SetVerb(TEXT("GET"));
     Request->SetHeader(TEXT("Accept"), TEXT("application/vnd.github.v3+json"));

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
@@ -65,7 +65,11 @@ private:
     static FDateTime GetLastCheckedTime();
     static void SaveLastCheckedTime(const FDateTime& Time);
 
+#if ENGINE_MAJOR_VERSION >= 5
     static FTSTicker::FDelegateHandle TickerHandle;
+#else
+    static FDelegateHandle TickerHandle;
+#endif
 
     static constexpr float StartupDelaySeconds = 180.0f;
     static constexpr double CheckIntervalHours = 24.0;

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
@@ -1,0 +1,78 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Containers/Ticker.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+/**
+ * Editor-only utility that checks GitHub Releases for a newer LootLocker SDK version
+ * and shows a non-blocking notification window when one is available.
+ *
+ * Call Initialize() from StartupModule() and Shutdown() from ShutdownModule().
+ * The automatic check fires once after a 180-second startup delay, then at most once
+ * every 24 hours. Silence and skip preferences are persisted via GConfig.
+ */
+class FLootLockerUpdateChecker
+{
+public:
+    /** Called from StartupModule — registers the delayed startup ticker. */
+    static void Initialize();
+
+    /** Called from ShutdownModule — removes the ticker handle. */
+    static void Shutdown();
+
+    /** Manual check triggered from the Tools menu. Bypasses throttle and silence settings. */
+    static void ManualCheck();
+
+    // Called by SLootLockerUpdateNotification button handlers
+    static void SetNeverNotify(bool bValue);
+    static void SetSkippedVersion(const FString& Version);
+    static void SetRemindAfterTime(const FDateTime& Time);
+
+private:
+    static bool OnStartupTick(float DeltaTime);
+
+    static void CheckForUpdate(bool bManual);
+
+    /** Returns true if the automatic check should proceed (throttle + silence guards). */
+    static bool ShouldCheck();
+
+    /** Returns true if the notification window should be shown for LatestVersion. */
+    static bool ShouldNotify(const FString& LatestVersion);
+
+    static void FetchLatestRelease(bool bManual);
+
+    static void OnResponseReceived(
+        FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual);
+
+    static void ShowUpdateNotification(
+        const FString& LatestVersion, const FString& ReleaseUrl, bool bManual);
+
+    static void ShowUpToDateNotification();
+
+    /** Numeric semver comparison — returns true if RemoteVersion is strictly newer than LocalVersion. */
+    static bool IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion);
+
+    /** Returns true if the plugin appears to be installed via Fab (engine Marketplace directory). */
+    static bool IsFabManaged();
+
+    /** Reads the current SDK version from the plugin descriptor. */
+    static FString GetCurrentVersion();
+
+    // --- Config helpers (GEditorPerProjectIni) ---
+    static bool GetNeverNotify();
+    static FString GetSkippedVersion();
+    static FDateTime GetRemindAfterTime();
+    static FDateTime GetLastCheckedTime();
+    static void SaveLastCheckedTime(const FDateTime& Time);
+
+    static FTSTicker::FDelegateHandle TickerHandle;
+    static double ElapsedStartupSeconds;
+
+    static constexpr double StartupDelaySeconds = 15.0;
+    static constexpr double CheckIntervalHours = 24.0;
+    static const TCHAR* ConfigSection;
+    static const TCHAR* GitHubReleasesUrl;
+};

--- a/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/LootLockerUpdateChecker.h
@@ -48,15 +48,12 @@ private:
         FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual);
 
     static void ShowUpdateNotification(
-        const FString& LatestVersion, const FString& ReleaseUrl, bool bManual);
+        const FString& LatestVersion, const FString& ReleaseUrl);
 
     static void ShowUpToDateNotification();
 
     /** Numeric semver comparison — returns true if RemoteVersion is strictly newer than LocalVersion. */
     static bool IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion);
-
-    /** Returns true if the plugin appears to be installed via Fab (engine Marketplace directory). */
-    static bool IsFabManaged();
 
     /** Reads the current SDK version from the plugin descriptor. */
     static FString GetCurrentVersion();
@@ -69,9 +66,8 @@ private:
     static void SaveLastCheckedTime(const FDateTime& Time);
 
     static FTSTicker::FDelegateHandle TickerHandle;
-    static double ElapsedStartupSeconds;
 
-    static constexpr double StartupDelaySeconds = 15.0;
+    static constexpr float StartupDelaySeconds = 180.0f;
     static constexpr double CheckIntervalHours = 24.0;
     static const TCHAR* ConfigSection;
     static const TCHAR* GitHubReleasesUrl;

--- a/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#include "SLootLockerUpdateNotification.h"
+#include "LootLockerUpdateChecker.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SSpacer.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/SBoxPanel.h"
+#include "HAL/PlatformProcess.h"
+#include "Framework/Application/SlateApplication.h"
+
+void SLootLockerUpdateNotification::Construct(const FArguments& InArgs)
+{
+    CurrentVersion = InArgs._CurrentVersion;
+    LatestVersion  = InArgs._LatestVersion;
+    ReleaseUrl     = InArgs._ReleaseUrl;
+    ParentWindow   = InArgs._ParentWindow;
+
+    ChildSlot
+    [
+        SNew(SBorder)
+        .Padding(FMargin(16.0f))
+        [
+            SNew(SVerticalBox)
+
+            // Header
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("A new version of the LootLocker SDK is available.")))
+                .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
+            ]
+
+            // Version info
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 4.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Installed:  ")))
+                ]
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("v%s"), *CurrentVersion)))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.6f, 0.6f)))
+                ]
+            ]
+
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 12.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Available:  ")))
+                ]
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("v%s"), *LatestVersion)))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.8f, 0.2f)))
+                ]
+            ]
+
+            // "See what's new" link button
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 16.0f)
+            [
+                SNew(SButton)
+                .ButtonStyle(FCoreStyle::Get(), "NoBorder")
+                .OnClicked(this, &SLootLockerUpdateNotification::OnSeeWhatsNewClicked)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(TEXT("See what's new \u2197")))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
+                ]
+            ]
+
+            // Action buttons — fill available width evenly
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            [
+                SNew(SHorizontalBox)
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Update Now")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnUpdateNowClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Skip This Version")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnSkipVersionClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Remind in 7 Days")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnRemindLaterClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Never Notify Me")))
+                    .OnClicked(this, &SLootLockerUpdateNotification::OnNeverNotifyClicked)
+                ]
+            ]
+        ]
+    ];
+}
+
+FReply SLootLockerUpdateNotification::OnSeeWhatsNewClicked()
+{
+    if (!ReleaseUrl.IsEmpty())
+    {
+        // Validate URL is from github.com before launching
+        if (ReleaseUrl.StartsWith(TEXT("https://github.com/")))
+        {
+            FPlatformProcess::LaunchURL(*ReleaseUrl, nullptr, nullptr);
+        }
+    }
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnUpdateNowClicked()
+{
+    if (!ReleaseUrl.IsEmpty())
+    {
+        if (ReleaseUrl.StartsWith(TEXT("https://github.com/")))
+        {
+            FPlatformProcess::LaunchURL(*ReleaseUrl, nullptr, nullptr);
+        }
+    }
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnSkipVersionClicked()
+{
+    FLootLockerUpdateChecker::SetSkippedVersion(LatestVersion);
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnRemindLaterClicked()
+{
+    FLootLockerUpdateChecker::SetRemindAfterTime(FDateTime::UtcNow() + FTimespan::FromDays(7.0));
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerUpdateNotification::OnNeverNotifyClicked()
+{
+    FLootLockerUpdateChecker::SetNeverNotify(true);
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+void SLootLockerUpdateNotification::CloseParentWindow()
+{
+    if (const TSharedPtr<SWindow> Window = ParentWindow.Pin())
+    {
+        Window->RequestDestroyWindow();
+    }
+}

--- a/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) LootLocker. All Rights Reserved.
 #include "SLootLockerUpdateNotification.h"
 #include "LootLockerUpdateChecker.h"
+#include "LootLockerConfig.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SSpacer.h"
@@ -30,7 +31,7 @@ void SLootLockerUpdateNotification::Construct(const FArguments& InArgs)
             .Padding(0.0f, 0.0f, 0.0f, 8.0f)
             [
                 SNew(STextBlock)
-                .Text(FText::FromString(TEXT("A new version of the LootLocker SDK is available.")))
+                .Text(FText::FromString(FString::Printf(TEXT("A new version of the %s SDK is available."), *ULootLockerConfig::PackageName)))
                 .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
             ]
 
@@ -82,6 +83,21 @@ void SLootLockerUpdateNotification::Construct(const FArguments& InArgs)
                     .Text(FText::FromString(TEXT("See what's new \u2197")))
                     .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
                 ]
+            ]
+
+            // Powered-by notice (shown when SDK is rebranded by a publisher)
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
+            [
+                SNew(STextBlock)
+                .Visibility(ULootLockerConfig::PackageName != TEXT("LootLocker")
+                    ? EVisibility::Visible : EVisibility::Collapsed)
+                .Text(FText::FromString(FString::Printf(
+                    TEXT("%s SDK is powered by LootLocker \u2014 release notes are on the LootLocker GitHub page."),
+                    *ULootLockerConfig::PackageName)))
+                .ColorAndOpacity(FSlateColor(FLinearColor(0.5f, 0.5f, 0.5f)))
+                .AutoWrapText(true)
             ]
 
             // Action buttons — fill available width evenly

--- a/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) LootLocker. All Rights Reserved.
 #include "SLootLockerUpdateNotification.h"
 #include "LootLockerUpdateChecker.h"
-#include "LootLockerConfig.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SSpacer.h"
@@ -31,7 +30,7 @@ void SLootLockerUpdateNotification::Construct(const FArguments& InArgs)
             .Padding(0.0f, 0.0f, 0.0f, 8.0f)
             [
                 SNew(STextBlock)
-                .Text(FText::FromString(FString::Printf(TEXT("A new version of the %s SDK is available."), *ULootLockerConfig::PackageName)))
+                .Text(FText::FromString(TEXT("A new version of the LootLocker SDK is available.")))
                 .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
             ]
 
@@ -83,21 +82,6 @@ void SLootLockerUpdateNotification::Construct(const FArguments& InArgs)
                     .Text(FText::FromString(TEXT("See what's new \u2197")))
                     .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
                 ]
-            ]
-
-            // Powered-by notice (shown when SDK is rebranded by a publisher)
-            + SVerticalBox::Slot()
-            .AutoHeight()
-            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
-            [
-                SNew(STextBlock)
-                .Visibility(ULootLockerConfig::PackageName != TEXT("LootLocker")
-                    ? EVisibility::Visible : EVisibility::Collapsed)
-                .Text(FText::FromString(FString::Printf(
-                    TEXT("%s SDK is powered by LootLocker \u2014 release notes are on the LootLocker GitHub page."),
-                    *ULootLockerConfig::PackageName)))
-                .ColorAndOpacity(FSlateColor(FLinearColor(0.5f, 0.5f, 0.5f)))
-                .AutoWrapText(true)
             ]
 
             // Action buttons — fill available width evenly

--- a/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.h
+++ b/LootLockerSDK/Source/LootLockerSDKEditor/SLootLockerUpdateNotification.h
@@ -1,0 +1,36 @@
+// Copyright (c) LootLocker. All Rights Reserved.
+#pragma once
+
+#include "Widgets/SCompoundWidget.h"
+#include "Templates/SharedPointer.h"
+
+/**
+ * Non-modal Slate window content shown when a newer LootLocker SDK version is available.
+ * Hosted inside an SWindow created by FLootLockerUpdateChecker::ShowUpdateNotification().
+ */
+class SLootLockerUpdateNotification : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SLootLockerUpdateNotification) {}
+        SLATE_ARGUMENT(FString, CurrentVersion)
+        SLATE_ARGUMENT(FString, LatestVersion)
+        SLATE_ARGUMENT(FString, ReleaseUrl)
+        SLATE_ARGUMENT(TSharedPtr<SWindow>, ParentWindow)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+private:
+    FReply OnSeeWhatsNewClicked();
+    FReply OnUpdateNowClicked();
+    FReply OnSkipVersionClicked();
+    FReply OnRemindLaterClicked();
+    FReply OnNeverNotifyClicked();
+
+    void CloseParentWindow();
+
+    FString CurrentVersion;
+    FString LatestVersion;
+    FString ReleaseUrl;
+    TWeakPtr<SWindow> ParentWindow;
+};


### PR DESCRIPTION
# LootLocker_UnrealSDK_V10.5.0

### Features

• 🎮 **Xbox Store IAP** — Full Xbox Store purchase flow from the client: `GetXboxServiceTicket()` retrieves a collection ID and purchase token, `RedeemXboxStorePurchaseForPlayer()` and `RedeemXboxStorePurchaseForClass()` redeem the purchase through LootLocker.

• 👥 **Multi-User Session Modes** — Three new session management strategies via `ELootLockerMultiUserSessionMode`:
  - **Hotseat** — Multiple players can hold active sessions simultaneously. The first authenticated player is the default. Ideal for local multiplayer / couch co-op.
  - **SingleSession** — Starting a new session automatically ends the previous one. The default for new SDK installs.
  - **ProfileSwitching** — The current player is deactivated but kept in a cold cache. Use `SetPlayerUlidToActive` to switch back without re-authenticating.
  Existing projects auto-migrate to Hotseat for backwards compatibility. See the [multi-user guide](https://docs.lootlocker.com/players/multi-user-sessions) for details.

• 🚫 **Player Ban Support** — `GetPlayerBanStatus()` lets you query whether a player is banned and why. Ban details (reason, dates, permanent flag) are also now included in `FLootLockerErrorData.ban` when a session start fails with the `player_banned` error code.

• 📡 **Connection State Check** — `CheckConnectionStatus()` pings the LootLocker server and returns a detailed `ELootLockerConnectionState` (8 states: `SignedInAndConnected`, `SessionExpired`, `Banned`, `NoConnection`, `ServerError`, etc.). Automatically queries ban status on 401/403 responses so you get a precise reason when something goes wrong.

• 🛒 **Catalog Items by ID** — `ListCatalogItemsById()` looks up catalog entries directly by `catalog_listing_id` (up to 100 at a time). Returns inlined entity details (asset, currency, progression, group with nested associations) and optional metadata with key filtering.

• 🏆 **Leaderboard Upcoming Resets** — `FLootLockerLeaderboardUpcomingReset` struct and `Upcoming_resets` array now exposed on leaderboard details, so you can surface pending manual resets in your UI.

• 👤 **Character ULID** — `FLootLockerListCharacterResponseItem` now includes a `ulid` field.

• 🎁 **Notification Asset Instance IDs** — `FLootLockerNotificationRewardAsset` now exposes `Asset_instance_ids`, listing the specific instance IDs granted for multi-quantity purchases.

• 🔧 **File-Based Pre-Configuration** — Place a `LootLockerPreConfig.bytes` file in the plugin's Config directory to override ALL SDK settings without touching `DefaultGame.ini`. Supports plain JSON or AES-256-ECB encrypted content. Editor UI is locked when active, preventing drift. Ideal for CI/CD pipelines.

• 📣 **In-Editor Update Checker** — **Tools → LootLocker Tools → Check for Updates** queries GitHub Releases and shows a non-modal notification when a newer SDK is available. Options: Update Now, Skip This Version, Remind in 7 Days, Never Notify. Auto-checks on startup after 180s.

• 🔒 **Credential Obfuscation** — 14 additional sensitive fields (`steam_ticket`, `id_token`, `auth_code`, `bearer_token`, etc.) are now redacted in log output, and all request/response bodies pass through `ObfuscateJsonStringForLogging()`.

### Fixes

• Fixed `FindPlugin` string literals — wrapped in `TEXT()` macro for correct Unicode handling.
• Fixed test runner script — proper process timeout handling prevents hung CI runs; commas in test filters now correctly translate to UE automation `OR` syntax.
• Fixed compile verification script — path corrected from `scripts/verify-compile.ps1` to `.github\scripts\verify-compilation.ps1` with proper `-Clean` flag support.

### Deprecations

• `FLootLockerCatalogGroupMetadata` — Marked deprecated (was never used and will be removed).

Full Changelog: [v10.4.0...v10.5.0](https://github.com/lootlocker/unreal-sdk/compare/v10.4.0...v10.5.0)
