### PR TITLE
Fix GetScoreList: after cursor was silently dropped

### DIFF
--- a/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerLeaderboardRequestHandler.cpp
+++ b/LootLockerSDK/Source/LootLockerSDK/Private/GameAPI/LootLockerLeaderboardRequestHandler.cpp
@@ -26,7 +26,11 @@ FString ULootLockerLeaderboardRequestHandler::GetByListOfMembers(const FLootLock
 FString ULootLockerLeaderboardRequestHandler::GetScoreList(const FLootLockerPlayerData& PlayerData, const FLootLockerGetScoreListRequest& GetScoreListRequests, const FLootLockerGetScoreListResponseDelegate& OnCompletedRequest)
 {
 	int32 after = GetScoreListRequests.after < 0 ? 0 : GetScoreListRequests.after;
-	return LLAPI<FLootLockerGetScoreListResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::GetScoreList, { GetScoreListRequests.leaderboard_key, GetScoreListRequests.count, after }, EmptyQueryParams, PlayerData, OnCompletedRequest);
+	if (after > 0)
+	{
+		return LLAPI<FLootLockerGetScoreListResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::GetScoreListAfter, { GetScoreListRequests.leaderboard_key, GetScoreListRequests.count, after }, EmptyQueryParams, PlayerData, OnCompletedRequest);
+	}
+	return LLAPI<FLootLockerGetScoreListResponse>::CallAPI(LootLockerEmptyRequest, ULootLockerGameEndpoints::GetScoreList, { GetScoreListRequests.leaderboard_key, GetScoreListRequests.count }, EmptyQueryParams, PlayerData, OnCompletedRequest);
 }
 
 FString ULootLockerLeaderboardRequestHandler::SubmitScore(const FLootLockerPlayerData& PlayerData, const FLootLockerSubmitScoreRequest& SubmitScoreRequests, FString LeaderboardKey, const FLootLockerSubmitScoreResponseDelegate& OnCompletedRequest)


### PR DESCRIPTION
Fixes a bug where ULootLockerLeaderboardRequestHandler::GetScoreList passed 3 path arguments to an endpoint template with only 2 placeholders, causing the \fter\ cursor to be silently dropped and pagination to be broken.

### Root Cause
- \GetScoreList\ endpoint template: \leaderboards/{0}/list?count={1}\ (2 placeholders)
- The handler always passed 3 args: \{leaderboard_key, count, after}\
- The 3rd arg (\fter\) was silently ignored by FString::Format

### Fix
- When \fter <= 0\: use \GetScoreList\ (2 placeholders, 2 args)
- When \fter > 0\: use \GetScoreListAfter\ (3 placeholders, already existed but was never called)
- Matches the Unity SDK pattern which conditionally appends \&after={2}\

### Verification
- ✅ Compile check: UnrealEditor Dev, UnrealGame Dev, UnrealGame Shipping all pass

Closes lootlocker/index#1591