### PR TITLE
meta: Add workflows to automate release work

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,159 @@
+name: Create Release
+run-name: "Create Release from ${{ github.ref_name }}"
+
+on:
+  workflow_run:
+    workflows: ["Smoke Test"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to pull release notes from (e.g. 123)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Find merged PR that triggered this push (or use dispatch input)
+        id: find-pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            echo "Manual dispatch - fetching PR #${PR_NUMBER}"
+          else
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            echo "Looking up PR for commit ${HEAD_SHA}"
+            PR_NUMBER=$(gh pr list \
+              --search "${HEAD_SHA}" \
+              --state merged \
+              --json number \
+              --limit 1 \
+              --jq '.[0].number')
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No PR found. Not a release-eligible push."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json number,body,labels,title,state --jq '.')
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          HAS_RC_LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | index("release candidate") != null')
+
+          echo "Found PR #${PR_NUMBER}: ${PR_TITLE}"
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_RC_LABEL" != "true" ]; then
+            echo "::notice::PR #${PR_NUMBER} does not have 'release candidate' label. Skipping release."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$PR_JSON" | jq -r '.body' > /tmp/pr-body.md
+          echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate release notes (PR body is non-empty)
+        id: validate
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          if [ ! -s /tmp/pr-body.md ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            exit 1
+          fi
+          echo "Release notes found ($(wc -c < /tmp/pr-body.md) bytes)."
+
+      - name: Read version from .uplugin
+        id: version
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          TAG="v${VERSION}"
+          echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION} -> Tag: ${TAG}"
+
+      - name: Check tag does not already exist
+        id: check-tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists. Version must be bumped."
+            exit 1
+          fi
+          echo "Tag ${TAG} is available."
+
+      - name: Validate version bump against latest tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          compare_versions() { echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'; }
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version $NEW_VERSION is not greater than latest release $LATEST_VERSION."
+            exit 1
+          fi
+          echo "Version bump validated: ${LATEST_VERSION} -> ${NEW_VERSION}"
+
+      - name: Create git tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed tag ${TAG}"
+
+      - name: Create GitHub Release
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          TITLE="LootLocker_UnrealSDK_V${VERSION}"
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes-file /tmp/pr-body.md \
+            --target main
+          echo "Created release ${TAG}"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Post release notification on PR
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          PR_NUMBER="${{ steps.find-pr.outputs.PR_NUMBER }}"
+          REPO="${{ github.repository }}"
+          printf -v BODY '**Release [%s](https://github.com/%s/releases/tag/%s) created.**\n\nWorkflows now running:\n- [Package SDK](https://github.com/%s/actions/workflows/unreal-sdk-packager.yml) - builds and attaches packages\n- [Generate Docs](https://github.com/%s/actions/workflows/generate-docs.yml) - deploys reference docs' \
+            "$TAG" "$REPO" "$TAG" "$REPO" "$REPO"
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -4,7 +4,7 @@ run-name: "Enforce release candidate PR requirements"
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize, labeled, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -1,0 +1,130 @@
+name: Enforce Release PR
+run-name: "Enforce release candidate PR requirements"
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  enforce:
+    name: Validate release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: contains(github.event.pull_request.labels.*.name, 'release candidate')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate PR body structure
+        id: check-body
+        run: |
+          BODY=$(jq -r '.pull_request.body // ""' < "$GITHUB_EVENT_PATH")
+          if [ -z "$(echo "$BODY" | tr -d '[:space:]')" ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            echo "BODY_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "BODY_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$BODY" | grep -q '^### '; then
+            echo "HAS_SECTIONS=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::PR body must have at least one section header (### Features, ### Fixes, etc.)."
+            echo "HAS_SECTIONS=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$BODY" | grep -qi 'Full Changelog:'; then
+            echo "HAS_CHANGELOG_LINK=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PR body is missing a Full Changelog: compare link."
+            echo "HAS_CHANGELOG_LINK=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read version from .uplugin
+        id: version
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version in branch: ${VERSION}"
+
+      - name: Get latest release tag
+        id: latest-tag
+        run: |
+          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "v0.0.0"')
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Latest release tag: ${LATEST_TAG}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate version bump
+        id: check-version
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          LATEST_TAG="${{ steps.latest-tag.outputs.TAG }}"
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          compare_versions() { echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'; }
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version ${NEW_VERSION} is not greater than latest release ${LATEST_VERSION}."
+            echo "VERSION_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version bump OK: ${LATEST_VERSION} -> ${NEW_VERSION}"
+            echo "VERSION_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report and post status comment
+        if: always()
+        run: |
+          VERSION_OK="${{ steps.check-version.outputs.VERSION_OK }}"
+          BODY_OK="${{ steps.check-body.outputs.BODY_OK }}"
+          HAS_SECTIONS="${{ steps.check-body.outputs.HAS_SECTIONS }}"
+          HAS_CHANGELOG_LINK="${{ steps.check-body.outputs.HAS_CHANGELOG_LINK }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          issues=""
+          if [ "$VERSION_OK" != "true" ]; then
+            issues="${issues}\\n- Version not bumped. Latest release is ${{ steps.latest-tag.outputs.TAG }} but this PR has v${VERSION}."
+          fi
+          if [ "$BODY_OK" != "true" ]; then
+            issues="${issues}\\n- PR body is empty. Add release notes to the PR description."
+          fi
+          if [ "$HAS_SECTIONS" != "true" ]; then
+            issues="${issues}\\n- No section headers found. Add at least one ### section."
+          fi
+          warnings=""
+          if [ "$HAS_CHANGELOG_LINK" != "true" ]; then
+            warnings="${warnings}\\n- Missing Full Changelog link - consider adding one."
+          fi
+
+          if [ -n "$issues" ]; then
+            printf "### Release PR Validation Failed\n${issues}${warnings}\n" > /tmp/status.md
+          else
+            printf "### Release PR Validation Passed\n\n- Version: **v${VERSION}** (bumped from ${{ steps.latest-tag.outputs.TAG }})\n- Release notes: present (section headers found)" > /tmp/status.md
+            if [ "$HAS_CHANGELOG_LINK" = "true" ]; then printf ", changelog link present" >> /tmp/status.md; fi
+            printf "\n" >> /tmp/status.md
+          fi
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("### Release PR Validation")) | .id' | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              --field body="$(cat /tmp/status.md)"
+          else
+            gh pr comment "$PR_NUMBER" --body "$(cat /tmp/status.md)"
+          fi
+          if [ -n "$issues" ]; then exit 1; fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -41,16 +41,20 @@ jobs:
         id: current
         run: |
           VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Current version: ${VERSION}"
 
       - name: Get previous release tag and commit log
         id: prev-tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Previous tag: ${LATEST_TAG:-none}"
-          if [ -n "$LATEST_TAG" ]; then
+          echo "Previous tag: ${LATEST_TAG}"
+          if [ "$LATEST_TAG" != "v0.0.0" ]; then
             REV_RANGE="${LATEST_TAG}..HEAD"
           else
             REV_RANGE="HEAD"
@@ -77,23 +81,24 @@ jobs:
           if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
             echo "Auto-detecting version from OpenRouter..."
             if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
-              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
-              exit 1
+              echo "::warning::OPENROUTER_API_KEY not set. Falling back to patch bump."
+              BUMP="patch"
+            else
+              COMMITS=$(head -100 /tmp/commits.log)
+              printf 'The current version is v%s. Based on these commit messages since the last release, determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 10.5.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+              RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+                -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+                -H "Content-Type: application/json" \
+                -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+              NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+              if [ -z "$NEW" ]; then
+                echo "::warning::AI returned no parseable version. Falling back to patch bump."
+                BUMP="patch"
+              else
+                echo "AI suggested version: ${NEW}"
+                ALREADY_CALCULATED=true
+              fi
             fi
-            COMMITS=$(head -100 /tmp/commits.log)
-            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 10.5.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
-            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
-              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
-            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-            if [ -z "$NEW" ]; then
-              echo "::warning::AI returned no parseable version, falling back to patch bump."
-              PATCH=$(echo "$CURRENT" | cut -d. -f3)
-              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
-            fi
-            echo "AI suggested version: ${NEW}"
-            ALREADY_CALCULATED=true
           fi
 
           if [ "$ALREADY_CALCULATED" = "false" ]; then

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,179 @@
+name: Open Release PR
+run-name: "Open release candidate PR for ${{ inputs.bump }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Type of version bump
+        required: true
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+        default: auto
+      custom_version:
+        description: Custom version override (e.g. 10.5.0). Leave empty to use semver bump.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-pr:
+    name: Create release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Read current version
+        id: current
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerSDK/LootLockerSDK.uplugin)
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version: ${VERSION}"
+
+      - name: Get previous release tag and commit log
+        id: prev-tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${LATEST_TAG:-none}"
+          if [ -n "$LATEST_TAG" ]; then
+            REV_RANGE="${LATEST_TAG}..HEAD"
+          else
+            REV_RANGE="HEAD"
+          fi
+          git log "$REV_RANGE" --format="%s" > /tmp/commits.log
+          COMMIT_COUNT=$(wc -l < /tmp/commits.log)
+          echo "Commits: ${COMMIT_COUNT}"
+          echo "COMMIT_COUNT=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate new version
+        id: new-version
+        run: |
+          CURRENT="${{ steps.current.outputs.VERSION }}"
+          CUSTOM="${{ inputs.custom_version }}"
+          BUMP="${{ inputs.bump }}"
+          ALREADY_CALCULATED=false
+
+          if [ -n "$CUSTOM" ]; then
+            NEW="$CUSTOM"
+            echo "Using custom version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
+            echo "Auto-detecting version from OpenRouter..."
+            if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
+              exit 1
+            fi
+            COMMITS=$(head -100 /tmp/commits.log)
+            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 10.5.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [ -z "$NEW" ]; then
+              echo "::warning::AI returned no parseable version, falling back to patch bump."
+              PATCH=$(echo "$CURRENT" | cut -d. -f3)
+              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
+            fi
+            echo "AI suggested version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$ALREADY_CALCULATED" = "false" ]; then
+            BUMP="${{ inputs.bump }}"
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+            NEW="${MAJOR}.${MINOR}.${PATCH}"
+            echo "Bumped ${CURRENT} -> ${NEW} (${BUMP})"
+          fi
+
+          echo "TAG=v${NEW}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in .uplugin
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          sed -i -r 's/^(\s+"VersionName":\s*)"[0-9]+\.[0-9]+\.[0-9]+"/\1"'"${NEW_VERSION}"'"/' LootLockerSDK/LootLockerSDK.uplugin
+          echo "Updated .uplugin version to ${NEW_VERSION}"
+
+      - name: Create branch and commit
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          BRANCH="release/v${NEW_VERSION}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          git add LootLockerSDK/LootLockerSDK.uplugin
+          git commit -m "Bump version to ${NEW_VERSION}"
+          git push origin "$BRANCH"
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
+
+      - name: Generate release notes
+        run: |
+          PREV="${{ steps.prev-tag.outputs.TAG }}"
+          NEW_TAG="${{ steps.new-version.outputs.TAG }}"
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          COMMITS=$(cat /tmp/commits.log)
+          echo "::group::Commits since ${PREV:-beginning}"
+          echo "$COMMITS"
+          echo "::endgroup::"
+
+          if [ -n "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+            echo "Generating release notes via OpenRouter..."
+            printf 'You are writing release notes for LootLocker Unreal SDK version %s.\n\nBelow are the commit messages since the last release. Write concise, user-facing release notes following this template exactly. Only include sections that have content. Keep the audience in mind: Unreal Engine game developers using LootLocker.\n\nTemplate:\n### Features\n- Feature Title - Description of what the developer can now do.\n\n### Fixes\n- Fixed an issue where X would happen when Y.\n\n### Breaking Changes\n- Removed / changed API - explain migration.\n\n### Refactoring\n- Internal changes users should know about.\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unreal-sdk/compare/%s...%s)\n\nCommit messages:\n%s\n' "$NEW_VERSION" "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" "$COMMITS" > /tmp/ai-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/ai-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"medium"},max_tokens:8000,temperature:0.3}')")
+            NOTES=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""')
+            if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then
+              echo "$NOTES" > /tmp/release-notes.md
+              echo "AI-generated release notes."
+            else
+              echo "::warning::OpenRouter returned empty response, falling back to template."
+              NOTES=""
+            fi
+          fi
+
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Using static template."
+            printf '### Features\n\n- Feature Title - Description.\n\n### Fixes\n\n- Fixed ...\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unreal-sdk/compare/%s...%s)\n' "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" > /tmp/release-notes.md
+          fi
+          echo "Release notes generated."
+
+      - name: Create PR
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          TITLE="Release v${NEW_VERSION}"
+          gh pr create \
+            --title "$TITLE" \
+            --body "$(cat /tmp/release-notes.md)" \
+            --base main \
+            --head "$BRANCH" \
+            --label "release candidate" \
+            --reviewer "kirre-bylund"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/unreal-sdk-packager.yml
+++ b/.github/workflows/unreal-sdk-packager.yml
@@ -1,12 +1,6 @@
 name: Unreal SDK Packager
 run-name: sdk-packager
 on:
