### PR TITLE
Add List Platform Keys endpoint

### DIFF
--- a/.doxygen/groups.dox
+++ b/.doxygen/groups.dox
@@ -210,6 +210,15 @@
 ///
 /// See the [LootLocker documentation](https://docs.lootlocker.com/commerce/wallets).
 
+/// @defgroup PlatformKeys Platform Keys
+/// @brief List platform keys redeemed by the authenticated player.
+///
+/// Platform keys are keys distributed through LootLocker's Campaign system
+/// (e.g. Steam keys, Discord keys). This endpoint returns all keys redeemed
+/// by the currently authenticated player, grouped by campaign.
+///
+/// See the [LootLocker documentation](https://docs.lootlocker.com/campaigns/overview).
+
 /// @defgroup Catalog Catalog
 /// @brief Browse item listings and prices in the LootLocker storefront catalog.
 ///

--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPlatformKeyRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerPlatformKeyRequestHandler.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 LootLocker
+
+#include "GameAPI/LootLockerPlatformKeyRequestHandler.h"
+#include "LootLockerGameEndpoints.h"
+#include "Utils/LootLockerUtilities.h"
+
+FString ULootLockerPlatformKeyRequestHandler::ListPlatformKeys(const FLootLockerPlayerData& PlayerData, const FLootLockerListPlatformKeysResponseDelegate& OnResponseCompleted)
+{
+    return LLAPI<FLootLockerListPlatformKeysResponse>::CallAPI(FLootLockerEmptyRequest{}, ULootLockerGameEndpoints::ListPlatformKeys, {}, {}, PlayerData, OnResponseCompleted);
+}

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerGameEndpoints.cpp
@@ -269,6 +269,9 @@ FLootLockerEndPoints ULootLockerGameEndpoints::ListCurrencies = InitEndpoint("cu
 FLootLockerEndPoints ULootLockerGameEndpoints::GetCurrencyDetails = InitEndpoint("currency/code/{0}", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::GetCurrencyDenominationsByCode = InitEndpoint("currency/code/{0}/denominations", ELootLockerHTTPMethod::GET);
 
+// Platform Keys
+FLootLockerEndPoints ULootLockerGameEndpoints::ListPlatformKeys = InitEndpoint("platform-keys/v1", ELootLockerHTTPMethod::GET);
+
 // Balances
 FLootLockerEndPoints ULootLockerGameEndpoints::ListBalancesInWallet = InitEndpoint("balances/wallet/{0}", ELootLockerHTTPMethod::GET);
 FLootLockerEndPoints ULootLockerGameEndpoints::GetWalletByWalletId = InitEndpoint("wallet/{0}", ELootLockerHTTPMethod::GET);

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerManager.cpp
@@ -1847,6 +1847,15 @@ FString ULootLockerManager::GetCurrencyDetails(const FString& ForPlayerWithUlid,
     }), ForPlayerWithUlid);
 }
 
+// Platform Keys
+FString ULootLockerManager::ListPlatformKeys(const FString& ForPlayerWithUlid, const FLootLockerListPlatformKeysResponseBP& OnCompletedRequest)
+{
+    return ULootLockerSDKManager::ListPlatformKeys(FLootLockerListPlatformKeysResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerListPlatformKeysResponse& Response)
+    {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }), ForPlayerWithUlid);
+}
+
 FString ULootLockerManager::GetCurrencyDenominationsByCode(const FString& ForPlayerWithUlid, const FString& CurrencyCode, const FLootLockerListDenominationsResponseBP& OnCompletedRequest)
 {
     return ULootLockerSDKManager::GetCurrencyDenominationsByCode(CurrencyCode, FLootLockerListDenominationsResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerListDenominationsResponse& Response)

--- a/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/LootLockerSDKManager.cpp
@@ -1357,6 +1357,13 @@ FString ULootLockerSDKManager::GetCurrencyDenominationsByCode(const FString& Cur
     return ULootLockerCurrencyRequestHandler::GetCurrencyDenominationsByCode(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), CurrencyCode, OnCompletedRequest);
 }
 
+// Platform Keys
+
+FString ULootLockerSDKManager::ListPlatformKeys(const FLootLockerListPlatformKeysResponseDelegate& OnCompletedRequest, const FString& ForPlayerWithUlid /* = "" */)
+{
+    return ULootLockerPlatformKeyRequestHandler::ListPlatformKeys(GetSavedStateOrDefaultOrEmptyForPlayer(ForPlayerWithUlid), OnCompletedRequest);
+}
+
 // Balances
 
 FString ULootLockerSDKManager::ListBalancesInWallet(const FString& WalletID, const FLootLockerListBalancesForWalletResponseDelegate& OnComplete, const FString& ForPlayerWithUlid /* = "" */)

--- a/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlatformKeyRequestHandler.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/GameAPI/LootLockerPlatformKeyRequestHandler.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+
+#include "CoreMinimal.h"
+#include "LootLockerResponse.h"
+#include "LootLockerPlayerData.h"
+#include "LootLockerPlatformKeyRequestHandler.generated.h"
+
+//==================================================
+// Data Type Definitions
+//==================================================
+
+/**
+ * Information about the campaign associated with a platform key
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerPlatformKeyCampaign
+{
+    GENERATED_BODY()
+    /**
+     * The name of the campaign that issued this key
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Name = "";
+    /**
+     * The platform this key is for (e.g. "steam", "discord")
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Platform = "";
+};
+
+/**
+ * A platform key redeemed by the player
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerPlatformKey
+{
+    GENERATED_BODY()
+    /**
+     * Information about the campaign that issued this key
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FLootLockerPlatformKeyCampaign Campaign;
+    /**
+     * The redeemed key value
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    FString Key = "";
+};
+
+//==================================================
+// Request Definitions
+//==================================================
+
+// N/A
+
+//==================================================
+// Response Definitions
+//==================================================
+
+/**
+ * Response containing the list of platform keys redeemed by the authenticated player.
+ */
+USTRUCT(BlueprintType, Category = "LootLocker")
+struct FLootLockerListPlatformKeysResponse : public FLootLockerResponse
+{
+    GENERATED_BODY()
+    /**
+     * List of platform keys redeemed by the player
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
+    TArray<FLootLockerPlatformKey> Platform_Keys;
+};
+
+//==================================================
+// Delegate Definitions
+//==================================================
+
+/// @addtogroup PlatformKeys
+/// @{
+/**
+ * C++ response delegate for listing platform keys
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerListPlatformKeysResponseDelegate, FLootLockerListPlatformKeysResponse);
+
+/// @}
+
+//==================================================
+// API Class Definition
+//==================================================
+
+UCLASS()
+class LOOTLOCKERSDK_API ULootLockerPlatformKeyRequestHandler : public UObject
+{
+    GENERATED_BODY()
+public:
+    ULootLockerPlatformKeyRequestHandler() {};
+
+    static FString ListPlatformKeys(const FLootLockerPlayerData& PlayerData, const FLootLockerListPlatformKeysResponseDelegate& OnResponseCompleted);
+};

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerGameEndpoints.h
@@ -304,6 +304,9 @@ public:
     static FLootLockerEndPoints GetCurrencyDetails;
     static FLootLockerEndPoints GetCurrencyDenominationsByCode;
 
+    // Platform Keys
+    static FLootLockerEndPoints ListPlatformKeys;
+
     // Balances
     static FLootLockerEndPoints ListBalancesInWallet;
     static FLootLockerEndPoints GetWalletByWalletId;

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerManager.h
@@ -14,6 +14,7 @@
 #include "GameAPI/LootLockerCharacterRequestHandler.h"
 #include "GameAPI/LootLockerConnectedAccountsRequestHandler.h"
 #include "GameAPI/LootLockerCurrencyRequestHandler.h"
+#include "GameAPI/LootLockerPlatformKeyRequestHandler.h"
 #include "GameAPI/LootLockerDropTablesRequestHandler.h"
 #include "GameAPI/LootLockerEntitlementRequestHandler.h"
 #include "GameAPI/LootLockerFollowersRequestHandler.h"
@@ -355,6 +356,12 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListCurrenciesResponseBP, FLootLock
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerGetCurrencyDetailsResponseBP, FLootLockerGetCurrencyDetailsResponse, Response);
 /** Blueprint response delegate for listing denominations responses */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListDenominationsResponseBP, FLootLockerListDenominationsResponse, Response);