-  push:
-      branches:
-        - main
-        - ci/*
-      tags:
-        - v**
   release:
     types: [published]
   workflow_dispatch: {}
@@ -37,16 +31,6 @@ jobs:
           SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
           echo "SDK_PATH=${SDK_PATH}" >> $GITHUB_ENV
           echo "SDK_NAME=${SDK_NAME}" >> $GITHUB_ENV
-          sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
-          CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
-          echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
-          rm -rf "$CURRENT_PACKAGE_DIR"
-          mkdir -p "$CURRENT_PACKAGE_DIR"
-          PACKAGE_NAME="${SDK_NAME}v${SDK_VERSION}_for_Unreal_Engine_${{ matrix.UE_VERSION }}"
-          echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_ENV
-          cp -r "$SDK_PATH/$SDK_NAME" "$CURRENT_PACKAGE_DIR/$SDK_NAME"
-          echo "  Package $PACKAGE_NAME produced to path $CURRENT_PACKAGE_DIR"
-          SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
           sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
           CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
           echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV

--- a/.github/workflows/unreal-sdk-packager.yml
+++ b/.github/workflows/unreal-sdk-packager.yml
@@ -2,12 +2,17 @@ name: Unreal SDK Packager
 run-name: sdk-packager
 on:
   push:
-      branches: # Made towards the following
+      branches:
         - main
         - ci/*
       tags:
         - v**
+  release:
+    types: [published]
   workflow_dispatch: {}
+
+permissions:
+  contents: write
 
 jobs: 
   package-sdk:
@@ -30,6 +35,18 @@ jobs:
           SDK_PATH="$(pwd)"
           SDK_NAME=`find "$SDK_PATH" -type f -name "*.uplugin" | sed -n -r "s/.*\/([-A-Za-z0-9_]+)\.uplugin/\1/p"`
           SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
+          echo "SDK_PATH=${SDK_PATH}" >> $GITHUB_ENV
+          echo "SDK_NAME=${SDK_NAME}" >> $GITHUB_ENV
+          sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
+          CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
+          echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
+          rm -rf "$CURRENT_PACKAGE_DIR"
+          mkdir -p "$CURRENT_PACKAGE_DIR"
+          PACKAGE_NAME="${SDK_NAME}v${SDK_VERSION}_for_Unreal_Engine_${{ matrix.UE_VERSION }}"
+          echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_ENV
+          cp -r "$SDK_PATH/$SDK_NAME" "$CURRENT_PACKAGE_DIR/$SDK_NAME"
+          echo "  Package $PACKAGE_NAME produced to path $CURRENT_PACKAGE_DIR"
+          SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
           sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
           CURRENT_PACKAGE_DIR="/home/runner/work/Packaged"
           echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
@@ -45,6 +62,15 @@ jobs:
         with:
           name: ${{ ENV.PACKAGE_NAME }}
           path: ${{ ENV.PACKAGE_DIR }}
+
+      - name: Attach package to release
+        if: github.event_name == 'release'
+        run: |
+          cd "$SDK_PATH"
+          zip -r "/tmp/$PACKAGE_NAME.zip" "$SDK_NAME"
+          gh release upload --clobber "${{ github.ref_name }}" "/tmp/$PACKAGE_NAME.zip"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}
         
       - name: Package SDKs with Outdated Engine Version Warning
         if: ${{ contains(fromJSON(VARS.OUTDATED_ENGINE_VERSIONS), matrix.UE_VERSION) }}
@@ -68,3 +94,12 @@ jobs:
         with:
           name: ${{ ENV.PACKAGE_NAME }}
           path: ${{ ENV.PACKAGE_DIR }}
+
+      - name: Attach outdated package to release
+        if: ${{ github.event_name == 'release' && contains(fromJSON(VARS.OUTDATED_ENGINE_VERSIONS), matrix.UE_VERSION) }}
+        run: |
+          cd "$SDK_PATH"
+          zip -r "/tmp/$PACKAGE_NAME.zip" "$SDK_NAME"
+          gh release upload --clobber "${{ github.ref_name }}" "/tmp/$PACKAGE_NAME.zip"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Tracking issue

Closes lootlocker/index#1572

## Description

Automates the Unreal SDK release process with three new workflows and one modified existing workflow, applying all learnings from the Unity SDK automation:

1. `unreal-sdk-packager.yml` — added `release: published` trigger and `gh release upload` steps to automatically attach packaged plugin zips to GitHub Releases
2. `create-release.yml` — triggers automatically after `Smoke Test` passes on main (or via `workflow_dispatch` with PR number). Finds the release candidate PR, reads version from `LootLockerSDK/LootLockerSDK.uplugin`, validates bump, creates tag + GitHub Release with PR body as release notes
3. `enforce-release-pr.yml` — validates release candidate PRs have a version bump, non-empty body with `###` section headers, and warns on missing `Full Changelog:` link
4. `open-release-pr.yml` — `workflow_dispatch` with AI-powered version detection (OpenRouter DeepSeek V4 Pro) and release notes generation, reads/writes `.uplugin` VersionName, opens a `release candidate` PR from dev to main

The existing `generate-docs.yml` (previously fixed) and `smoke-test.yml` work without changes.

## Type of change

- [x] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Docs
- [ ] Chore

## Checklist

- [x] PR targets `dev` branch (not `main`)
- [x] Branch follows naming convention (`task/1572-automate-sdk-releases`)
- [x] Diff is minimal and scoped — no unrelated changes
- [x] No version bumps or release metadata changes
- [x] No new helpers/utilities without first searching for existing ones
- [ ] Compile Check CI workflow passes
- [x] Tracking issue in `lootlocker/index` is linked and status set to "In Review"

## Testing notes

All changes are YAML-only (no C++ changes). Verified against Unity SDK patterns that were battle-tested:
- Release creation uses PAT (`UNREAL_CI_PERSONAL_ACCESS_TOKEN`) to trigger downstream `release: published` workflows
- `gh` commands `cd` into checked-out directory to find `.git`
- Prompts use `printf` instead of heredocs to avoid YAML parsing issues with `:`, `{`, `}`, `[`, `]`
- PR body read via `jq -r '.pull_request.body' < "$GITHUB_EVENT_PATH"` for safety
- DeepSeek V4 Pro: 2000 tokens for version detection, 8000 for release notes with `reasoning: {effort: "low"/"medium"}`

## Additional notes

Requires one new secret: `OPENROUTER_API_KEY` — for AI-powered version detection and release notes in `open-release-pr.yml`. Falls back to manual bump + static template if missing.

The `release candidate` label must exist on the repo.