+
+//==================================================
+// Platform Key Delegates
+//==================================================
+/** Blueprint response delegate for listing platform keys responses */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerListPlatformKeysResponseBP, FLootLockerListPlatformKeysResponse, Response);
 
 //==================================================
 // Balance Delegates
@@ -3426,6 +3433,20 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Currency", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
     static UPARAM(DisplayName = "RequestId") FString GetCurrencyDenominationsByCode(const FString& ForPlayerWithUlid, const FString& CurrencyCode, const FLootLockerListDenominationsResponseBP& OnCompletedRequest);
+
+    //==================================================
+    // Platform Keys
+    //==================================================
+
+    /**
+     List platform keys redeemed by the authenticated player.
+
+     @param ForPlayerWithUlid Optional: Execute the request for the player with the specified ulid. If not supplied, the default player will be used
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLocker Methods | Platform Keys", meta = (AdvancedDisplay = "ForPlayerWithUlid", ForPlayerWithUlid=""))
+    static UPARAM(DisplayName = "RequestId") FString ListPlatformKeys(const FString& ForPlayerWithUlid, const FLootLockerListPlatformKeysResponseBP& OnCompletedRequest);
 
     //==================================================
     // Balances

--- a/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
+++ b/LootLockerSDK/Source/LootLockerSDK/Public/LootLockerSDKManager.h
@@ -13,6 +13,7 @@
 #include "GameAPI/LootLockerCharacterRequestHandler.h"
 #include "GameAPI/LootLockerConnectedAccountsRequestHandler.h"
 #include "GameAPI/LootLockerCurrencyRequestHandler.h"
+#include "GameAPI/LootLockerPlatformKeyRequestHandler.h"
 #include "GameAPI/LootLockerDropTablesRequestHandler.h"
 #include "GameAPI/LootLockerEntitlementRequestHandler.h"
 #include "GameAPI/LootLockerErrorReportRequestHandler.h"
@@ -3066,6 +3067,23 @@ public:
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     static FString GetCurrencyDenominationsByCode(const FString & CurrencyCode, const FLootLockerListDenominationsResponseDelegate & OnCompletedRequest, const FString& ForPlayerWithUlid = "");
+
+    /// @}
+
+    //==================================================
+    // Platform Keys
+    //==================================================
+    /// @addtogroup PlatformKeys
+    /// @{
+
+    /**
+     List platform keys redeemed by the authenticated player.
+
+     @param OnCompletedRequest Delegate for handling the server response
+     @param ForPlayerWithUlid Optional: Execute for the specified player ULID (default player if empty)
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString ListPlatformKeys(const FLootLockerListPlatformKeysResponseDelegate & OnCompletedRequest, const FString& ForPlayerWithUlid = "");
 
     /// @}
 


### PR DESCRIPTION
Adds support for `GET /game/platform-keys/v1` returning platform keys redeemed by the authenticated player.

### Changes
- **New handler**: `LootLockerPlatformKeyRequestHandler` (header + implementation)
- **New DTOs**: `FLootLockerPlatformKeyCampaign`, `FLootLockerPlatformKey`, `FLootLockerListPlatformKeysResponse`
- **C++ facade**: `ULootLockerSDKManager::ListPlatformKeys(OnCompletedRequest, ForPlayerWithUlid)`
- **Blueprint facade**: `ULootLockerManager::ListPlatformKeys(ForPlayerWithUlid, OnCompletedRequest)` with BP delegate
- **New endpoint**: `platform-keys/v1` (GET)
- **Compile check**: ✅ UnrealEditor Development, UnrealGame Development, UnrealGame Shipping all pass

### API
```
GET /game/platform-keys/v1
Response: { "platform_keys": [{ "campaign": { "name": "...", "platform": "..." }, "key": "..." }] }
```

Closes lootlocker/index#1530